### PR TITLE
using os.path.expandvars in train.py to enable generic save_loc paths in config files

### DIFF
--- a/applications/train.py
+++ b/applications/train.py
@@ -164,7 +164,7 @@ def distributed_model_wrapper(conf, vae, device):
 def load_model_and_optimizer(conf, model, device):
 
     start_epoch = conf['trainer']['start_epoch']
-    save_loc = conf['save_loc']
+    save_loc = os.path.expandvars(conf['save_loc'])
     learning_rate = float(conf['trainer']['learning_rate'])
     weight_decay = float(conf['trainer']['weight_decay'])
     amp = conf['trainer']['amp']
@@ -443,9 +443,10 @@ if __name__ == "__main__":
         conf = yaml.load(cf, Loader=yaml.FullLoader)
 
     # Create directories if they do not exist and copy yml file
-    os.makedirs(conf["save_loc"], exist_ok=True)
-    if not os.path.exists(os.path.join(conf["save_loc"], "model.yml")):
-        shutil.copy(config, os.path.join(conf["save_loc"], "model.yml"))
+    save_loc = os.path.expandvars(conf["save_loc"])
+    os.makedirs(save_loc, exist_ok=True)
+    if not os.path.exists(os.path.join(save_loc, "model.yml")):
+        shutil.copy(config, os.path.join(save_loc, "model.yml"))
 
     # Launch PBS jobs
     if launch:

--- a/config/crossformer.yml
+++ b/config/crossformer.yml
@@ -1,4 +1,4 @@
-save_loc: "/glade/work/schreck/repos/global/miles-credit/results/crossformer/"
+save_loc: "/glade/work/$USER/repos/global/miles-credit/results/crossformer/"
 seed: 1000
 
 data:

--- a/config/fuxi.yml
+++ b/config/fuxi.yml
@@ -1,4 +1,4 @@
-save_loc: "/glade/work/schreck/repos/global/miles-credit/results/fuxi/"
+save_loc: "/glade/work/$USER/repos/global/miles-credit/results/fuxi/"
 seed: 1000
 
 data:
@@ -14,7 +14,7 @@ data:
     time_step: 1
     
 trainer:
-    mode: ddp # none, ddp, fsdp
+    mode: none # none, ddp, fsdp
     train_batch_size: 1
     valid_batch_size: 1
     batches_per_epoch: 0 # Set to 0 to use len(dataloader)

--- a/config/rvt.yml
+++ b/config/rvt.yml
@@ -1,4 +1,4 @@
-save_loc: "/glade/work/schreck/repos/global/miles-credit/results/test_configs"
+save_loc: "/glade/work/$USER/repos/global/miles-credit/results/test_configs"
 seed: 1000
 
 data:

--- a/config/simple-vit.yml
+++ b/config/simple-vit.yml
@@ -1,4 +1,4 @@
-save_loc: "/glade/work/schreck/repos/global/miles-credit/results/simple_zscore/"
+save_loc: "/glade/work/$USER/repos/global/miles-credit/results/simple_zscore/"
 seed: 1000
 
 data:

--- a/config/vit.yml
+++ b/config/vit.yml
@@ -1,4 +1,4 @@
-save_loc: "/glade/work/schreck/repos/global/miles-credit/results/vit_zscore/"
+save_loc: "/glade/work/$USER/repos/global/miles-credit/results/vit_zscore/"
 seed: 1000
 
 data:

--- a/config/vit3d.yml
+++ b/config/vit3d.yml
@@ -1,4 +1,4 @@
-save_loc: "/glade/work/schreck/repos/global/miles-credit/results/vit_multi_step_input/"
+save_loc: "/glade/work/$USER/repos/global/miles-credit/results/vit_multi_step_input/"
 seed: 1000
 
 data:


### PR DESCRIPTION
used env vars to have generic save_locs path in config files. Updated train.py to use os.path.expandvars. Is backwards compatible with old hardcoded save_locs.