### PR TITLE
Quantile static

### DIFF
--- a/applications/train.py
+++ b/applications/train.py
@@ -38,7 +38,7 @@ from torchsummary import summary
 from credit.models import load_model
 from credit.loss import VariableTotalLoss2D
 from credit.data import ERA5Dataset
-from credit.transforms import ToTensor, NormalizeState
+from credit.transforms import load_transforms
 from credit.scheduler import load_scheduler, annealed_probability
 from credit.trainer import Trainer
 from credit.metrics import LatWeightedMetrics
@@ -80,16 +80,15 @@ def load_dataset_and_sampler(conf, files, world_size, rank, is_train, seed=42):
     shuffle = is_train
     name = "Train" if is_train else "Valid"
 
+    transforms = load_transforms(conf)
+    
     dataset = ERA5Dataset(
         filenames=files,
         history_len=history_len,
         forecast_len=forecast_len,
         skip_periods=time_step,
         one_shot=one_shot,
-        transform=transforms.Compose([
-            NormalizeState(conf["data"]["mean_path"], conf["data"]["std_path"]),
-            ToTensor(history_len=history_len, forecast_len=forecast_len),
-        ]),
+        transform=transforms
     )
     sampler = DistributedSampler(
         dataset,

--- a/config/crossformer.yml
+++ b/config/crossformer.yml
@@ -4,9 +4,11 @@ seed: 1000
 data:
     variables: ['U','V','T','Q']
     surface_variables: ['SP','t2m','V500','U500','T500','Z500','Q500']
+    static_vars: ['SP','LSM']
     save_loc: '/glade/derecho/scratch/schreck/STAGING/TOTAL_*'
     mean_path: '/glade/derecho/scratch/schreck/STAGING/All_2010_staged.mean.Lev.SLO.nc'
     std_path: '/glade/derecho/scratch/schreck/STAGING/All_2010_staged.std.Lev.SLO.nc'
+    quant_path: '/glade/campaign/cisl/aiml/credit_scalers/era5_quantile_scalers_2024-02-13_07:33.parquet'
     history_len: 2 
     forecast_len: 0
     valid_history_len: 2
@@ -71,7 +73,7 @@ loss:
     spectral_wavenum_init: 20
     spectral_lambda_reg: 0.1 # power loss is order of 1e1 (usually between 1-10)
     use_latitude_weights: True
-    latitude_weights: "/glade/u/home/wchapman/MLWPS/DataLoader/static_variables_ERA5_zhght.nc"
+    latitude_weights: "/glade/u/home/wchapman/MLWPS/DataLoader/LSM_static_variables_ERA5_zhght.nc"
     use_variable_weights: False
     variable_weights:
         U: [0.132, 0.123, 0.113, 0.104, 0.095, 0.085, 0.076, 0.067, 0.057, 0.048, 0.039, 0.029, 0.02 , 0.011, 0.005]

--- a/config/crossformer.yml
+++ b/config/crossformer.yml
@@ -4,11 +4,12 @@ seed: 1000
 data:
     variables: ['U','V','T','Q']
     surface_variables: ['SP','t2m','V500','U500','T500','Z500','Q500']
-    static_vars: ['SP','LSM']
+    static_variables: ['SP','LSM'] # []
     save_loc: '/glade/derecho/scratch/schreck/STAGING/TOTAL_*'
     mean_path: '/glade/derecho/scratch/schreck/STAGING/All_2010_staged.mean.Lev.SLO.nc'
     std_path: '/glade/derecho/scratch/schreck/STAGING/All_2010_staged.std.Lev.SLO.nc'
     quant_path: '/glade/campaign/cisl/aiml/credit_scalers/era5_quantile_scalers_2024-02-13_07:33.parquet'
+    scaler_type: 'quantile' # 'std'
     history_len: 2 
     forecast_len: 0
     valid_history_len: 2

--- a/credit/transforms.py
+++ b/credit/transforms.py
@@ -5,6 +5,8 @@ import xarray as xr
 import netCDF4 as nc
 from credit.data import Sample
 from typing import Dict
+import pandas as pd
+from bridgescaler import read_scaler
 
 
 logger = logging.getLogger(__name__)

--- a/credit/transforms.py
+++ b/credit/transforms.py
@@ -243,7 +243,7 @@ class ToTensor:
         self.for_len = int(conf["data"]["forecast_len"])
         self.variables = conf["data"]["variables"]
         self.surface_variables = conf["data"]["surface_variables"]
-        self.allvars = variables + surface_variables
+        self.allvars = self.variables + self.surface_variables
         self.static_variables = conf["data"]["static_variables"]
 
     def __call__(self, sample: Sample) -> Sample:

--- a/credit/transforms.py
+++ b/credit/transforms.py
@@ -12,7 +12,9 @@ from torchvision import transforms as tforms
 
 logger = logging.getLogger(__name__)
 
+
 def load_transforms(conf):
+
     if conf["data"]["scaler_type"] == 'quantile':
         transform_scaler = NormalizeState_Quantile(scaler_file=conf["data"]["quant_path"])
     elif conf["data"]["scaler_type"] == 'std':
@@ -130,7 +132,7 @@ class NormalizeState_Quantile:
         self.scaler_surf = self.scaler_surfs.sum()
         self.variables = variables 
         self.surface_variables = surface_variables 
-        self.levels = 15
+        self.levels = levels
 
     def __call__(self, sample: Sample, inverse: bool = False) -> Sample:
         if inverse:
@@ -252,7 +254,7 @@ class ToTensor:
         self.for_len = int(conf["data"]["forecast_len"])
         self.variables = conf["data"]["variables"]
         self.surface_variables = conf["data"]["surface_variables"]
-        self.allvars = variables + surface_variables
+        self.allvars = self.variables + self.surface_variables
         self.static_variables = conf["data"]["static_variables"]
 
     def __call__(self, sample: Sample) -> Sample:
@@ -292,7 +294,7 @@ class ToTensor:
                 return_dict['y'] = y
 
         if self.static_variables:
-            DSD = xr.open_dataset(conf["loss"]["latitude_weights"])
+            DSD = xr.open_dataset(self.conf["loss"]["latitude_weights"])
             arrs = []
             for sv in self.static_variables:
 

--- a/credit/transforms.py
+++ b/credit/transforms.py
@@ -118,7 +118,7 @@ class NormalizeState_Quantile:
         self.variables = conf['data']['variables']
         self.variables = conf['data']['surface_variables']
         self.levels = int(conf['model']['levels'])
-        self.scaler_df = pd.read_parquet(scaler_file)
+        self.scaler_df = pd.read_parquet(self.scaler_file)
         self.scaler_3ds = self.scaler_df["scaler_3d"].apply(read_scaler)
         self.scaler_surfs = self.scaler_df["scaler_surface"].apply(read_scaler)
         self.scaler_3d = self.scaler_3ds.sum()

--- a/credit/transforms.py
+++ b/credit/transforms.py
@@ -20,7 +20,7 @@ def load_transforms(conf):
     elif conf["data"]["scaler_type"] == 'std':
         transform_scaler = NormalizeState(conf["data"]["mean_path"], conf["data"]["std_path"])
     else:
-        logger.log('scaler type not supported check data: scaler_type in config file')
+        logger.info('scaler type not supported check data: scaler_type in config file')
         raise
 
     to_tensor_scaler = ToTensor(conf=conf)

--- a/credit/transforms.py
+++ b/credit/transforms.py
@@ -283,7 +283,7 @@ class ToTensor:
                 return_dict['y'] = y
 
         if self.static_variables:
-            DSD = xr.open_dataset(conf["loss"]["latitude_weights"])
+            DSD = xr.open_dataset(self.conf["loss"]["latitude_weights"])
             arrs = []
             for sv in self.static_variables:
 

--- a/environment.yml
+++ b/environment.yml
@@ -36,5 +36,6 @@ dependencies:
     - torchsummary
     - vector_quantize_pytorch
     - timm>=0.9.12
+    - torch-harmonics 
     - .
 


### PR DESCRIPTION
This pull request provides access to the quantile transform scaler (via the bridgescaler package), It returns the exact tensors structure as our current scaling, so should cause no pipeline issues. I am optimistic it will help training alot. 

Here is the use: 

```
Dataset= ERA5Dataset(filenames=[FNS[nunu]],history_len=history_len,forecast_len=forecast_len,skip_periods=1,transform=transforms.Compose([
            NormalizeState_Quantile(scaler_file=conf["data"]["quant_path"]),
            ToTensor(history_len=history_len, forecast_len=forecast_len,static_variables=conf["data"]["static_vars"]),
        ]))
print(FNS[nunu])
BB_trancs_quant = Dataset.__getitem__(8784)

Dataset= ERA5Dataset(filenames=[FNS[nunu]],history_len=history_len,forecast_len=forecast_len,skip_periods=1,transform=transforms.Compose([
            NormalizeState(conf["data"]["mean_path"], conf["data"]["std_path"]),
            ToTensor(history_len=history_len, forecast_len=forecast_len,static_variables=conf["data"]["static_vars"]),
        ]))
print(FNS[nunu])
BB_trancs_std = Dataset.__getitem__(8784)
```
I am requesting two variables added to the data section of the config file, though i don't think it is static (I am happy to adjust once I know what needs to be added). They are currently integrated into crossformer.yml

The adjustment of the quantile scalar is apparent. Here is the difference between the Q at upper levels for a standard scaling (bottom) vs a quantile scaling (top).

![image](https://github.com/NCAR/miles-credit/assets/14932329/38f7b5a0-6c5e-4879-9829-faa1ae023248)
 

Additionally, I have added a 'static variables' option to the to_tensor transform. This will now return a feild 'static' which provides the LandSea mask  (scaled 0-1)  and the topography (scaled 0-2). See Below: 

![image](https://github.com/NCAR/miles-credit/assets/14932329/a4a6594f-f3c4-4a38-982c-78be985b44a6)

This addresses #24 
