### PR TITLE
edits to pbs.py to improve usability

### DIFF
--- a/credit/pbs.py
+++ b/credit/pbs.py
@@ -24,7 +24,8 @@ def launch_script(config_file, script_path, launch=True):
     # Extract PBS options from the config
     pbs_options = config['pbs']
 
-    config_save_path = os.path.expandvars(os.path.join(config["save_loc"], "model.yml"))
+    save_loc = os.path.expandvars(config["save_loc"])
+    config_save_path = os.path.join(save_loc, "model.yml")
 
     # Generate the PBS script
     script = f"""#!/bin/bash -l
@@ -56,6 +57,7 @@ def launch_script(config_file, script_path, launch=True):
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            cwd=save_loc,
         ).communicate()[0]
         jobid = jobid.decode("utf-8").strip("\n")
         logger.info(jobid)
@@ -179,6 +181,7 @@ def launch_script_mpi(config_file, script_path, launch=True, backend='nccl'):
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            cwd=save_loc
         ).communicate()[0]
         jobid = jobid.decode("utf-8").strip("\n")
         logger.info(jobid)


### PR DESCRIPTION
--------------
before, if you tried to use a config where the path included symlinks, the logic would delete the config file at save_loc/model.yml even though it is the same file. tested on derecho with launch option

explanation: `realpath` resolves symlinks and then applies `abspath`

-----------

new feature:
- updated pbs.py so that .o files are saved to save_loc

testing:
checkout the branch, update your credit env, update the env in unet_test.yml with your env then launch a test with:

`python applications/train.py -c [path-to-your-repo]miles-credit/config/unet_test.yml -l 1`

**see this dir for my results:**
`/glade/work/dkimpara/CREDIT_runs/test_1dg_unet/`