### PR TITLE
`PHB` does not work. Revert to `PBH`

### DIFF
--- a/credit/pbs.py
+++ b/credit/pbs.py
@@ -141,7 +141,7 @@ def launch_script_mpi(config_file, script_path, launch=True, backend='nccl'):
 
     export MPICH_RDMA_ENABLED_CUDA=1
     export NCCL_NET="AWS Libfabric"
-    export NCCL_NET_GDR_LEVEL=PHB
+    export NCCL_NET_GDR_LEVEL=PBH
 
     export FI_CXI_DISABLE_HOST_REGISTER=1
     export FI_CXI_OPTIMIZED_MRS=false


### PR DESCRIPTION
Jobs freeze when initializing the NCCL process group or communication when using the correct setting `PHB`. Setting the original `PBH` back, which seems to be a typo but does work.