### PR TITLE
BUGFIX [URGENT] pbs.py not using right launch file

### DIFF
--- a/config/unet_test.yml
+++ b/config/unet_test.yml
@@ -4,7 +4,7 @@
 # The model is trained on hourly model-level ERA5 data with top solar irradiance, geopotential, and land-sea mask
 # Output variables: model level [U, V, T, Q], single level [SP, t2m], and 500 hPa [U, V, T, Z, Q]
 # --------------------------------------------------------------------------------------------------------------------- #
-save_loc: '/glade/work/$USER/CREDIT_runs/test_1dg_unet/'
+save_loc: '/glade/work/$USER/CREDIT_runs/blah/'
 seed: 1000
 
 data:
@@ -186,6 +186,7 @@ pbs: # casper
     walltime: '00:10:00'
     gpu_type: 'a100'
     queue: 'casper'
+
 
 # pbs: #derecho
 #     conda: "credit-derecho"


### PR DESCRIPTION
discovered a bug with pbs.py after introduction of the `cwd` argument to subprocess.popen. When launching, we would either
1. use the old launch file at save_loc/launch.sh` 
3. error out because no `save_loc/launch.sh` file exists

resolution: move file copying logic to before subprocess.popen call

New features
- unified behavior between `launch_script` and `launch_script_mpi`
- returning error message from `qsub` command


testing:
- config/unet_test.yml
- `/glade/work/dkimpara/CREDIT_runs/test_1dg_wx` for derecho testing