### PR TITLE
Added valid_forecast_len to the result_dict

### DIFF
--- a/credit/trainers/trainerERA5_multistep_grad_accum.py
+++ b/credit/trainers/trainerERA5_multistep_grad_accum.py
@@ -623,6 +623,7 @@ class Trainer(BaseTrainer):
                     torch.distributed.barrier()
 
                 results_dict["valid_loss"].append(batch_loss[0].item())
+                results_dict["valid_forecast_len"].append(forecast_len + 1)
 
                 stop_forecast = False
 


### PR DESCRIPTION
Adding (missing) valid forecast len entry to the metric result dictionary 