### PR TITLE
Refactored validate method in trainerERA5_multistep_grad_acum.py for new dataset

### DIFF
--- a/config/model_test_new_dataset.yml
+++ b/config/model_test_new_dataset.yml
@@ -1,0 +1,193 @@
+# --------------------------------------------------------------------------------------------------------------------- #
+# This yaml file implements 1 hourly state-in-state-out graph model
+# on NSF NCAR HPCs (casper.ucar.edu and derecho.hpc.ucar.edu) 
+# The model is trained on 1 hourly model-level ERA5 data with top solar irradiance, geopotential, and land-sea mask
+# Output variables: model level [U, V, T, Q], single level [SP, t2m], and 500 hPa [U, V, T, Z, Q]
+# --------------------------------------------------------------------------------------------------------------------- #
+save_loc: '/glade/derecho/scratch/$USER/test-credit/'
+seed: 1000
+
+data:
+    # upper-air variables
+    variables: ['U','V','T','Q']
+    save_loc: '/glade/campaign/cisl/aiml/akn7/test-data/ERA5_mlevel_cesm_6h_lev16__1979_27steps.zarr'
+    
+    # surface variables
+    surface_variables: ['SP','t2m','V500','U500','T500','Z500','Q500']
+    save_loc_surface: '/glade/campaign/cisl/aiml/akn7/test-data/ERA5_mlevel_cesm_6h_lev16__1979_27steps.zarr'
+    
+    # dynamic forcing variables
+    dynamic_forcing_variables: ['tsi']
+    save_loc_dynamic_forcing: '/glade/campaign/cisl/aiml/akn7/test-data/ERA5_mlevel_cesm_6h_lev16__1979_27steps.zarr'
+    
+    # static variables
+    static_variables: ['Z_GDS4_SFC','LSM'] 
+    save_loc_static: '/glade/derecho/scratch/ksha/CREDIT_data/ERA5_mlevel_cesm_stage1/static/ERA5_mlevel_cesm_static.zarr'
+    
+    # mean / std path
+    mean_path: '/glade/derecho/scratch/ksha/CREDIT_data/ERA5_mlevel_cesm_stage1/mean_std/mean_6h_1979_2018_cesm.nc'
+    # regular z-score version
+    # std_path: '/glade/derecho/scratch/ksha/CREDIT_data/ERA5_mlevel_cesm_stage1/mean_std/std_6h_1979_2018_cesm.nc'
+    # residual norm version
+    std_path: '/glade/derecho/scratch/ksha/CREDIT_data/ERA5_mlevel_cesm_stage1/mean_std/std_residual_6h_1979_2018_cesm.nc'
+    
+    # train / validation split
+    train_years: [1979, 1980]
+    valid_years: [1979, 1980]
+    
+    # data workflow
+    scaler_type: 'std_new'
+    
+    # state-in-state-out
+    history_len: 1
+    valid_history_len: 1
+    
+    forecast_len: 0
+    valid_forecast_len: 3
+    
+    one_shot: True
+    
+    # 1 for hourly model
+    lead_time_periods: 6
+    
+    # do not use skip_period
+    skip_periods: null
+    
+    # compatible with the old 'std'
+    static_first: True
+
+    dataset_type: MultiprocessingBatcher # ERA5_and_Forcing_MultiStep MultiprocessingBatcherPrefetch ERA5_MultiStep_Batcher MultiprocessingBatcher
+    
+trainer:
+    type: universal # <---------- change to your type: single/multi-step training
+
+    mode: fsdp
+    cpu_offload: False
+    activation_checkpoint: True
+    
+    load_weights: False
+    load_optimizer: False
+    load_scaler: False
+    load_scheduler: False
+
+    skip_validation: False
+    update_learning_rate: False
+
+    save_backup_weights: True
+    save_best_weights: True
+    
+    learning_rate: 1.0e-03 # <-- change to your lr
+    weight_decay: 0
+    
+    train_batch_size: 2
+    valid_batch_size: 4
+    
+    batches_per_epoch: 1000 # Total number of samples = 341,880  (1h) ~56,960 (6h)
+    valid_batches_per_epoch: 1000
+    stopping_patience: 999
+    
+    start_epoch: 0
+    num_epoch: 10
+    reload_epoch: True
+    epochs: &epochs 100
+    
+    use_scheduler: True
+    scheduler: {'scheduler_type': 'cosine-annealing', 'T_max': *epochs,  'last_epoch': -1}
+    
+    # Automatic Mixed Precision: False
+    amp: False
+    
+    # rescale loss as loss = loss / grad_accum_every
+    grad_accum_every: 1 
+    # gradient clipping
+    grad_max_norm: 1.0
+    
+    # number of workers
+    thread_workers: 4
+    valid_thread_workers: 4
+
+    # compile 
+    # compile: True
+    prefetch_factor: 20
+
+model:
+    # crossformer example
+    type: "crossformer"
+    frames: 1                         # number of input states (default: 1)
+    image_height: 192                 # number of latitude grids (default: 640)
+    image_width: 288                 # number of longitude grids (default: 1280)
+    levels: 16                        # number of upper-air variable levels (default: 15)
+    channels: 4                       # upper-air variable channels
+    surface_channels: 7               # surface variable channels
+    input_only_channels: 3            # dynamic forcing, forcing, static channels
+    output_only_channels: 0           # diagnostic variable channels
+    
+    patch_width: 1                    # number of latitude grids in each 3D patch (default: 1)
+    patch_height: 1                   # number of longitude grids in each 3D patch (default: 1)
+    frame_patch_size: 1               # number of input states in each 3D patch (default: 1)
+    
+    dim: [64, 128, 256, 512]           # Dimensionality of each layer
+    depth: [2, 2, 8, 2]               # Depth of each layer
+    global_window_size: [4, 4, 2, 1]   # Global window size for each layer
+    local_window_size: 3             # Local window size
+    cross_embed_kernel_sizes:         # kernel sizes for cross-embedding
+    - [4, 8, 16, 32]
+    - [2, 4]
+    - [2, 4]
+    - [2, 4]
+    cross_embed_strides: [2, 2, 2, 2] # Strides for cross-embedding (default: [4, 2, 2, 2])
+    attn_dropout: 0.                  # Dropout probability for attention layers (default: 0.0)
+    ff_dropout: 0.                    # Dropout probability for feed-forward layers (default: 0.0)
+    
+    # map boundary padding
+    pad_lon: 48             # number of grids to pad on 0 and 360 deg lon
+    pad_lat: 48             # number of grids to pad on -90 and 90 deg lat
+    
+loss: 
+    # the main training loss
+    training_loss: "mse"
+    
+    # power loss (x), spectral_loss (x)
+    use_power_loss: False
+    use_spectral_loss: False
+    
+    # use latitude weighting
+    use_latitude_weights: True
+    latitude_weights: '/glade/derecho/scratch/ksha/CREDIT_data/ERA5_mlevel_cesm_stage1/static/ERA5_mlevel_cesm_static.zarr'
+    
+    # turn-off variable weighting
+    use_variable_weights: False
+    
+predict:
+    mode: fsdp
+    forecasts:
+        type: "custom"       # keep it as "custom"
+        start_year: 2020     # year of the first initialization (where rollout will start)
+        start_month: 1       # month of the first initialization
+        start_day: 1         # day of the first initialization
+        start_hours: [0, 12] # hour-of-day for each initialization, 0 for 00Z, 12 for 12Z
+        duration: 8          # number of days to initialize, starting from the (year, mon, day) above
+                             # duration should be divisible by the number of GPUs 
+                             # (e.g., duration: 384 for 365-day rollout using 32 GPUs)
+        days: 10             # forecast lead time as days (1 means 24-hour forecast)
+        
+    metadata: '/glade/u/home/akn7/miles-credit/credit/metadata/era5.yaml'
+    save_forecast: '/glade/derecho/scratch/$USER/test-credit/'
+    # save_vars: ['SP','t2m','V500','U500','T500','Z500','Q500']
+    
+    # turn-off low-pass filter
+    use_laplace_filter: False
+    
+    # deprecated
+    # save_format: "nc"
+
+pbs: #derecho
+    conda: "/glade/work/akn7/conda-envs/credit-derecho"
+    project: "NAML0001"
+    job_name: "graph_1h"
+    walltime: "12:00:00"
+    nodes: 8
+    ncpus: 64
+    ngpus: 4
+    mem: '480GB'
+    queue: 'main'

--- a/credit/trainers/trainerERA5_multistep_grad_accum.py
+++ b/credit/trainers/trainerERA5_multistep_grad_accum.py
@@ -170,166 +170,153 @@ class Trainer(BaseTrainer):
         self.model.train()
 
         dl = cycle(trainloader)
-
         results_dict = defaultdict(list)
-
         for steps in range(batches_per_epoch):
             logs = {}
             loss = 0
             stop_forecast = False
             y_pred = None  # Place holder that gets updated after first roll-out
+            while not stop_forecast:
+                batch = next(dl)
+                forecast_step = batch["forecast_step"].item()
+                if forecast_step == 1:
+                    # Initialize x and x_surf with the first time step
+                    if "x_surf" in batch:
+                        # combine x and x_surf
+                        # input: (batch_num, time, var, level, lat, lon), (batch_num, time, var, lat, lon)
+                        # output: (batch_num, var, time, lat, lon), 'x' first and then 'x_surf'
+                        x = concat_and_reshape(batch["x"], batch["x_surf"]).to(
+                            self.device
+                        )  # .float()
+                    else:
+                        # no x_surf
+                        x = reshape_only(batch["x"]).to(self.device)  # .float()
 
-            with autocast(enabled=amp):
-                while not stop_forecast:
-                    batch = next(dl)
+                # add forcing and static variables (regardless of fcst hours)
+                if "x_forcing_static" in batch:
+                    # (batch_num, time, var, lat, lon) --> (batch_num, var, time, lat, lon)
+                    x_forcing_batch = (
+                        batch["x_forcing_static"].to(self.device).permute(0, 2, 1, 3, 4)
+                    )  # .float()
 
-                    for i, forecast_step in enumerate(batch["forecast_step"]):
-                        # if self.rank == 0:
-                        #     logger.info(f"i: {i}, forecast_step: {forecast_step}")
-                        if forecast_step == 1:
-                            # Initialize x and x_surf with the first time step
-                            if "x_surf" in batch:
-                                # combine x and x_surf
-                                # input: (batch_num, time, var, level, lat, lon), (batch_num, time, var, lat, lon)
-                                # output: (batch_num, var, time, lat, lon), 'x' first and then 'x_surf'
-                                x = concat_and_reshape(batch["x"], batch["x_surf"]).to(
-                                    self.device
-                                )  # .float()
-                            else:
-                                # no x_surf
-                                x = reshape_only(batch["x"]).to(self.device)  # .float()
+                    # concat on var dimension
+                    x = torch.cat((x, x_forcing_batch), dim=1)
 
-                        # add forcing and static variables (regardless of fcst hours)
-                        if "x_forcing_static" in batch:
-                            # (batch_num, time, var, lat, lon) --> (batch_num, var, time, lat, lon)
-                            x_forcing_batch = (
-                                batch["x_forcing_static"]
-                                .to(self.device)
-                                .permute(0, 2, 1, 3, 4)
-                            )  # .float()
+                # --------------------------------------------- #
+                # clamp
+                if flag_clamp:
+                    x = torch.clamp(x, min=clamp_min, max=clamp_max)
 
-                            # concat on var dimension
-                            x = torch.cat((x, x_forcing_batch), dim=1)
+                # predict with the model
+                with autocast(enabled=amp):
+                    y_pred = self.model(x)
 
-                        # --------------------------------------------- #
-                        # clamp
-                        if flag_clamp:
-                            x = torch.clamp(x, min=clamp_min, max=clamp_max)
+                # ============================================= #
+                # postblock opts outside of model
 
-                        # predict with the model
-                        y_pred = self.model(x)
+                # backup init state
+                if flag_mass_conserve:
+                    if forecast_step == 1:
+                        x_init = x.clone()
 
-                        # ============================================= #
-                        # postblock opts outside of model
+                # mass conserve using initialization as reference
+                if flag_mass_conserve:
+                    input_dict = {"y_pred": y_pred, "x": x_init}
+                    input_dict = opt_mass(input_dict)
+                    y_pred = input_dict["y_pred"]
 
-                        # backup init state
-                        if flag_mass_conserve:
-                            if forecast_step == 1:
-                                x_init = x.clone()
+                # water conserve use previous step output as reference
+                if flag_water_conserve:
+                    input_dict = {"y_pred": y_pred, "x": x}
+                    input_dict = opt_water(input_dict)
+                    y_pred = input_dict["y_pred"]
 
-                        # mass conserve using initialization as reference
-                        if flag_mass_conserve:
-                            input_dict = {"y_pred": y_pred, "x": x_init}
-                            input_dict = opt_mass(input_dict)
-                            y_pred = input_dict["y_pred"]
+                # energy conserve use previous step output as reference
+                if flag_energy_conserve:
+                    input_dict = {"y_pred": y_pred, "x": x}
+                    input_dict = opt_energy(input_dict)
+                    y_pred = input_dict["y_pred"]
+                # ============================================= #
 
-                        # water conserve use previous step output as reference
-                        if flag_water_conserve:
-                            input_dict = {"y_pred": y_pred, "x": x}
-                            input_dict = opt_water(input_dict)
-                            y_pred = input_dict["y_pred"]
+                # only load y-truth data if we intend to backprop (default is every step gets grads computed
+                if forecast_step in backprop_on_timestep:
+                    # calculate rolling loss
+                    if "y_surf" in batch:
+                        y = concat_and_reshape(batch["y"], batch["y_surf"]).to(
+                            self.device
+                        )
+                    else:
+                        y = reshape_only(batch["y"]).to(self.device)
 
-                        # energy conserve use previous step output as reference
-                        if flag_energy_conserve:
-                            input_dict = {"y_pred": y_pred, "x": x}
-                            input_dict = opt_energy(input_dict)
-                            y_pred = input_dict["y_pred"]
-                        # ============================================= #
+                    if "y_diag" in batch:
+                        # (batch_num, time, var, lat, lon) --> (batch_num, var, time, lat, lon)
+                        y_diag_batch = (
+                            batch["y_diag"].to(self.device).permute(0, 2, 1, 3, 4)
+                        )  # .float()
 
-                        # only load y-truth data if we intend to backprop (default is every step gets grads computed
-                        if forecast_step in backprop_on_timestep:
-                            # calculate rolling loss
-                            if "y_surf" in batch:
-                                y = concat_and_reshape(batch["y"], batch["y_surf"]).to(
-                                    self.device
-                                )
-                            else:
-                                y = reshape_only(batch["y"]).to(self.device)
+                        # concat on var dimension
+                        y = torch.cat((y, y_diag_batch), dim=1)
 
-                            if "y_diag" in batch:
-                                # (batch_num, time, var, lat, lon) --> (batch_num, var, time, lat, lon)
-                                y_diag_batch = (
-                                    batch["y_diag"]
-                                    .to(self.device)
-                                    .permute(0, 2, 1, 3, 4)
-                                )  # .float()
+                    # --------------------------------------------- #
+                    # clamp
+                    if flag_clamp:
+                        y = torch.clamp(y, min=clamp_min, max=clamp_max)
 
-                                # concat on var dimension
-                                y = torch.cat((y, y_diag_batch), dim=1)
+                    with autocast(enabled=amp):
+                        loss = criterion(y.to(y_pred.dtype), y_pred).mean()
 
-                            # --------------------------------------------- #
-                            # clamp
-                            if flag_clamp:
-                                y = torch.clamp(y, min=clamp_min, max=clamp_max)
+                    # track the loss
+                    accum_log(logs, {"loss": loss.item()})
 
-                            loss = criterion(y.to(y_pred.dtype), y_pred).mean()
-
-                            # track the loss
-                            accum_log(logs, {"loss": loss.item()})
-
-                            # compute gradients
-                            scaler.scale(loss).backward()
-
-                        if distributed:
-                            torch.distributed.barrier()
-
-                        # stop after X steps
-                        stop_forecast = batch["stop_forecast"][i]
-
-                        # step-in-step-out
-                        if x.shape[2] == 1:
-                            # cut diagnostic vars from y_pred, they are not inputs
-                            if "y_diag" in batch:
-                                x = y_pred[:, :-varnum_diag, ...].detach()
-                            else:
-                                x = y_pred.detach()
-
-                        # multi-step in
-                        else:
-                            # static channels will get updated on next pass
-
-                            if static_dim_size == 0:
-                                x_detach = x[:, :, 1:, ...].detach()
-                            else:
-                                x_detach = x[:, :-static_dim_size, 1:, ...].detach()
-
-                            # cut diagnostic vars from y_pred, they are not inputs
-                            if "y_diag" in batch:
-                                x = torch.cat(
-                                    [x_detach, y_pred[:, :-varnum_diag, ...].detach()],
-                                    dim=2,
-                                )
-                            else:
-                                x = torch.cat([x_detach, y_pred.detach()], dim=2)
-
-                    if stop_forecast:
-                        break
-
-                # scale, accumulate, backward
+                    # compute gradients
+                    scaler.scale(loss).backward()
 
                 if distributed:
                     torch.distributed.barrier()
 
-                if grad_max_norm is not None:
-                    scaler.unscale_(optimizer)
-                    torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=grad_max_norm)
-        
-                scaler.step(optimizer)
-                scaler.update()
-                optimizer.zero_grad()
+                # stop after X steps
+                stop_forecast = batch["stop_forecast"].item()
+                if stop_forecast:
+                    break
+
+                # step-in-step-out
+                if x.shape[2] == 1:
+                    # cut diagnostic vars from y_pred, they are not inputs
+                    if "y_diag" in batch:
+                        x = y_pred[:, :-varnum_diag, ...].detach()
+                    else:
+                        x = y_pred.detach()
+
+                # multi-step in
+                else:
+                    # static channels will get updated on next pass
+
+                    if static_dim_size == 0:
+                        x_detach = x[:, :, 1:, ...].detach()
+                    else:
+                        x_detach = x[:, :-static_dim_size, 1:, ...].detach()
+
+                    # cut diagnostic vars from y_pred, they are not inputs
+                    if "y_diag" in batch:
+                        x = torch.cat(
+                            [x_detach, y_pred[:, :-varnum_diag, ...].detach()],
+                            dim=2,
+                        )
+                    else:
+                        x = torch.cat([x_detach, y_pred.detach()], dim=2)
+
+            if distributed:
+                torch.distributed.barrier()
+
+            scaler.unscale_(optimizer)
+            torch.nn.utils.clip_grad_norm_(
+                self.model.parameters(), max_norm=grad_max_norm
+            )
+            scaler.step(optimizer)
+            scaler.update()
+            optimizer.zero_grad()
 
             # Metrics
-            # metrics_dict = metrics(y_pred.float(), y.float())
             metrics_dict = metrics(y_pred, y)
             for name, value in metrics_dict.items():
                 value = torch.Tensor([value]).cuda(self.device, non_blocking=True)
@@ -426,13 +413,17 @@ class Trainer(BaseTrainer):
         results_dict = defaultdict(list)
 
         # set up a custom tqdm
-        if isinstance(valid_loader.dataset, IterableDataset):
-            valid_batches_per_epoch = valid_batches_per_epoch
-        else:
+        if not isinstance(valid_loader.dataset, IterableDataset):
+            # Check if the dataset has its own batches_per_epoch method
+            if hasattr(valid_loader.dataset, "batches_per_epoch"):
+                dataset_batches_per_epoch = valid_loader.dataset.batches_per_epoch()
+            else:
+                dataset_batches_per_epoch = len(valid_loader)
+            # Use the user-given number if not larger than the dataset
             valid_batches_per_epoch = (
                 valid_batches_per_epoch
-                if 0 < valid_batches_per_epoch < len(valid_loader)
-                else len(valid_loader)
+                if 0 < valid_batches_per_epoch < dataset_batches_per_epoch
+                else dataset_batches_per_epoch
             )
 
         # ------------------------------------------------------- #
@@ -476,10 +467,16 @@ class Trainer(BaseTrainer):
         )
 
         stop_forecast = False
+        dl = cycle(valid_loader)
         with torch.no_grad():
-            for k, batch in enumerate(valid_loader):
+            for steps in range(valid_batches_per_epoch):
+                loss = 0
+                stop_forecast = False
                 y_pred = None  # Place holder that gets updated after first roll-out
-                for _, forecast_step in enumerate(batch["forecast_step"]):
+                while not stop_forecast:
+                    batch = next(dl)
+                    forecast_step = batch["forecast_step"].item()
+                    stop_forecast = batch["stop_forecast"].item()
                     if forecast_step == 1:
                         # Initialize x and x_surf with the first time step
                         if "x_surf" in batch:
@@ -585,9 +582,8 @@ class Trainer(BaseTrainer):
 
                             results_dict[f"valid_{name}"].append(value[0].item())
 
-                        stop_forecast = True
-
-                        break
+                        assert stop_forecast
+                        break  # stop after X steps
 
                     # ================================================================================== #
                     # scope of keep rolling out
@@ -616,9 +612,6 @@ class Trainer(BaseTrainer):
                         else:
                             x = torch.cat([x_detach, y_pred.detach()], dim=2)
 
-                if not stop_forecast:
-                    continue
-
                 batch_loss = torch.Tensor([loss.item()]).cuda(self.device)
 
                 if distributed:
@@ -639,9 +632,6 @@ class Trainer(BaseTrainer):
                 if self.rank == 0:
                     batch_group_generator.update(1)
                     batch_group_generator.set_description(to_print)
-
-                if k // history_len >= valid_batches_per_epoch and k > 0:
-                    break
 
         # Shutdown the progbar
         batch_group_generator.close()


### PR DESCRIPTION
This PR refactors `validate` method in `trainerERA5_multistep_grad_acum.py` to work with new dataset:  `ERA5_MultiStep_Batcher` and `MultiprocessingBatcher`. 

`train_one_method` in `trainerERA5_multistep_grad_acum.py ` is also refactored to remove so bits of code not longer necessary. 

`load_dataset_dataloader.py` is also modified to pass to dataset the appropriate train type (i.e., training set and validation set) related files/parameters. 

This PR can be tested with the included config file, which points to a single file  of a subset of ERA5 data (27 teps only in the time dimensions). Cases to consider would be 

- Different batch_sizes for train and validateion 
- Different forecast_len for train and validation 