### PR TITLE
Fixed trainer classes to actually use DDP

### DIFF
--- a/applications/train.py
+++ b/applications/train.py
@@ -580,7 +580,7 @@ def main(rank, world_size, conf, backend, trial=False):
 
     # Initialize a trainer object
     trainer_cls = load_trainer(conf)
-    trainer = trainer_cls(model, rank, module=(conf["trainer"]["mode"] == "ddp"))
+    trainer = trainer_cls(model, rank)
 
     # Fit the model
 

--- a/applications/train404.py
+++ b/applications/train404.py
@@ -348,7 +348,7 @@ def main(rank, world_size, conf, trial=False):
 
     # Initialize a trainer object
 
-    trainer = Trainer(model, rank, module=(conf["trainer"]["mode"] == "ddp"))
+    trainer = Trainer(model, rank)
 
     # Fit the model
 

--- a/applications/train_multistep.py
+++ b/applications/train_multistep.py
@@ -27,10 +27,7 @@ from credit.loss import VariableTotalLoss2D
 from credit.scheduler import load_scheduler
 from credit.trainers import load_trainer
 from credit.parser import credit_main_parser, training_data_check
-from credit.datasets.load_dataset_and_dataloader import (
-    load_dataset,
-    load_dataloader
-)
+from credit.datasets.load_dataset_and_dataloader import load_dataset, load_dataloader
 
 from credit.metrics import LatWeightedMetrics
 from credit.pbs import launch_script, launch_script_mpi
@@ -278,8 +275,12 @@ def main(rank, world_size, conf, backend, trial=False):
     valid_dataset = load_dataset(conf, rank=rank, world_size=world_size, is_train=False)
 
     # Load the dataloader
-    train_loader = load_dataloader(conf, train_dataset, rank=rank, world_size=world_size, is_train=True)
-    valid_loader = load_dataloader(conf, valid_dataset, rank=rank, world_size=world_size, is_train=False)
+    train_loader = load_dataloader(
+        conf, train_dataset, rank=rank, world_size=world_size, is_train=True
+    )
+    valid_loader = load_dataloader(
+        conf, valid_dataset, rank=rank, world_size=world_size, is_train=False
+    )
 
     # model
     m = load_model(conf)
@@ -308,7 +309,7 @@ def main(rank, world_size, conf, backend, trial=False):
 
     # Initialize a trainer object
     trainer_cls = load_trainer(conf)
-    trainer = trainer_cls(model, rank, module=(conf["trainer"]["mode"] == "ddp"))
+    trainer = trainer_cls(model, rank)
 
     # Fit the model
     result = trainer.fit(

--- a/applications/train_universal.py
+++ b/applications/train_universal.py
@@ -329,7 +329,7 @@ def main(rank, world_size, conf, backend, trial=False):
 
     # Initialize a trainer object
     trainer_cls = load_trainer(conf)
-    trainer = trainer_cls(model, rank, module=(conf["trainer"]["mode"] == "ddp"))
+    trainer = trainer_cls(model, rank)
 
     # Fit the model
     result = trainer.fit(

--- a/credit/distributed.py
+++ b/credit/distributed.py
@@ -232,8 +232,7 @@ def distributed_model_wrapper(conf, neural_network, device):
         )
 
     elif conf["trainer"]["mode"] == "ddp":
-        model = DDP(neural_network, device_ids=[device]) 
-        # model = DDP(neural_network, device_ids=[device], find_unused_parameters=True) # Use this if you have a model with layers/modules/parameters unused in the forward method
+        model = DDP(neural_network, device_ids=[device], find_unused_parameters=True) 
 
     else:
         model = neural_network

--- a/credit/distributed.py
+++ b/credit/distributed.py
@@ -232,7 +232,7 @@ def distributed_model_wrapper(conf, neural_network, device):
         )
 
     elif conf["trainer"]["mode"] == "ddp":
-        model = DDP(neural_network, device_ids=[device])
+        model = DDP(neural_network, device_ids=[device], find_unused_parameters=True) 
 
     else:
         model = neural_network

--- a/credit/distributed.py
+++ b/credit/distributed.py
@@ -232,7 +232,8 @@ def distributed_model_wrapper(conf, neural_network, device):
         )
 
     elif conf["trainer"]["mode"] == "ddp":
-        model = DDP(neural_network, device_ids=[device], find_unused_parameters=True) 
+        model = DDP(neural_network, device_ids=[device]) 
+        # model = DDP(neural_network, device_ids=[device], find_unused_parameters=True) # Use this if you have a model with layers/modules/parameters unused in the forward method
 
     else:
         model = neural_network

--- a/credit/trainers/trainer404.py
+++ b/credit/trainers/trainer404.py
@@ -19,8 +19,8 @@ from credit.trainers.base_trainer import BaseTrainer
 
 
 class Trainer(BaseTrainer):
-    def __init__(self, model: torch.nn.Module, rank: int, module: bool = False):
-        super().__init__(model, rank, module)
+    def __init__(self, model: torch.nn.Module, rank: int):
+        super().__init__(model, rank)
         # Add any additional initialization if needed
         logging.info("Loading a trainer class for the conus404 dataset")
 

--- a/credit/trainers/trainerERA5_multistep_concat.py
+++ b/credit/trainers/trainerERA5_multistep_concat.py
@@ -34,8 +34,8 @@ class Trainer(BaseTrainer):
         module (bool): If True, use model with module parallelism (default: False).
     """
 
-    def __init__(self, model: torch.nn.Module, rank: int, module: bool = False):
-        super().__init__(model, rank, module)
+    def __init__(self, model: torch.nn.Module, rank: int):
+        super().__init__(model, rank)
         # Add any additional initialization if needed
         logger.info("Loading a multi-step trainer class")
 

--- a/credit/trainers/trainerERA5_multistep_grad_accum.py
+++ b/credit/trainers/trainerERA5_multistep_grad_accum.py
@@ -47,8 +47,8 @@ class Trainer(BaseTrainer):
             and checkpointing.
     """
 
-    def __init__(self, model: torch.nn.Module, rank: int, module: bool = False):
-        super().__init__(model, rank, module)
+    def __init__(self, model: torch.nn.Module, rank: int):
+        super().__init__(model, rank)
         # Add any additional initialization if needed
         logger.info("Loading a multi-step trainer class")
 

--- a/credit/trainers/trainerERA5_multistep_sum.py
+++ b/credit/trainers/trainerERA5_multistep_sum.py
@@ -34,8 +34,8 @@ class Trainer(BaseTrainer):
         module (bool): If True, use model with module parallelism (default: False).
     """
 
-    def __init__(self, model: torch.nn.Module, rank: int, module: bool = False):
-        super().__init__(model, rank, module)
+    def __init__(self, model: torch.nn.Module, rank: int):
+        super().__init__(model, rank)
         # Add any additional initialization if needed
         logger.info("Loading a multi-step trainer class")
 

--- a/credit/trainers/trainerERA5_multistep_v1.py
+++ b/credit/trainers/trainerERA5_multistep_v1.py
@@ -23,8 +23,8 @@ from credit.trainers.utils import cleanup
 
 
 class Trainer(BaseTrainer):
-    def __init__(self, model: torch.nn.Module, rank: int, module: bool = False):
-        super().__init__(model, rank, module)
+    def __init__(self, model: torch.nn.Module, rank: int):
+        super().__init__(model, rank)
         # Add any additional initialization if needed
         logging.info("Loading a multi-step trainer class")
 

--- a/credit/trainers/trainerERA5_v1.py
+++ b/credit/trainers/trainerERA5_v1.py
@@ -45,8 +45,8 @@ class TOADataLoader:
 
 
 class Trainer(BaseTrainer):
-    def __init__(self, model: torch.nn.Module, rank: int, module: bool = False):
-        super().__init__(model, rank, module)
+    def __init__(self, model: torch.nn.Module, rank: int):
+        super().__init__(model, rank)
         # Add any additional initialization if needed
         logger.info("Loading a batch trainer class")
 

--- a/credit/trainers/trainerERA5_v2.py
+++ b/credit/trainers/trainerERA5_v2.py
@@ -34,8 +34,8 @@ logger = logging.getLogger(__name__)
 
 
 class Trainer(BaseTrainer):
-    def __init__(self, model: torch.nn.Module, rank: int, module: bool = False):
-        super().__init__(model, rank, module)
+    def __init__(self, model: torch.nn.Module, rank: int):
+        super().__init__(model, rank)
         # Add any additional initialization if needed
         logger.info("Loading a batch trainer class")
 


### PR DESCRIPTION
The current behavior of the trainers removes the DDP wrapper from the model, leading to independent models on different GPUs that do not share gradient updates. This caused error spikes when reloading weights to resume training.

To test this PR, use `config/model_test_new_dataset.yml`, which contains a small subset of ERA5, runnable in a couple of minutes. For instance, you can run for 2 epochs and then resume training by reloading the weights to confirm that the error does not spike. Note: Ensure that trainer:type: is set to `ddp` in the config file.