### PR TITLE
add missing arg for historical gfs

### DIFF
--- a/applications/gfs_init.py
+++ b/applications/gfs_init.py
@@ -34,6 +34,7 @@ gfs_init = build_GFS_init(
     date=date,
     variables=variables,
     model_level_indices=model_level_indices,
+    gdas_base_path=gdas_base_path
 )
 
 gfs_init.to_zarr(


### PR DESCRIPTION
One line change to add missing argument to allow for historical GFS data (back through 2021) to be used to create initial conditions.