### PR TITLE
Fixed seed issues with CRPS across GPUs

### DIFF
--- a/applications/train.py
+++ b/applications/train.py
@@ -72,26 +72,10 @@ def load_model_states_and_optimizer(conf, model, device):
     amp = conf["trainer"]["amp"]
 
     # load weights / states flags
-    load_weights = (
-        False
-        if "load_weights" not in conf["trainer"]
-        else conf["trainer"]["load_weights"]
-    )
-    load_optimizer_conf = (
-        False
-        if "load_optimizer" not in conf["trainer"]
-        else conf["trainer"]["load_optimizer"]
-    )
-    load_scaler_conf = (
-        False
-        if "load_scaler" not in conf["trainer"]
-        else conf["trainer"]["load_scaler"]
-    )
-    load_scheduler_conf = (
-        False
-        if "load_scheduler" not in conf["trainer"]
-        else conf["trainer"]["load_scheduler"]
-    )
+    load_weights = False if "load_weights" not in conf["trainer"] else conf["trainer"]["load_weights"]
+    load_optimizer_conf = False if "load_optimizer" not in conf["trainer"] else conf["trainer"]["load_optimizer"]
+    load_scaler_conf = False if "load_scaler" not in conf["trainer"] else conf["trainer"]["load_scaler"]
+    load_scheduler_conf = False if "load_scheduler" not in conf["trainer"] else conf["trainer"]["load_scheduler"]
 
     #  Load an optimizer, gradient scaler, and learning rate scheduler, the optimizer must come after wrapping model using FSDP
     if not load_weights:  # Loaded after loading model weights when reloading
@@ -104,16 +88,10 @@ def load_model_states_and_optimizer(conf, model, device):
         if conf["trainer"]["mode"] == "fsdp":
             optimizer = FSDPOptimizerWrapper(optimizer, model)
         scheduler = load_scheduler(optimizer, conf)
-        scaler = (
-            ShardedGradScaler(enabled=amp)
-            if conf["trainer"]["mode"] == "fsdp"
-            else GradScaler(enabled=amp)
-        )
+        scaler = ShardedGradScaler(enabled=amp) if conf["trainer"]["mode"] == "fsdp" else GradScaler(enabled=amp)
 
     # Multi-step training case -- when starting, only load the model weights (then after load all states)
-    elif load_weights and not (
-        load_optimizer_conf or load_scaler_conf or load_scheduler_conf
-    ):
+    elif load_weights and not (load_optimizer_conf or load_scaler_conf or load_scheduler_conf):
         optimizer = torch.optim.AdamW(
             filter(lambda p: p.requires_grad, model.parameters()),
             lr=learning_rate,
@@ -131,33 +109,23 @@ def load_model_states_and_optimizer(conf, model, device):
             )
             optimizer = FSDPOptimizerWrapper(optimizer, model)
             checkpoint_io = TorchFSDPCheckpointIO()
-            checkpoint_io.load_unsharded_model(
-                model, os.path.join(save_loc, "model_checkpoint.pt")
-            )
+            checkpoint_io.load_unsharded_model(model, os.path.join(save_loc, "model_checkpoint.pt"))
         else:
             # DDP settings
             ckpt = os.path.join(save_loc, "checkpoint.pt")
             checkpoint = torch.load(ckpt, map_location=device)
             if conf["trainer"]["mode"] == "ddp":
                 logging.info(f"Loading DDP model state only from {save_loc}")
-                load_msg = model.module.load_state_dict(
-                    checkpoint["model_state_dict"], strict=False
-                )
+                load_msg = model.module.load_state_dict(checkpoint["model_state_dict"], strict=False)
                 load_state_dict_error_handler(load_msg)
             else:
                 logging.info(f"Loading model state only from {save_loc}")
-                load_msg = model.load_state_dict(
-                    checkpoint["model_state_dict"], strict=False
-                )
+                load_msg = model.load_state_dict(checkpoint["model_state_dict"], strict=False)
                 load_state_dict_error_handler(load_msg)
 
         # Load the learning rate scheduler and mixed precision grad scaler
         scheduler = load_scheduler(optimizer, conf)
-        scaler = (
-            ShardedGradScaler(enabled=amp)
-            if conf["trainer"]["mode"] == "fsdp"
-            else GradScaler(enabled=amp)
-        )
+        scaler = ShardedGradScaler(enabled=amp) if conf["trainer"]["mode"] == "fsdp" else GradScaler(enabled=amp)
         # Update the config file to the current epoch based on the checkpoint
         if (
             "reload_epoch" in conf["trainer"]
@@ -184,16 +152,9 @@ def load_model_states_and_optimizer(conf, model, device):
             )
             optimizer = FSDPOptimizerWrapper(optimizer, model)
             checkpoint_io = TorchFSDPCheckpointIO()
-            checkpoint_io.load_unsharded_model(
-                model, os.path.join(save_loc, "model_checkpoint.pt")
-            )
-            if (
-                "load_optimizer" in conf["trainer"]
-                and conf["trainer"]["load_optimizer"]
-            ):
-                checkpoint_io.load_unsharded_optimizer(
-                    optimizer, os.path.join(save_loc, "optimizer_checkpoint.pt")
-                )
+            checkpoint_io.load_unsharded_model(model, os.path.join(save_loc, "model_checkpoint.pt"))
+            if "load_optimizer" in conf["trainer"] and conf["trainer"]["load_optimizer"]:
+                checkpoint_io.load_unsharded_optimizer(optimizer, os.path.join(save_loc, "optimizer_checkpoint.pt"))
 
         else:
             # DDP settings
@@ -201,17 +162,13 @@ def load_model_states_and_optimizer(conf, model, device):
                 logging.info(
                     f"Loading DDP model, optimizer, grad scaler, and learning rate scheduler states from {save_loc}"
                 )
-                load_msg = model.module.load_state_dict(
-                    checkpoint["model_state_dict"], strict=False
-                )
+                load_msg = model.module.load_state_dict(checkpoint["model_state_dict"], strict=False)
                 load_state_dict_error_handler(load_msg)
             else:
                 logging.info(
                     f"Loading model, optimizer, grad scaler, and learning rate scheduler states from {save_loc}"
                 )
-                load_msg = model.load_state_dict(
-                    checkpoint["model_state_dict"], strict=False
-                )
+                load_msg = model.load_state_dict(checkpoint["model_state_dict"], strict=False)
                 load_state_dict_error_handler(load_msg)
 
             optimizer = torch.optim.AdamW(
@@ -220,18 +177,11 @@ def load_model_states_and_optimizer(conf, model, device):
                 weight_decay=weight_decay,
                 betas=(0.9, 0.95),
             )
-            if (
-                "load_optimizer" in conf["trainer"]
-                and conf["trainer"]["load_optimizer"]
-            ):
+            if "load_optimizer" in conf["trainer"] and conf["trainer"]["load_optimizer"]:
                 optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
 
         scheduler = load_scheduler(optimizer, conf)
-        scaler = (
-            ShardedGradScaler(enabled=amp)
-            if conf["trainer"]["mode"] == "fsdp"
-            else GradScaler(enabled=amp)
-        )
+        scaler = ShardedGradScaler(enabled=amp) if conf["trainer"]["mode"] == "fsdp" else GradScaler(enabled=amp)
 
         # Update the config file to the current epoch
         if "reload_epoch" in conf["trainer"] and conf["trainer"]["reload_epoch"]:
@@ -246,11 +196,7 @@ def load_model_states_and_optimizer(conf, model, device):
             scaler.load_state_dict(checkpoint["scaler_state_dict"])
 
     # Enable updating the lr if not using a policy
-    if (
-        conf["trainer"]["update_learning_rate"]
-        if "update_learning_rate" in conf["trainer"]
-        else False
-    ):
+    if conf["trainer"]["update_learning_rate"] if "update_learning_rate" in conf["trainer"] else False:
         for param_group in optimizer.param_groups:
             param_group["lr"] = learning_rate
 
@@ -280,9 +226,7 @@ def main(rank, world_size, conf, backend=None, trial=False):
 
     # infer device id from rank
     device = (
-        torch.device(f"cuda:{rank % torch.cuda.device_count()}")
-        if torch.cuda.is_available()
-        else torch.device("cpu")
+        torch.device(f"cuda:{rank % torch.cuda.device_count()}") if torch.cuda.is_available() else torch.device("cpu")
     )
     torch.cuda.set_device(rank % torch.cuda.device_count())
 
@@ -291,12 +235,8 @@ def main(rank, world_size, conf, backend=None, trial=False):
     valid_dataset = load_dataset(conf, rank=rank, world_size=world_size, is_train=False)
 
     # Load the dataloader
-    train_loader = load_dataloader(
-        conf, train_dataset, rank=rank, world_size=world_size, is_train=True
-    )
-    valid_loader = load_dataloader(
-        conf, valid_dataset, rank=rank, world_size=world_size, is_train=False
-    )
+    train_loader = load_dataloader(conf, train_dataset, rank=rank, world_size=world_size, is_train=True)
+    valid_loader = load_dataloader(conf, valid_dataset, rank=rank, world_size=world_size, is_train=False)
 
     seed = conf["seed"] + rank
     seed_everything(seed)
@@ -318,9 +258,7 @@ def main(rank, world_size, conf, backend=None, trial=False):
         model = m
 
     # Load model weights (if any), an optimizer, scheduler, and gradient scaler
-    conf, model, optimizer, scheduler, scaler = load_model_states_and_optimizer(
-        conf, model, device
-    )
+    conf, model, optimizer, scheduler, scaler = load_model_states_and_optimizer(conf, model, device)
 
     # Train and validation losses
     train_criterion = VariableTotalLoss2D(conf)
@@ -390,14 +328,10 @@ class Objective(BaseObjective):
 
         except Exception as E:
             if "CUDA" in str(E) or "non-singleton" in str(E):
-                logging.warning(
-                    f"Pruning trial {trial.number} due to CUDA memory overflow: {str(E)}."
-                )
+                logging.warning(f"Pruning trial {trial.number} due to CUDA memory overflow: {str(E)}.")
                 raise optuna.TrialPruned()
             elif "non-singleton" in str(E):
-                logging.warning(
-                    f"Pruning trial {trial.number} due to shape mismatch: {str(E)}."
-                )
+                logging.warning(f"Pruning trial {trial.number} due to shape mismatch: {str(E)}.")
                 raise optuna.TrialPruned()
             else:
                 logging.warning(f"Trial {trial.number} failed due to error: {str(E)}.")
@@ -405,7 +339,9 @@ class Objective(BaseObjective):
 
 
 if __name__ == "__main__":
-    description = "Train an AI model for Numerical Weather Prediction (NWP) using a specified dataset and configuration."
+    description = (
+        "Train an AI model for Numerical Weather Prediction (NWP) using a specified dataset and configuration."
+    )
     parser = ArgumentParser(description=description)
     parser.add_argument(
         "-c",
@@ -468,9 +404,7 @@ if __name__ == "__main__":
 
     # ======================================================== #
     # handling config args
-    conf = credit_main_parser(
-        conf, parse_training=True, parse_predict=False, print_summary=False
-    )
+    conf = credit_main_parser(conf, parse_training=True, parse_predict=False, print_summary=False)
     training_data_check(conf, print_summary=False)
     # ======================================================== #
 

--- a/applications/train.py
+++ b/applications/train.py
@@ -72,10 +72,26 @@ def load_model_states_and_optimizer(conf, model, device):
     amp = conf["trainer"]["amp"]
 
     # load weights / states flags
-    load_weights = False if "load_weights" not in conf["trainer"] else conf["trainer"]["load_weights"]
-    load_optimizer_conf = False if "load_optimizer" not in conf["trainer"] else conf["trainer"]["load_optimizer"]
-    load_scaler_conf = False if "load_scaler" not in conf["trainer"] else conf["trainer"]["load_scaler"]
-    load_scheduler_conf = False if "load_scheduler" not in conf["trainer"] else conf["trainer"]["load_scheduler"]
+    load_weights = (
+        False
+        if "load_weights" not in conf["trainer"]
+        else conf["trainer"]["load_weights"]
+    )
+    load_optimizer_conf = (
+        False
+        if "load_optimizer" not in conf["trainer"]
+        else conf["trainer"]["load_optimizer"]
+    )
+    load_scaler_conf = (
+        False
+        if "load_scaler" not in conf["trainer"]
+        else conf["trainer"]["load_scaler"]
+    )
+    load_scheduler_conf = (
+        False
+        if "load_scheduler" not in conf["trainer"]
+        else conf["trainer"]["load_scheduler"]
+    )
 
     #  Load an optimizer, gradient scaler, and learning rate scheduler, the optimizer must come after wrapping model using FSDP
     if not load_weights:  # Loaded after loading model weights when reloading
@@ -88,10 +104,16 @@ def load_model_states_and_optimizer(conf, model, device):
         if conf["trainer"]["mode"] == "fsdp":
             optimizer = FSDPOptimizerWrapper(optimizer, model)
         scheduler = load_scheduler(optimizer, conf)
-        scaler = ShardedGradScaler(enabled=amp) if conf["trainer"]["mode"] == "fsdp" else GradScaler(enabled=amp)
+        scaler = (
+            ShardedGradScaler(enabled=amp)
+            if conf["trainer"]["mode"] == "fsdp"
+            else GradScaler(enabled=amp)
+        )
 
     # Multi-step training case -- when starting, only load the model weights (then after load all states)
-    elif load_weights and not (load_optimizer_conf or load_scaler_conf or load_scheduler_conf):
+    elif load_weights and not (
+        load_optimizer_conf or load_scaler_conf or load_scheduler_conf
+    ):
         optimizer = torch.optim.AdamW(
             filter(lambda p: p.requires_grad, model.parameters()),
             lr=learning_rate,
@@ -100,9 +122,7 @@ def load_model_states_and_optimizer(conf, model, device):
         )
         # FSDP checkpoint settings
         if conf["trainer"]["mode"] == "fsdp":
-            logging.info(
-                f"Loading FSDP model state only from {save_loc}"
-            )
+            logging.info(f"Loading FSDP model state only from {save_loc}")
             optimizer = torch.optim.AdamW(
                 filter(lambda p: p.requires_grad, model.parameters()),
                 lr=learning_rate,
@@ -111,22 +131,24 @@ def load_model_states_and_optimizer(conf, model, device):
             )
             optimizer = FSDPOptimizerWrapper(optimizer, model)
             checkpoint_io = TorchFSDPCheckpointIO()
-            checkpoint_io.load_unsharded_model(model, os.path.join(save_loc, "model_checkpoint.pt"))
+            checkpoint_io.load_unsharded_model(
+                model, os.path.join(save_loc, "model_checkpoint.pt")
+            )
         else:
             # DDP settings
             ckpt = os.path.join(save_loc, "checkpoint.pt")
             checkpoint = torch.load(ckpt, map_location=device)
             if conf["trainer"]["mode"] == "ddp":
-                logging.info(
-                    f"Loading DDP model state only from {save_loc}"
+                logging.info(f"Loading DDP model state only from {save_loc}")
+                load_msg = model.module.load_state_dict(
+                    checkpoint["model_state_dict"], strict=False
                 )
-                load_msg = model.module.load_state_dict(checkpoint["model_state_dict"], strict=False)
                 load_state_dict_error_handler(load_msg)
             else:
-                logging.info(
-                    f"Loading model state only from {save_loc}"
+                logging.info(f"Loading model state only from {save_loc}")
+                load_msg = model.load_state_dict(
+                    checkpoint["model_state_dict"], strict=False
                 )
-                load_msg = model.load_state_dict(checkpoint["model_state_dict"], strict=False)
                 load_state_dict_error_handler(load_msg)
 
         # Load the learning rate scheduler and mixed precision grad scaler
@@ -137,12 +159,12 @@ def load_model_states_and_optimizer(conf, model, device):
             else GradScaler(enabled=amp)
         )
         # Update the config file to the current epoch based on the checkpoint
-        if ("reload_epoch" in conf["trainer"] 
+        if (
+            "reload_epoch" in conf["trainer"]
             and conf["trainer"]["reload_epoch"]
-            and os.path.exists(os.path.join(save_loc, "training_log.csv"))):
-            
+            and os.path.exists(os.path.join(save_loc, "training_log.csv"))
+        ):
             conf["trainer"]["start_epoch"] = checkpoint["epoch"] + 1
-
 
     # load optimizer and grad scaler states
     else:
@@ -162,9 +184,16 @@ def load_model_states_and_optimizer(conf, model, device):
             )
             optimizer = FSDPOptimizerWrapper(optimizer, model)
             checkpoint_io = TorchFSDPCheckpointIO()
-            checkpoint_io.load_unsharded_model(model, os.path.join(save_loc, "model_checkpoint.pt"))
-            if "load_optimizer" in conf["trainer"] and conf["trainer"]["load_optimizer"]:
-                checkpoint_io.load_unsharded_optimizer(optimizer, os.path.join(save_loc, "optimizer_checkpoint.pt"))
+            checkpoint_io.load_unsharded_model(
+                model, os.path.join(save_loc, "model_checkpoint.pt")
+            )
+            if (
+                "load_optimizer" in conf["trainer"]
+                and conf["trainer"]["load_optimizer"]
+            ):
+                checkpoint_io.load_unsharded_optimizer(
+                    optimizer, os.path.join(save_loc, "optimizer_checkpoint.pt")
+                )
 
         else:
             # DDP settings
@@ -172,13 +201,17 @@ def load_model_states_and_optimizer(conf, model, device):
                 logging.info(
                     f"Loading DDP model, optimizer, grad scaler, and learning rate scheduler states from {save_loc}"
                 )
-                load_msg = model.module.load_state_dict(checkpoint["model_state_dict"], strict=False)
+                load_msg = model.module.load_state_dict(
+                    checkpoint["model_state_dict"], strict=False
+                )
                 load_state_dict_error_handler(load_msg)
             else:
                 logging.info(
                     f"Loading model, optimizer, grad scaler, and learning rate scheduler states from {save_loc}"
                 )
-                load_msg = model.load_state_dict(checkpoint["model_state_dict"], strict=False)
+                load_msg = model.load_state_dict(
+                    checkpoint["model_state_dict"], strict=False
+                )
                 load_state_dict_error_handler(load_msg)
 
             optimizer = torch.optim.AdamW(
@@ -187,11 +220,18 @@ def load_model_states_and_optimizer(conf, model, device):
                 weight_decay=weight_decay,
                 betas=(0.9, 0.95),
             )
-            if "load_optimizer" in conf["trainer"] and conf["trainer"]["load_optimizer"]:
+            if (
+                "load_optimizer" in conf["trainer"]
+                and conf["trainer"]["load_optimizer"]
+            ):
                 optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
 
         scheduler = load_scheduler(optimizer, conf)
-        scaler = ShardedGradScaler(enabled=amp) if conf["trainer"]["mode"] == "fsdp" else GradScaler(enabled=amp)
+        scaler = (
+            ShardedGradScaler(enabled=amp)
+            if conf["trainer"]["mode"] == "fsdp"
+            else GradScaler(enabled=amp)
+        )
 
         # Update the config file to the current epoch
         if "reload_epoch" in conf["trainer"] and conf["trainer"]["reload_epoch"]:
@@ -206,7 +246,11 @@ def load_model_states_and_optimizer(conf, model, device):
             scaler.load_state_dict(checkpoint["scaler_state_dict"])
 
     # Enable updating the lr if not using a policy
-    if conf["trainer"]["update_learning_rate"] if "update_learning_rate" in conf["trainer"] else False:
+    if (
+        conf["trainer"]["update_learning_rate"]
+        if "update_learning_rate" in conf["trainer"]
+        else False
+    ):
         for param_group in optimizer.param_groups:
             param_group["lr"] = learning_rate
 
@@ -236,21 +280,26 @@ def main(rank, world_size, conf, backend=None, trial=False):
 
     # infer device id from rank
     device = (
-        torch.device(f"cuda:{rank % torch.cuda.device_count()}") if torch.cuda.is_available() else torch.device("cpu")
+        torch.device(f"cuda:{rank % torch.cuda.device_count()}")
+        if torch.cuda.is_available()
+        else torch.device("cpu")
     )
     torch.cuda.set_device(rank % torch.cuda.device_count())
-
-    # Config settings
-    seed = conf["seed"]
-    seed_everything(seed)
 
     # Load the dataset using the provided dataset_type
     train_dataset = load_dataset(conf, rank=rank, world_size=world_size, is_train=True)
     valid_dataset = load_dataset(conf, rank=rank, world_size=world_size, is_train=False)
 
     # Load the dataloader
-    train_loader = load_dataloader(conf, train_dataset, rank=rank, world_size=world_size, is_train=True)
-    valid_loader = load_dataloader(conf, valid_dataset, rank=rank, world_size=world_size, is_train=False)
+    train_loader = load_dataloader(
+        conf, train_dataset, rank=rank, world_size=world_size, is_train=True
+    )
+    valid_loader = load_dataloader(
+        conf, valid_dataset, rank=rank, world_size=world_size, is_train=False
+    )
+
+    seed = conf["seed"] + rank
+    seed_everything(seed)
 
     # model
     m = load_model(conf)
@@ -269,7 +318,9 @@ def main(rank, world_size, conf, backend=None, trial=False):
         model = m
 
     # Load model weights (if any), an optimizer, scheduler, and gradient scaler
-    conf, model, optimizer, scheduler, scaler = load_model_states_and_optimizer(conf, model, device)
+    conf, model, optimizer, scheduler, scaler = load_model_states_and_optimizer(
+        conf, model, device
+    )
 
     # Train and validation losses
     train_criterion = VariableTotalLoss2D(conf)
@@ -339,10 +390,14 @@ class Objective(BaseObjective):
 
         except Exception as E:
             if "CUDA" in str(E) or "non-singleton" in str(E):
-                logging.warning(f"Pruning trial {trial.number} due to CUDA memory overflow: {str(E)}.")
+                logging.warning(
+                    f"Pruning trial {trial.number} due to CUDA memory overflow: {str(E)}."
+                )
                 raise optuna.TrialPruned()
             elif "non-singleton" in str(E):
-                logging.warning(f"Pruning trial {trial.number} due to shape mismatch: {str(E)}.")
+                logging.warning(
+                    f"Pruning trial {trial.number} due to shape mismatch: {str(E)}."
+                )
                 raise optuna.TrialPruned()
             else:
                 logging.warning(f"Trial {trial.number} failed due to error: {str(E)}.")
@@ -397,7 +452,7 @@ if __name__ == "__main__":
     # Stream output to stdout
     ch = logging.StreamHandler()
     # see if we are in debug mode to set logging level
-    gettrace = getattr(sys, 'gettrace', None)
+    gettrace = getattr(sys, "gettrace", None)
     debug = gettrace()
     if debug:
         ch.setLevel(logging.DEBUG)
@@ -407,14 +462,15 @@ if __name__ == "__main__":
     root.addHandler(ch)
     logging.debug("logging set to DEBUG level")
 
-
     # Load the configuration and get the relevant variables
     with open(config) as cf:
         conf = yaml.load(cf, Loader=yaml.FullLoader)
 
     # ======================================================== #
     # handling config args
-    conf = credit_main_parser(conf, parse_training=True, parse_predict=False, print_summary=False)
+    conf = credit_main_parser(
+        conf, parse_training=True, parse_predict=False, print_summary=False
+    )
     training_data_check(conf, print_summary=False)
     # ======================================================== #
 
@@ -436,9 +492,6 @@ if __name__ == "__main__":
             logging.info("Launching to PBS on Derecho")
             launch_script_mpi(config, script_path)
         sys.exit()
-
-    seed = conf["seed"]
-    seed_everything(seed)
 
     local_rank, world_rank, world_size = get_rank_info(conf["trainer"]["mode"])
     main(world_rank, world_size, conf, backend)

--- a/credit/datasets/load_dataset_and_dataloader.py
+++ b/credit/datasets/load_dataset_and_dataloader.py
@@ -379,7 +379,10 @@ def load_dataloader(conf, dataset, rank=0, world_size=1, is_train=True):
     # pair as the CDF is computed across GPUs. Randomness is handled by adding noise
     # to the input x to create different samples. There are many other ways to do this
     # but using the same rank and world_size is the fastest as far as communication.
-    if conf["loss"]["training_loss"] == "KCRPS":
+    if (
+        conf["loss"]["training_loss"] == "KCRPS"
+        and conf["trainer"]["type"] == "era5-ensemble"
+    ):
         rank = 0
         world_size = 1
         logging.info(

--- a/credit/datasets/load_dataset_and_dataloader.py
+++ b/credit/datasets/load_dataset_and_dataloader.py
@@ -109,13 +109,9 @@ class BatchForecastLenDataLoader:
             int: The total number of samples or iterations.
         """
         if hasattr(self.dataset, "batches_per_epoch"):
-            return (
-                self.dataset.batches_per_epoch() * self.forecast_len
-            )  # Use the dataset's method if available
+            return self.dataset.batches_per_epoch() * self.forecast_len  # Use the dataset's method if available
         else:
-            return (
-                len(self.dataset) * self.forecast_len
-            )  # Otherwise, fall back to the dataset's length
+            return len(self.dataset) * self.forecast_len  # Otherwise, fall back to the dataset's length
 
 
 def collate_fn(batch):
@@ -154,9 +150,7 @@ def load_dataset(conf, rank=0, world_size=1, is_train=True):
     try:
         data_config = setup_data_loading(conf)
     except KeyError:
-        logging.warning(
-            "You must run credit.parser.credit_main_parser(conf) before loading data. Exiting."
-        )
+        logging.warning("You must run credit.parser.credit_main_parser(conf) before loading data. Exiting.")
         sys.exit()
     seed = conf["seed"]
     shuffle = is_train
@@ -166,20 +160,12 @@ def load_dataset(conf, rank=0, world_size=1, is_train=True):
     )
     batch_size = conf["trainer"][f"{training_type}_batch_size"]
     shuffle = is_train
-    num_workers = (
-        conf["trainer"]["thread_workers"]
-        if is_train
-        else conf["trainer"]["valid_thread_workers"]
-    )
+    num_workers = conf["trainer"]["thread_workers"] if is_train else conf["trainer"]["valid_thread_workers"]
     prefetch_factor = conf["trainer"].get(
         "prefetch_factor",
     )
-    history_len = (
-        data_config["history_len"] if is_train else data_config["valid_history_len"]
-    )
-    forecast_len = (
-        data_config["forecast_len"] if is_train else data_config["valid_forecast_len"]
-    )
+    history_len = data_config["history_len"] if is_train else data_config["valid_history_len"]
+    forecast_len = data_config["forecast_len"] if is_train else data_config["valid_forecast_len"]
     if prefetch_factor is None:
         logging.warning(
             "prefetch_factor not found in config under 'trainer'. Using default value of 4. "
@@ -333,9 +319,7 @@ def load_dataset(conf, rank=0, world_size=1, is_train=True):
 
     train_flag = "training" if is_train else "validation"
 
-    logging.info(
-        f"Loaded a {train_flag} {dataset_type} dataset (forecast length = {data_config['forecast_len'] + 1})"
-    )
+    logging.info(f"Loaded a {train_flag} {dataset_type} dataset (forecast length = {data_config['forecast_len'] + 1})")
 
     return dataset
 
@@ -359,14 +343,8 @@ def load_dataloader(conf, dataset, rank=0, world_size=1, is_train=True):
     training_type = "train" if is_train else "valid"
     batch_size = conf["trainer"][f"{training_type}_batch_size"]
     shuffle = is_train
-    num_workers = (
-        conf["trainer"]["thread_workers"]
-        if is_train
-        else conf["trainer"]["valid_thread_workers"]
-    )
-    forecast_len = (
-        conf["data"]["forecast_len"] if is_train else conf["data"]["valid_forecast_len"]
-    )
+    num_workers = conf["trainer"]["thread_workers"] if is_train else conf["trainer"]["valid_thread_workers"]
+    forecast_len = conf["data"]["forecast_len"] if is_train else conf["data"]["valid_forecast_len"]
     prefetch_factor = conf["trainer"].get("prefetch_factor")
     if prefetch_factor is None:
         logging.warning(
@@ -379,10 +357,7 @@ def load_dataloader(conf, dataset, rank=0, world_size=1, is_train=True):
     # pair as the CDF is computed across GPUs. Randomness is handled by adding noise
     # to the input x to create different samples. There are many other ways to do this
     # but using the same rank and world_size is the fastest as far as communication.
-    if (
-        conf["loss"]["training_loss"] == "KCRPS"
-        and conf["trainer"]["type"] == "era5-ensemble"
-    ):
+    if conf["loss"]["training_loss"] == "KCRPS" and conf["trainer"]["type"] == "era5-ensemble":
         rank = 0
         world_size = 1
         logging.info(
@@ -402,9 +377,7 @@ def load_dataloader(conf, dataset, rank=0, world_size=1, is_train=True):
                     collated_batch[key] = torch.stack(items)
                 elif isinstance(items[0], (int, float, bool)):
                     collated_batch[key] = torch.tensor(
-                        [items[0]]
-                        if key in ["forecast_step", "stop_forecast"]
-                        else items
+                        [items[0]] if key in ["forecast_step", "stop_forecast"] else items
                     )
                 else:
                     collated_batch[key] = items
@@ -495,9 +468,7 @@ if __name__ == "__main__":
     with open("../../config/example-v2025.2.0.yml") as cf:
         conf = yaml.load(cf, Loader=yaml.FullLoader)
 
-    conf = credit_main_parser(
-        conf, parse_training=True, parse_predict=False, print_summary=False
-    )
+    conf = credit_main_parser(conf, parse_training=True, parse_predict=False, print_summary=False)
     training_data_check(conf, print_summary=False)
 
     # options

--- a/credit/trainers/trainerERA5_ensemble.py
+++ b/credit/trainers/trainerERA5_ensemble.py
@@ -120,9 +120,7 @@ class Trainer(BaseTrainer):
         logger.info("Loading a multi-step trainer class")
 
     # Training function.
-    def train_one_epoch(
-        self, epoch, conf, trainloader, optimizer, criterion, scaler, scheduler, metrics
-    ):
+    def train_one_epoch(self, epoch, conf, trainloader, optimizer, criterion, scaler, scheduler, metrics):
         """
         Trains the model for one epoch.
 
@@ -174,10 +172,7 @@ class Trainer(BaseTrainer):
         ), f"forecast_length ({forecast_length + 1}) must not exceed the max value in backprop_on_timestep {backprop_on_timestep}"
 
         # update the learning rate if epoch-by-epoch updates that dont depend on a metric
-        if (
-            conf["trainer"]["use_scheduler"]
-            and conf["trainer"]["scheduler"]["scheduler_type"] == "lambda"
-        ):
+        if conf["trainer"]["use_scheduler"] and conf["trainer"]["scheduler"]["scheduler_type"] == "lambda":
             scheduler.step()
 
         # ------------------------------------------------------- #
@@ -227,14 +222,10 @@ class Trainer(BaseTrainer):
                 dataset_batches_per_epoch = len(trainloader)
             # Use the user-given number if not larger than the dataset
             batches_per_epoch = (
-                batches_per_epoch
-                if 0 < batches_per_epoch < dataset_batches_per_epoch
-                else dataset_batches_per_epoch
+                batches_per_epoch if 0 < batches_per_epoch < dataset_batches_per_epoch else dataset_batches_per_epoch
             )
 
-        batch_group_generator = tqdm.tqdm(
-            range(batches_per_epoch), total=batches_per_epoch, leave=True
-        )
+        batch_group_generator = tqdm.tqdm(range(batches_per_epoch), total=batches_per_epoch, leave=True)
 
         self.model.train()
 
@@ -254,9 +245,7 @@ class Trainer(BaseTrainer):
                         # combine x and x_surf
                         # input: (batch_num, time, var, level, lat, lon), (batch_num, time, var, lat, lon)
                         # output: (batch_num, var, time, lat, lon), 'x' first and then 'x_surf'
-                        x = concat_and_reshape(batch["x"], batch["x_surf"]).to(
-                            self.device
-                        )  # .float()
+                        x = concat_and_reshape(batch["x"], batch["x_surf"]).to(self.device)  # .float()
                     else:
                         # no x_surf
                         x = reshape_only(batch["x"]).to(self.device)  # .float()
@@ -272,15 +261,11 @@ class Trainer(BaseTrainer):
                 # add forcing and static variables (regardless of fcst hours)
                 if "x_forcing_static" in batch:
                     # (batch_num, time, var, lat, lon) --> (batch_num, var, time, lat, lon)
-                    x_forcing_batch = (
-                        batch["x_forcing_static"].to(self.device).permute(0, 2, 1, 3, 4)
-                    )  # .float()
+                    x_forcing_batch = batch["x_forcing_static"].to(self.device).permute(0, 2, 1, 3, 4)  # .float()
                     # ---------------- ensemble ----------------- #
                     # ensemble x_forcing_batch for concat. see above for explanation of code
                     if ensemble_size > 1:
-                        x_forcing_batch = torch.repeat_interleave(
-                            x_forcing_batch, ensemble_size, 0
-                        )
+                        x_forcing_batch = torch.repeat_interleave(x_forcing_batch, ensemble_size, 0)
                     # --------------------------------------------- #
 
                     # concat on var dimension
@@ -326,17 +311,13 @@ class Trainer(BaseTrainer):
                 if forecast_step in backprop_on_timestep:  # steps go from 1 to n
                     # calculate rolling loss
                     if "y_surf" in batch:
-                        y = concat_and_reshape(batch["y"], batch["y_surf"]).to(
-                            self.device
-                        )
+                        y = concat_and_reshape(batch["y"], batch["y_surf"]).to(self.device)
                     else:
                         y = reshape_only(batch["y"]).to(self.device)
 
                     if "y_diag" in batch:
                         # (batch_num, time, var, lat, lon) --> (batch_num, var, time, lat, lon)
-                        y_diag_batch = (
-                            batch["y_diag"].to(self.device).permute(0, 2, 1, 3, 4)
-                        )  # .float()
+                        y_diag_batch = batch["y_diag"].to(self.device).permute(0, 2, 1, 3, 4)  # .float()
 
                         # concat on var dimension
                         y = torch.cat((y, y_diag_batch), dim=1)
@@ -359,20 +340,11 @@ class Trainer(BaseTrainer):
                         # y_slice = gather_tensor(y_slice)
 
                         # Compute loss for this slice
-                        loss = (
-                            criterion(
-                                y_slice.to(y_pred_slice.dtype), y_pred_slice
-                            ).mean()
-                            / lat_size
-                        )
+                        loss = criterion(y_slice.to(y_pred_slice.dtype), y_pred_slice).mean() / lat_size
                         total_loss += loss
 
                         # Compute the std
-                        std = (
-                            (y_pred_slice - y_slice.to(y_pred_slice.dtype))
-                            .detach()
-                            .std()
-                        ) / lat_size
+                        std = ((y_pred_slice - y_slice.to(y_pred_slice.dtype)).detach().std()) / lat_size
                         total_std += std
 
                         # Track per-channel loss
@@ -429,13 +401,7 @@ class Trainer(BaseTrainer):
             if grad_max_norm == "dynamic":
                 # Compute local L2 norm
                 local_norm = torch.norm(
-                    torch.stack(
-                        [
-                            p.grad.detach().norm(2)
-                            for p in self.model.parameters()
-                            if p.grad is not None
-                        ]
-                    )
+                    torch.stack([p.grad.detach().norm(2) for p in self.model.parameters() if p.grad is not None])
                 )
 
                 # All-reduce to get global norm across ranks
@@ -444,13 +410,9 @@ class Trainer(BaseTrainer):
                 global_norm = local_norm.sqrt()  # Compute total global norm
 
                 # Clip gradients using the global norm
-                torch.nn.utils.clip_grad_norm_(
-                    self.model.parameters(), max_norm=global_norm
-                )
+                torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=global_norm)
             elif grad_max_norm > 0.0:
-                torch.nn.utils.clip_grad_norm_(
-                    self.model.parameters(), max_norm=grad_max_norm
-                )
+                torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=grad_max_norm)
 
             # Step optimizer
             scaler.step(optimizer)
@@ -500,10 +462,7 @@ class Trainer(BaseTrainer):
                 batch_group_generator.update(1)
                 batch_group_generator.set_description(to_print)
 
-            if (
-                conf["trainer"]["use_scheduler"]
-                and conf["trainer"]["scheduler"]["scheduler_type"] in update_on_batch
-            ):
+            if conf["trainer"]["use_scheduler"] and conf["trainer"]["scheduler"]["scheduler_type"] in update_on_batch:
                 scheduler.step()
 
         #  Shutdown the progbar
@@ -543,15 +502,9 @@ class Trainer(BaseTrainer):
         )
 
         valid_batches_per_epoch = conf["trainer"]["valid_batches_per_epoch"]
-        history_len = (
-            conf["data"]["valid_history_len"]
-            if "valid_history_len" in conf["data"]
-            else conf["history_len"]
-        )
+        history_len = conf["data"]["valid_history_len"] if "valid_history_len" in conf["data"] else conf["history_len"]
         forecast_len = (
-            conf["data"]["valid_forecast_len"]
-            if "valid_forecast_len" in conf["data"]
-            else conf["forecast_len"]
+            conf["data"]["valid_forecast_len"] if "valid_forecast_len" in conf["data"] else conf["forecast_len"]
         )
         ensemble_size = conf["trainer"].get("ensemble_size", 1)
 
@@ -611,9 +564,7 @@ class Trainer(BaseTrainer):
                     opt_energy = GlobalEnergyFixer(post_conf)
         # ====================================================== #
 
-        batch_group_generator = tqdm.tqdm(
-            range(valid_batches_per_epoch), total=valid_batches_per_epoch, leave=True
-        )
+        batch_group_generator = tqdm.tqdm(range(valid_batches_per_epoch), total=valid_batches_per_epoch, leave=True)
 
         stop_forecast = False
         dl = cycle(valid_loader)
@@ -633,9 +584,7 @@ class Trainer(BaseTrainer):
                             # combine x and x_surf
                             # input: (batch_num, time, var, level, lat, lon), (batch_num, time, var, lat, lon)
                             # output: (batch_num, var, time, lat, lon), 'x' first and then 'x_surf'
-                            x = concat_and_reshape(batch["x"], batch["x_surf"]).to(
-                                self.device
-                            )  # .float()
+                            x = concat_and_reshape(batch["x"], batch["x_surf"]).to(self.device)  # .float()
                         else:
                             # no x_surf
                             x = reshape_only(batch["x"]).to(self.device)  # .float()
@@ -650,17 +599,11 @@ class Trainer(BaseTrainer):
                     # add forcing and static variables (regardless of fcst hours)
                     if "x_forcing_static" in batch:
                         # (batch_num, time, var, lat, lon) --> (batch_num, var, time, lat, lon)
-                        x_forcing_batch = (
-                            batch["x_forcing_static"]
-                            .to(self.device)
-                            .permute(0, 2, 1, 3, 4)
-                        )  # .float()
+                        x_forcing_batch = batch["x_forcing_static"].to(self.device).permute(0, 2, 1, 3, 4)  # .float()
                         # ---------------- ensemble ----------------- #
                         # ensemble x_forcing_batch for concat. see above for explanation of code
                         if ensemble_size > 1:
-                            x_forcing_batch = torch.repeat_interleave(
-                                x_forcing_batch, ensemble_size, 0
-                            )
+                            x_forcing_batch = torch.repeat_interleave(x_forcing_batch, ensemble_size, 0)
                         # --------------------------------------------- #
 
                         # concat on var dimension
@@ -702,17 +645,13 @@ class Trainer(BaseTrainer):
 
                     # creating `y` tensor for loss compute
                     if "y_surf" in batch:
-                        y = concat_and_reshape(batch["y"], batch["y_surf"]).to(
-                            self.device
-                        )
+                        y = concat_and_reshape(batch["y"], batch["y_surf"]).to(self.device)
                     else:
                         y = reshape_only(batch["y"]).to(self.device)
 
                     if "y_diag" in batch:
                         # (batch_num, time, var, lat, lon) --> (batch_num, var, time, lat, lon)
-                        y_diag_batch = (
-                            batch["y_diag"].to(self.device).permute(0, 2, 1, 3, 4)
-                        )  # .float()
+                        y_diag_batch = batch["y_diag"].to(self.device).permute(0, 2, 1, 3, 4)  # .float()
 
                         # concat on var dimension
                         y = torch.cat((y, y_diag_batch), dim=1)
@@ -733,20 +672,11 @@ class Trainer(BaseTrainer):
                         y_pred_slice = gather_tensor(y_pred_slice)
 
                         # Compute loss for this slice
-                        loss = (
-                            criterion(
-                                y_slice.to(y_pred_slice.dtype), y_pred_slice
-                            ).mean()
-                            / lat_size
-                        )
+                        loss = criterion(y_slice.to(y_pred_slice.dtype), y_pred_slice).mean() / lat_size
                         total_loss += loss
 
                         # Compute the std
-                        std = (
-                            (y_pred_slice - y_slice.to(y_pred_slice.dtype))
-                            .detach()
-                            .std()
-                        ) / lat_size
+                        std = ((y_pred_slice - y_slice.to(y_pred_slice.dtype)).detach().std()) / lat_size
 
                         # Track per-channel loss, std
                         accum_log(logs, {"loss": loss.item()})
@@ -758,9 +688,7 @@ class Trainer(BaseTrainer):
                     metrics_dict = metrics(y_pred.float(), y.float())
 
                     for name, value in metrics_dict.items():
-                        value = torch.Tensor([value]).cuda(
-                            self.device, non_blocking=True
-                        )
+                        value = torch.Tensor([value]).cuda(self.device, non_blocking=True)
 
                         if distributed:
                             dist.all_reduce(value, dist.ReduceOp.AVG, async_op=False)


### PR DESCRIPTION
Previously the noise in each model was replicated across the GPUs, so each GPU gave the same predictions. Its fixed in train.py and downstream. Also added extra conditional in load_* so that both KCRPS loss and era5-ensemble needs to be called for rank and world size to be set to 0 and 1, resp. to preserve (x,y) pairs across GPUs so we compute CDF correctly.