### PR TITLE
Update docs admonitions and TOC to render properly

### DIFF
--- a/docs/source/Inference.md
+++ b/docs/source/Inference.md
@@ -48,11 +48,12 @@ GFS initial timesteps on model levels are also available on
 The `gfs_init.py` program regrids the data onto the appropriate CREDIT grid and interpolates in
 the vertical from the GFS to selected CREDIT ERA5 hybrid sigma-pressure levels. 
 
-> [!IMPORTANT]                                                                          
-> `gfs_init.py` requires xesmf, which depends on the [ESMF](https://github.com/esmf-org/esmf) suite 
-> and cannot be installed from PyPI. The easist way to install xesmf without messing up your CREDIT
-> environment is to run `conda install -c conda-forge esmf esmpy` then `pip install xesmf` after building
-> your CREDIT environment first. 
+:::{important}                                                                          
+`gfs_init.py` requires xesmf, which depends on the [ESMF](https://github.com/esmf-org/esmf) suite 
+and cannot be installed from PyPI. The easist way to install xesmf without messing up your CREDIT
+environment is to run `conda install -c conda-forge esmf esmpy` then `pip install xesmf` after building
+your CREDIT environment first. 
+:::
 
 Realtime rollouts are handled by `applications/rollout_realtime.py`. Update the paths in the 
 data section of the config file to point to the GFS initial conditions zarr file. `rollout_realtime.py`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,6 +19,7 @@ extensions = ["sphinx.ext.napoleon", "autoapi.extension", "myst_parser"]
 templates_path = ["_templates"]
 exclude_patterns = []
 
+myst_enable_extensions = ["colon_fence"]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -31,11 +31,12 @@ git clone git@github.com:NCAR/miles-credit.git
 cd miles-credit
 ./create_derecho_env.sh
 ```
-> [!IMPORTANT] 
-> The credit conda environment requires multiple gigabytes of space. Use the `gladequota` command
-> to verify that you have sufficient space in your home or work directories before installing.
-> You can specify where to install your conda environments in a `.condarc` file with the section
-> `envs_dirs`. 
+:::{important}
+The credit conda environment requires multiple gigabytes of space. Use the `gladequota` command
+to verify that you have sufficient space in your home or work directories before installing.
+You can specify where to install your conda environments in a `.condarc` file with the section
+`envs_dirs`. 
+:::
 
 ## Installation from Scratch
 See <project:installation.md> for detailed instructions on building CREDIT and its 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -31,6 +31,7 @@ git clone git@github.com:NCAR/miles-credit.git
 cd miles-credit
 ./create_derecho_env.sh
 ```
+
 :::{important}
 The credit conda environment requires multiple gigabytes of space. Use the `gladequota` command
 to verify that you have sufficient space in your home or work directories before installing.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,8 +43,9 @@ If you encounter issues or have suggestions, please open an issue on our GitHub 
    Training a Model <Training.md>
    Running Inference <Inference.md>
    Evaluation and Metrics <Evaluation.md>
-   Deterministic vs ensemble model training  <Ensembles.md> and inference  <EnsemblesInference.md>
-   Working with loss functions <Losses.md>
+   Ensemble Training <Ensembles.md>
+   Ensemble Inference <EnsemblesInference.md>
+   Working with Loss Functions <Losses.md>
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Just a couple of minor things that caught my eye while reading through the docs.  Figured I'd throw in a PR in case it's helpful.

For the admonitions I could have just used the back tick syntax without updating the docs configuration, but the content in colon fences should render properly in standard Markdown editors as well which is nice.  See here: https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#code-fences-using-colons

I also updated the table of contents to include both pages on ensembles.  Linking both pages to a single entry in the toc wasn't working quite right.