### PR TITLE
Add a note about installation requirements specific to macOS users

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -23,6 +23,10 @@ cd miles-credit
 pip install -e .
 ```
 
+:::{important}
+macOS users will need to ensure that the required compilers are present and properly configured before installing mile-credit.  See this [note in the pySTEPS documentation](https://pysteps.readthedocs.io/en/latest/user_guide/install_pysteps.html#osx-users-gcc-compiler) for details.
+:::
+
 ## Installation on Derecho
 If you want to build a conda environment and install a Derecho-compatible version of PyTorch, run
 the `create_derecho_env.sh` script. 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -39,9 +39,9 @@ You can specify where to install your conda environments in a `.condarc` file wi
 `envs_dirs`. 
 :::
 
-## Installation from Scratch
+## Installation from source
 See <project:installation.md> for detailed instructions on building CREDIT and its 
-dependencies from scratch or for building CREDIT on the Derecho supercomputer.
+dependencies from source or for building CREDIT on the Derecho supercomputer.
 
 ## Running a pretrained model
 See <project:Inference.md> for more details on how to run one of the pretrained CREDIT models.

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -24,7 +24,7 @@ pip install -e .
 ```
 
 :::{important}
-macOS users will need to ensure that the required compilers are present and properly configured before installing mile-credit.  See this [note in the pySTEPS documentation](https://pysteps.readthedocs.io/en/latest/user_guide/install_pysteps.html#osx-users-gcc-compiler) for details.
+macOS users will need to ensure that the required compilers are present and properly configured before installing mile-credit for versions requiring pySTEPS (miles-credit > 2025.2.0).  See this [note in the pySTEPS documentation](https://pysteps.readthedocs.io/en/latest/user_guide/install_pysteps.html#osx-users-gcc-compiler) for details.
 :::
 
 ## Installation on Derecho

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -1,4 +1,4 @@
-# Installing CREDIT from Scratch
+# Installing CREDIT from source
 
 If you want to take advantage of the full power of CREDIT,
 which includes scaling training across multiple nodes, you 
@@ -17,7 +17,7 @@ Mac or Linux laptop.
 ### MacOS (Intel or ARM)
 1. First, install either the [Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/) package managers 
 so you can easily install all the system-level dependencies and other helpful Linux programs like wget, gcc, etc.
-Further instructions will assume the use of homebrew, but should also work for MacPorts. Homebrew
+Further instructions will assume the use of Homebrew, but should also work for MacPorts. Homebrew
 should also install the XCode Command Line tools, which include git and clang.
 2. Install the following programs with the `brew install <program>`
 command.


### PR DESCRIPTION
Adds a note to the "Getting Started" page about installation requirements specific to macOS users.

It looks like some of this is covered in the installation from source docs (though not the env vars which may be important there as well), but this is also an issue for pip installs of versions of miles-credit requiring pySTEPS.  Right now, this is only unreleased versions of the code.  I suspect this is why it maybe hasn't come up in the past (or at least in some cases).