### PR TITLE
Add NCAR HPC documentation link

### DIFF
--- a/docs/source/config.md
+++ b/docs/source/config.md
@@ -1416,7 +1416,7 @@ pbs:
 
 ## Additional Resources  
 
-- **NCAR HPC Guide**: *[Insert Link]*  
+[NCAR HPC Guide](https://ncar-hpc-docs.readthedocs.io/en/latest/compute-systems/derecho/)
 
 ---
 


### PR DESCRIPTION
Hi MILES,

I'd like to help with the documentation as I read through it.  This PR adds a missing link to the NCAR HPC documentation in config.md, shown below:

<img width="1079" height="487" alt="Screen Shot 2025-07-14 at 9 57 09 AM" src="https://github.com/user-attachments/assets/eb2b16bc-cbbe-421c-bc98-77f24e0019dd" />
