### PR TITLE
Credit ptype

### DIFF
--- a/config/arXiv_2024/wxformer_1h_single_step.yml
+++ b/config/arXiv_2024/wxformer_1h_single_step.yml
@@ -3,7 +3,7 @@
 # on NSF NCAR HPCs (casper.ucar.edu and derecho.hpc.ucar.edu) 
 # The model is trained on hourly model-level ERA5 data with top solar irradiance, geopotential, and land-sea mask
 # Output variables: model level [U, V, T, Q], single level [SP, t2m], and 500 hPa [U, V, T, Z, Q]
-# --------------------------------------------------------------------------------------------------------------------- #
+# ----------------------------------------------------------------------------------------------------------------------- #
 save_loc: '/glade/work/sakor/credit_arxiv_models/wxformer_1h/finetune_final/'
 seed: 1000
 


### PR DESCRIPTION
- Use 'spawn' start method to avoid CUDA re-initialization in forked subprocesses
- Ensure predictions are moved to CPU before calling .numpy()