### PR TITLE
Update gfs_init.py paths for L137_model_level_indices.csv and ERA5_Lev_Info.nc

### DIFF
--- a/applications/gfs_init.py
+++ b/applications/gfs_init.py
@@ -23,7 +23,7 @@ def main():
         os.path.join(base_path, "../credit/metadata/ERA5_Lev_Info.nc")
     )
     model_levels = pd.read_csv(
-        join(base_path, "../credit/metadata/L137_model_level_indices.csv")
+        os.path.join(metadata_path, "L137_model_level_indices.csv")
     )
     model_level_indices = model_levels["model_level_indices"].values
     variables = config["data"]["variables"] + config["data"]["surface_variables"]

--- a/applications/gfs_init.py
+++ b/applications/gfs_init.py
@@ -24,7 +24,7 @@ def main():
     else:
         metadata_path = os.path.join(base_path, os.pardir, "credit", "metadata")
     credit_grid = xr.open_dataset(
-        os.path.join(base_path, "../credit/metadata/ERA5_Lev_Info.nc")
+        os.path.join(metadata_path, "ERA5_Lev_Info.nc")
     )
     model_levels = pd.read_csv(
         os.path.join(metadata_path, "L137_model_level_indices.csv")

--- a/applications/gfs_init.py
+++ b/applications/gfs_init.py
@@ -19,6 +19,10 @@ def main():
     n_procs = args.proc
     os.makedirs(config["predict"]["initial_condition_path"], exist_ok=True)
     base_path = os.path.abspath(os.path.dirname(__file__))
+    if os.path.basename(os.path.abspath(os.path.join(base_path, os.pardir))) == "credit":
+        metadata_path = os.path.join(base_path, os.pardir, "metadata")
+    else:
+        metadata_path = os.path.join(base_path, os.pardir, "credit", "metadata")
     credit_grid = xr.open_dataset(
         os.path.join(base_path, "../credit/metadata/ERA5_Lev_Info.nc")
     )

--- a/applications/gfs_init.py
+++ b/applications/gfs_init.py
@@ -20,10 +20,10 @@ def main():
     os.makedirs(config["predict"]["initial_condition_path"], exist_ok=True)
     base_path = os.path.abspath(os.path.dirname(__file__))
     credit_grid = xr.open_dataset(
-        os.path.join(base_path, "../metadata/ERA5_Lev_Info.nc")
+        os.path.join(base_path, "../credit/metadata/ERA5_Lev_Info.nc")
     )
     model_levels = pd.read_csv(
-        join(base_path, "../metadata/L137_model_level_indices.csv")
+        join(base_path, "../credit/metadata/L137_model_level_indices.csv")
     )
     model_level_indices = model_levels["model_level_indices"].values
     variables = config["data"]["variables"] + config["data"]["surface_variables"]


### PR DESCRIPTION
For me, gfs_init.py is unable to find L137_model_level_indices.csv and ERA5_Lev_Info.nc.  I believe the filepaths need to be prefixed with the `credit` directory.

Potentially fixes #214