### PR TITLE
Compatibility with Zarr v3

### DIFF
--- a/credit/data.py
+++ b/credit/data.py
@@ -151,7 +151,7 @@ def get_forward_data(filename) -> xr.Dataset:
     if filename[-3:] == ".nc" or filename[-4:] == ".nc4":
         dataset = xr.open_dataset(filename)
     else:
-        dataset = xr.open_zarr(filename, consolidated=True)
+        dataset = xr.open_zarr(filename)
     return dataset
 
 

--- a/credit/data404.py
+++ b/credit/data404.py
@@ -13,7 +13,7 @@ import torch.utils.data
 
 def get_forward_data(filename) -> xr.DataArray:
     """Lazily opens a Zarr store"""
-    dataset = xr.open_zarr(filename, consolidated=True)
+    dataset = xr.open_zarr(filename)
     return dataset
 
 

--- a/credit/datasets/era5_multistep_batcher.py
+++ b/credit/datasets/era5_multistep_batcher.py
@@ -1059,7 +1059,7 @@ class Predict_Dataset_Batcher(torch.utils.data.Dataset):
         if filename.endswith((".nc", ".nc4")):
             dataset = xr.open_dataset(filename, decode_times=False, engine="h5netcdf")
         else:
-            dataset = xr.open_zarr(filename, consolidated=True)
+            dataset = xr.open_zarr(filename)
 
         dataset = dataset.drop_vars(list(dataset.data_vars))
         dataset = dataset.isel(time=slice(time_start, time_end))

--- a/notebooks/gather_global_data/Make_Climo_Data.py
+++ b/notebooks/gather_global_data/Make_Climo_Data.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 
     def get_forward_data(filename: str = ZARR) -> xr.DataArray:
         """Lazily opens the Zarr store on gladefilesystem."""
-        dataset = xr.open_zarr(filename, consolidated=True)
+        dataset = xr.open_zarr(filename)
         return dataset
 
     forcing_data = get_forward_data().unify_chunks()

--- a/notebooks/multistep_datasets.ipynb
+++ b/notebooks/multistep_datasets.ipynb
@@ -676,7 +676,7 @@
     "                    \"TOA\": [],\n",
     "                }\n",
     "                sliced = xr.open_zarr(\n",
-    "                    self.filenames[int(result_key)], consolidated=True\n",
+    "                    self.filenames[int(result_key)]\n",
     "                ).isel(\n",
     "                    time=slice(\n",
     "                        ind,\n",


### PR DESCRIPTION
Removes the `consolidated=True` parameter from `open_zarr` for compatibility with Zarr v3 (this setting does not work with Zarr v3 files).

Since version 0.19 of Xarray ([released in 2021](https://docs.xarray.dev/en/v0.19.0/whats-new.html?highlight=release%20notes#new-features)) the default will try to read consolidated metadata first falling back to reading unconsolidated metadata if that fails.  This should be more robust overall and compatible with Zarr v3. 

Closes #216 