### PR TITLE
Update workflow triggers for testing

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,6 +1,11 @@
 name: Python Package using Mamba
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build-linux:


### PR DESCRIPTION
Configures the GitHub Actions workflow for testing to run on pull requests, pushes to the main branch, and when manually triggered (i.e. workflow dispatch).

Adding the pull request and workflow dispatch triggers shouldn't be too controversial, but I'm a little less clear on how you all would like this configured for pushes to the repo...  Currently, this workflow is configured to run on all pushes to the repository regardless of branch.  That seems a little heavy to me, but I'm not super familiar with your current dev workflows.  Happy to revert or iterate on that and/or chat more on Slack too if that's preferred.

Closes #218 