### PR TITLE
Updates to gefs_init and mean sea level pressure calculations

### DIFF
--- a/applications/gefs_init.py
+++ b/applications/gefs_init.py
@@ -49,7 +49,7 @@ def main():
         "-v",
         "--variables",
         type=str,
-        default="ps,t,sphum,liq_wat,ice_wat,rainwat,snowwat,graupel,u_s,v_w,slmsk,tsea,fice,t2m,q2m",
+        default="ps,t,sphum,liq_wat,ice_wat,rainwat,snowwat,graupel,u_s,v_w,slmsk,tsea,fice,t2m,q2m,zh",
         help="Variables to use separated by commas.",
     )
     parser.add_argument(

--- a/credit/interp.py
+++ b/credit/interp.py
@@ -789,9 +789,52 @@ def mean_sea_level_pressure(
                 gamma = LAPSE_RATE
                 if temp_surface_k < 255:
                     temp_surface_k = 0.5 * (255 + temp_surface_k)
-            beta = surface_geopotential[i, j] / (RDGAS * temp_surface_k)
-            x = gamma * surface_geopotential[i, j] / (GRAVITY * temp_surface_k)
+            x = surface_geopotential[i, j] / (RDGAS * temp_surface_k)
             mslp[i, j] = surface_pressure_pa[i, j] * np.exp(
-                beta * (1.0 - x / 2.0 + x**2 / 3.0)
+                x * (1.0 - 0.5 * gamma * x + (gamma * x) ** 2 / 3.0)
+            )
+    return mslp
+
+
+def mean_sea_level_pressure_simple(
+    surface_pressure_pa, temperature_k, surface_geopotential
+):
+    """
+    Simpler calculation for mean sea level pressure that only requires 2D fields of pressure (Pa), temperature (K),
+    and surface geopotential (m ** 2 s ** -2).
+    Based on Trenberth et al. 1993 calculation but simplified by removing the T* calculation since it seemed to
+    only vary by about 0.2 K and requires a lot more data to compute.
+    Trenberth, K., J. Berry , and L. Buja, 1993: Vertical Interpolation and Truncation of Model-Coordinate,
+    University Corporation for Atmospheric Research, https://doi.org/10.5065/D6HX19NH.
+
+    Args:
+        surface_pressure_pa: surface pressure in Pascals
+        temperature_k: temperature in Kelvin
+        surface_geopotential: surface geopotential in m^2 s^-2. If you have surface height, multiply by g (9.81 m2s-2)
+
+    Returns:
+        mean sea level pressure in Pascals.
+    """
+    LAPSE_RATE = 0.0065  # K / m
+    ALPHA = LAPSE_RATE * RDGAS / GRAVITY
+    mslp = np.zeros(surface_pressure_pa.shape, dtype=surface_pressure_pa.dtype)
+    for (i, j), p in np.ndenumerate(mslp):
+        sgp = surface_geopotential[i, j]
+        if np.abs(sgp / GRAVITY) < 1e-4:
+            mslp[i, j] = surface_pressure_pa[i, j]
+        else:
+            temp = temperature_k[i, j]
+            tto = temp + LAPSE_RATE * sgp
+            alpha_local = ALPHA
+            if (temp <= 290.5) and (tto > 290.5):
+                alpha_local = RDGAS * (290.5 - temp) / sgp
+            elif temp > 290.5:
+                alpha_local = 0
+                temp = 0.5 * (290.5 + temp)
+            elif temp < 255:
+                temp = 0.5 * (255 + temp)
+            x = sgp / (RDGAS * temp)
+            mslp[i, j] = surface_pressure_pa[i, j] * np.exp(
+                x * (1 - 0.5 * alpha_local * x + 1 / 3.0 * (alpha_local * x) ** 2)
             )
     return mslp

--- a/credit/interp.py
+++ b/credit/interp.py
@@ -788,7 +788,7 @@ def mean_sea_level_pressure(
             else:
                 gamma = LAPSE_RATE
                 if temp_surface_k < 255:
-                    temp_surface_k = 0.5 * (255.0 + temp_surface_k)
+                    temp_surface_k = 0.5 * (255 + temp_surface_k)
             beta = surface_geopotential[i, j] / (RDGAS * temp_surface_k)
             x = gamma * surface_geopotential[i, j] / (GRAVITY * temp_surface_k)
             mslp[i, j] = surface_pressure_pa[i, j] * np.exp(


### PR DESCRIPTION
I have updated gefs_init and interp.py to address some issues that have been coming up in the AI Weather Quest. 
* gefs_init now checks if gefs files have been already downloaded before downloading them from google cloud. I still need to add a file size or checksum comparison to catch partially downloaded files, but this should prevent users from having to manually delete the directory of a gefs run when they want to run the script again. GEFS init also now regrids the GEFS height field by default, so you can access the surface height (not geopotential height, need to multiply by 9.81). 
* When regridding surface pressure, I have the model take the log of surface pressure, regrid, and then exp the regridded values. This should reduce artifacts from exponential variation of surface pressure across fine grid cells and make it a linear combination of values.
* I updated the original mean sea level pressure calculation. I think my formula was not written correctly, resulting in some way off values. 
* I also created a mean_sea_level_pressure_simple function that only uses surface pressure, lowest model level temperature, and surface geopotential. It's within 400 Pa of the corrected mslp function and is a lot simpler to run. I would recommend trying both ones out on some of our different datasets. It looked good for the raw GEFS data at least.
* `temp_height` the height of the temperature level being used for the MSLP reduction, is now adjustable from the config file with the argument `mslp_temp_height` under where you put your other pressure interpolation arguments. 