### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -18,7 +18,7 @@ pip install miles-credit
 
 If you want to install the main development branch
 ```bash
-git clone git@github.com:NCAR/miles-credit.git
+git clone https://github.com/NCAR/miles-credit.git
 cd miles-credit
 pip install -e .
 ```
@@ -31,7 +31,7 @@ macOS users will need to ensure that the required compilers are present and prop
 If you want to build a conda environment and install a Derecho-compatible version of PyTorch, run
 the `create_derecho_env.sh` script.
 ```bash
-git clone git@github.com:NCAR/miles-credit.git
+git clone https://github.com/NCAR/miles-credit.git
 cd miles-credit
 ./create_derecho_env.sh
 ```


### PR DESCRIPTION
In the Getting Started documentation:

`git clone git@github.com:NCAR/miles-credit.git` 

lead to issues with invalid ssh keys for me.

```
(panel) bash-3.2$ git clone git@github.com:NCAR/miles-credit.git
Cloning into 'miles-credit'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

Changing the url https://github.com/NCAR/miles-credit.git worked without issue.

```
(panel) bash-3.2$ git clone https://github.com/NCAR/miles-credit.git
Cloning into 'miles-credit'...
remote: Enumerating objects: 11517, done.
remote: Counting objects: 100% (1444/1444), done.
remote: Compressing objects: 100% (245/245), done.
remote: Total 11517 (delta 1298), reused 1226 (delta 1199), pack-reused 10073 (from 1)
Receiving objects: 100% (11517/11517), 305.05 MiB | 14.37 MiB/s, done.
Resolving deltas: 100% (8579/8579), done.
```