### PR TITLE
Preblocks

### DIFF
--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -1,0 +1,38 @@
+import torch.nn as nn
+from credit.preblock.log import LogTransform
+from credit.preblock.sqrt import SqrtTransform
+from credit.preblock.scaler import BridgeScaleTransformer
+from credit.preblock.regrid import Regridder
+
+PREBLOCK_REGISTRY = {
+    "log_transform": LogTransform,
+    "sqrt_transform": SqrtTransform,
+    "bridgescaler_transform": BridgeScaleTransformer,
+    "regrid": Regridder,
+}
+
+
+def build_preblocks(preblock_cfg: dict) -> nn.ModuleDict:
+    """
+    Instantiates all preblocks from the config's 'preblocks' section.
+
+    Args:
+        preblock_cfg: the full preblocks dict from the config, e.g.:
+            {
+                'era5_log_transform': {'type': 'log_transform', 'args': {...}},
+                'era5_z_transform':   {'type': 'z_transform',   'args': {...}},
+            }
+
+    Returns:
+        nn.ModuleDict of instantiated preblocks, ordered as in config.
+    """
+    return nn.ModuleDict(
+        {name: PREBLOCK_REGISTRY[block_cfg["type"]](**block_cfg["args"]) for name, block_cfg in preblock_cfg.items()}
+    )
+
+
+def apply_preblocks(preblocks: nn.ModuleDict, batch: dict) -> dict:
+    """Sequentially applies all preblocks to a batch dict."""
+    for preblock in preblocks.values():
+        batch = preblock(batch)
+    return batch

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -3,12 +3,14 @@ from credit.preblock.log import LogTransform
 from credit.preblock.sqrt import SqrtTransform
 from credit.preblock.scaler import BridgeScaleTransformer
 from credit.preblock.regrid import Regridder
+from credit.preblock.concat import ConcatenateToTensor
 
 PREBLOCK_REGISTRY = {
     "log_transform": LogTransform,
     "sqrt_transform": SqrtTransform,
     "bridgescaler_transform": BridgeScaleTransformer,
     "regrid": Regridder,
+    "concat": ConcatenateToTensor,
 }
 
 
@@ -27,12 +29,18 @@ def build_preblocks(preblock_cfg: dict) -> nn.ModuleDict:
         nn.ModuleDict of instantiated preblocks, ordered as in config.
     """
     return nn.ModuleDict(
-        {name: PREBLOCK_REGISTRY[block_cfg["type"]](**block_cfg["args"]) for name, block_cfg in preblock_cfg.items()}
+        {
+            name: PREBLOCK_REGISTRY[block_cfg["type"]](**(block_cfg.get("args") or {}))
+            for name, block_cfg in preblock_cfg.items()
+        }
     )
 
 
-def apply_preblocks(preblocks: nn.ModuleDict, batch: dict) -> dict:
-    """Sequentially applies all preblocks to a batch dict."""
+def apply_preblocks(preblocks: nn.ModuleDict, batch: dict):
+    """Sequentially applies transform preblocks (dict→dict), then concatenates to tensors.
+
+    Concatenation is always performed last and is not configurable.
+    """
     for preblock in preblocks.values():
         batch = preblock(batch)
-    return batch
+    return PREBLOCK_REGISTRY["concat"]()(batch)

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -1,16 +1,16 @@
 import torch.nn as nn
 from credit.preblock.log import LogTransform
 from credit.preblock.sqrt import SqrtTransform
-from credit.preblock.scaler import BridgeScaleTransformer
+from credit.preblock.scaler import BridgeScalerTransformer
 from credit.preblock.regrid import Regridder
-from credit.preblock.concat import ConcatenateToTensor
+from credit.preblock.concat import ConcatToTensor
 
 PREBLOCK_REGISTRY = {
     "log_transform": LogTransform,
     "sqrt_transform": SqrtTransform,
-    "bridgescaler_transform": BridgeScaleTransformer,
+    "bridgescaler_transform": BridgeScalerTransformer,
     "regrid": Regridder,
-    "concat": ConcatenateToTensor,
+    "concat": ConcatToTensor,
 }
 
 

--- a/credit/preblock/base.py
+++ b/credit/preblock/base.py
@@ -1,0 +1,17 @@
+import torch.nn as nn
+
+
+class BasePreblock(nn.Module):
+    """
+    Base class for all preblocks. Enforces the forward signature and
+    provides the from_config classmethod used by the registry.
+    """
+
+    VALID_DATA_TYPES = ("input", "target")
+
+    def forward(self, batch: dict) -> dict:
+        pass
+
+    @classmethod
+    def from_config(cls, **kwargs):
+        return cls(**kwargs)

--- a/credit/preblock/concat.py
+++ b/credit/preblock/concat.py
@@ -2,7 +2,7 @@ import torch
 from credit.preblock.base import BasePreblock
 
 
-class ConcatenateToTensor(BasePreblock):
+class ConcatToTensor(BasePreblock):
     """End-of-chain preblock that concatenates a nested batch dict of tensors
     into a single input tensor (and optionally a target tensor).
 

--- a/credit/preblock/concat.py
+++ b/credit/preblock/concat.py
@@ -1,0 +1,56 @@
+import torch
+from credit.preblock.base import BasePreblock
+
+
+class ConcatenateToTensor(BasePreblock):
+    """End-of-chain preblock that concatenates a nested batch dict of tensors
+    into a single input tensor (and optionally a target tensor).
+
+    Expects a batch dict of the form::
+
+        batch[source][data_type][var_name] -> torch.Tensor
+
+    where tensor shapes are (batch, channel, time, lon, lat) and concatenation
+    is performed along dim=1 (channel). Traversal order follows key insertion
+    order: for each source, all var_names under a data_type are concatenated,
+    then the next source, and so on.
+
+    ``metadata`` keys are passed through as-is (not concatenated).
+
+    Returns either::
+
+        (input_tensor, metadata)                    # if no "target" data_type present
+        (input_tensor, target_tensor, metadata)     # if "target" is present
+
+    Example config::
+
+        type: "concatenate_to_tensor"
+        args: {}
+    """
+
+    def forward(self, batch):
+        input_tensors = []
+        target_tensors = []
+        metadata = {}
+
+        for source, data_types in batch.items():
+            for data_type, variables in data_types.items():
+                if data_type == "metadata":
+                    metadata[source] = variables
+                elif data_type == "input":
+                    for tensor in variables.values():
+                        input_tensors.append(tensor)
+                elif data_type == "target":
+                    for tensor in variables.values():
+                        target_tensors.append(tensor)
+
+        if not input_tensors:
+            raise ValueError("No 'input' tensors found in batch.")
+
+        input_tensor = torch.cat(input_tensors, dim=1)
+
+        if target_tensors:
+            target_tensor = torch.cat(target_tensors, dim=1)
+            return input_tensor, target_tensor, metadata
+
+        return input_tensor, metadata

--- a/credit/preblock/log.py
+++ b/credit/preblock/log.py
@@ -36,11 +36,7 @@ class LogTransform(BasePreblock):
         # Validate data_types at init
         invalid = set(self.data_types) - set(self.VALID_DATA_TYPES)
         if invalid:
-            raise ValueError(
-                f"Invalid data_types {invalid}. "
-                f"Valid options are {self.VALID_DATA_TYPES}. "
-                f"Preblocks never operate on 'metadata'."
-            )
+            raise ValueError(f"Invalid data_types {invalid}. Valid options are {self.VALID_DATA_TYPES}. ")
 
         if base == "e":
             self._log_fn = torch.log
@@ -71,6 +67,6 @@ class LogTransform(BasePreblock):
 
                 x = batch[source][data_type][var_key]
                 # Out-of-place: safe for autograd
-                batch[source][data_type][var_key] = self._log_fn(x + self.eps)
+                batch[source][data_type][var_key] = self._log_fn(x + self.eps) - self._log_fn(self.eps)
 
         return batch

--- a/credit/preblock/log.py
+++ b/credit/preblock/log.py
@@ -1,0 +1,76 @@
+from credit.preblock.base import BasePreblock
+import torch
+
+
+class LogTransform(BasePreblock):
+    """
+    Applies a log transformation to specified variables in a batch dict.
+
+    Expected dict structure:
+        batch[source][data_type]['source/var_type/var_shape/var_name']
+
+    Config example:
+        type: "log_transform"
+        args:
+            variables:
+                - 'ERA5/prognostic/3D/Q'
+            data_types:     # optional, defaults to ['input', 'target']
+                - 'input'
+                - 'target'
+            base: 'e'       # optional, default 'e'. Options: 'e', '2', '10'
+            eps: 1.0e-8     # optional, default 1e-8
+    """
+
+    def __init__(
+        self,
+        variables: list[str],
+        data_types: list[str] = None,
+        base: str = "e",
+        eps: float = 1e-8,
+    ):
+        super().__init__()
+        self.variables = variables
+        self.data_types = data_types or ["input", "target"]
+        self.eps = eps
+
+        # Validate data_types at init
+        invalid = set(self.data_types) - set(self.VALID_DATA_TYPES)
+        if invalid:
+            raise ValueError(
+                f"Invalid data_types {invalid}. "
+                f"Valid options are {self.VALID_DATA_TYPES}. "
+                f"Preblocks never operate on 'metadata'."
+            )
+
+        if base == "e":
+            self._log_fn = torch.log
+        elif base == "2":
+            self._log_fn = torch.log2
+        elif base == "10":
+            self._log_fn = torch.log10
+        else:
+            raise ValueError(f"Unsupported log base '{base}'. Choose from: 'e', '2', '10'.")
+
+    def forward(self, batch: dict) -> dict:
+        for var_key in self.variables:
+            source = var_key.split("/")[0]
+
+            if source not in batch:
+                raise KeyError(f"LogTransform: source '{source}' not found in batch.")
+
+            for data_type in self.data_types:
+                # Silent skip: data_type absent (e.g. 'target' during inference)
+                if data_type not in batch[source]:
+                    continue
+
+                # Silent skip: variable not present in this data_type
+                if var_key not in batch[source][data_type]:
+                    print(batch[source][data_type].keys())
+                    print(f"LogTransform: data_type '{data_type}' not found in batch.")
+                    continue
+
+                x = batch[source][data_type][var_key]
+                # Out-of-place: safe for autograd
+                batch[source][data_type][var_key] = self._log_fn(x + self.eps)
+
+        return batch

--- a/credit/preblock/log.py
+++ b/credit/preblock/log.py
@@ -31,7 +31,7 @@ class LogTransform(BasePreblock):
         super().__init__()
         self.variables = variables
         self.data_types = data_types or ["input", "target"]
-        self.eps = eps
+        self.eps = torch.tensor(eps)
 
         # Validate data_types at init
         invalid = set(self.data_types) - set(self.VALID_DATA_TYPES)

--- a/credit/preblock/regrid.py
+++ b/credit/preblock/regrid.py
@@ -1,20 +1,23 @@
 import torch
-import torch.nn as nn
 import numpy as np
 import xarray as xr
+from credit.preblock.base import BasePreblock
 
 
-class Regridder(nn.Module):
+class Regridder(BasePreblock):
     """
-    Regridding layer using weights file provide by the ESMF library.
+    Regridding layer using weights file provided by the ESMF library.
     Args:
         weight_file: path to weights file
+        variables: list of variable keys to regrid (e.g. ['era5/prognostic/3d/T'])
+        data_types: list of data types to process (default: ['input', 'target'])
         reshape_to_xy: whether to reshape the flattened array back to xy coordinates
-        flip_axis (list, tuple, or None): whether to flip any axis of the input data. If flipping is desired set a list
-                                          of axis to flip (e.g. [-1, -2])
+        flip_axis (list, tuple, or None): axes to flip before regridding (e.g. [-1, -2])
     """
 
-    def __init__(self, weight_file, reshape_to_xy=True, flip_axis=None):
+    def __init__(
+        self, weight_file, variables: list[str], data_types: list[str] = None, reshape_to_xy=True, flip_axis=None
+    ):
 
         super().__init__()
         with xr.open_dataset(weight_file) as grid_weights:
@@ -36,8 +39,14 @@ class Regridder(nn.Module):
                 # Irregular unstructured: output stays flat, no 2D shape needed
                 dst_shape = None
 
+        self.variables = variables
+        self.data_types = data_types or ["input", "target"]
         self.reshape_to_xy = reshape_to_xy
         self.flip_axis = flip_axis
+
+        invalid = set(self.data_types) - set(self.VALID_DATA_TYPES)
+        if invalid:
+            raise ValueError(f"Invalid data_types {invalid}. Valid options are {self.VALID_DATA_TYPES}.")
         # store as buffers (CPU tensors)
         self.register_buffer("row", torch.from_numpy(rows.astype(np.int64)), persistent=True)
         self.register_buffer("col", torch.from_numpy(cols.astype(np.int64)), persistent=True)
@@ -63,8 +72,7 @@ class Regridder(nn.Module):
         self._W_device = device
         return W
 
-    def forward(self, x):
-
+    def _regrid(self, x: torch.Tensor) -> torch.Tensor:
         device = x.device
         W = self._get_W(device)
         if self.flip_axis is not None:
@@ -78,3 +86,19 @@ class Regridder(nn.Module):
             return y_flat.reshape(*lead_shape, ny, nx)
         else:
             return y_flat
+
+    def forward(self, batch: dict) -> dict:
+        for var_key in self.variables:
+            source = var_key.split("/")[0]
+
+            if source not in batch:
+                raise KeyError(f"Regridder: source '{source}' not found in batch.")
+
+            for data_type in self.data_types:
+                if data_type not in batch[source]:
+                    continue
+                if var_key not in batch[source][data_type]:
+                    continue
+                batch[source][data_type][var_key] = self._regrid(batch[source][data_type][var_key])
+
+        return batch

--- a/credit/preblock/regrid.py
+++ b/credit/preblock/regrid.py
@@ -4,7 +4,7 @@ import numpy as np
 import xarray as xr
 
 
-class Regrid(nn.Module):
+class Regridder(nn.Module):
     """
     Regridding layer using weights file provide by the ESMF library.
     Args:

--- a/credit/preblock/scaler.py
+++ b/credit/preblock/scaler.py
@@ -1,19 +1,73 @@
-import torch.nn as nn
-from bridgescaler import load_scaler
+from bridgescaler import load_scaler_dict
+from credit.preblock.base import BasePreblock
 
 
-class BridgeScaleTransformer(nn.Module):
+class BridgeScaleTransformer(BasePreblock):
+    """Scaling preblock using a fitted bridgescaler dict.
+
+    Applies per-variable z-score scaling (or its inverse) to tensors in a
+    nested batch dict of the form ``batch[source][data_type][var_key]``.
+
+    The scaler dict must have been fit with ``bridgescaler.scale_var_dict``
+    using the same nested structure and saved with ``bridgescaler.save_scaler_dict``.
+
+    Example config::
+
+        type: "bridgescaler_transform"
+        args:
+            scaler_path: "/path/to/scaler.json"
+            variables:
+                - "era5/prognostic/3d/T"
+                - "era5/prognostic/3d/U"
+            method: "transform"
+            data_types:       # optional, defaults to ['input', 'target']
+                - "input"
+                - "target"
     """
-    Scaling layer using a bridgescaler object. Supports transform and its inverse.
-    """
 
-    def __init__(self, scaler_path, inverse=False):
+    def __init__(self, scaler_path: str, variables: list[str], method: str, data_types: list[str] = None):
+
         super().__init__()
-        self.scaler = load_scaler(scaler_path)
-        self.inverse = inverse
+        self.variables = variables
+        self.data_types = data_types or ["input", "target"]
+        self.method = method
+        self.scaler_path = scaler_path
+        self.scaler = load_scaler_dict(scaler_path)
 
-    def forward(self, x):
-        if self.inverse:
-            return self.scaler.inverse_transform(x)
-        else:
-            return self.scaler.transform(x)
+        # Validate data_types at init
+        invalid = set(self.data_types) - set(self.VALID_DATA_TYPES)
+        if invalid:
+            raise ValueError(f"Invalid data_types {invalid}. Valid options are {self.VALID_DATA_TYPES}. ")
+
+    def forward(self, batch: dict) -> dict:
+        for var_key in self.variables:
+            source = var_key.split("/")[0]
+
+            if source not in batch:
+                raise KeyError(f"Source '{source}' not found in batch.")
+
+            for data_type in self.data_types:
+                # Silent skip: data_type absent (e.g. 'target' during inference)
+                if data_type not in batch[source]:
+                    continue
+
+                # Silent skip: variable not present in this data_type
+                if var_key not in batch[source][data_type]:
+                    continue
+
+                if var_key not in self.scaler[source][data_type]:
+                    raise KeyError(
+                        f"BridgeScaleTransformer: no fitted scaler for '{var_key}' "
+                        f"in {source}/{data_type}. Check that the scaler was fit on this variable."
+                    )
+
+                x = batch[source][data_type][var_key]
+                s = self.scaler[source][data_type][var_key]
+                if self.method == "inverse":
+                    batch[source][data_type][var_key] = s.inverse_transform(x)
+                elif self.method == "transform":
+                    batch[source][data_type][var_key] = s.transform(x)
+                else:
+                    raise ValueError(f"Unsupported method: {self.method}. Choose 'transform' or 'inverse'.")
+
+        return batch

--- a/credit/preblock/scaler.py
+++ b/credit/preblock/scaler.py
@@ -2,7 +2,7 @@ from bridgescaler import load_scaler_dict, scale_var_dict
 from credit.preblock.base import BasePreblock
 
 
-class BridgeScaleTransformer(BasePreblock):
+class BridgeScalerTransformer(BasePreblock):
     """Scaling preblock using a fitted bridgescaler dict.
 
     Applies per-variable z-score scaling (or its inverse) to tensors in a

--- a/credit/preblock/scaler.py
+++ b/credit/preblock/scaler.py
@@ -1,4 +1,4 @@
-from bridgescaler import load_scaler_dict
+from bridgescaler import load_scaler_dict, scale_var_dict
 from credit.preblock.base import BasePreblock
 
 
@@ -20,54 +20,16 @@ class BridgeScaleTransformer(BasePreblock):
                 - "era5/prognostic/3d/T"
                 - "era5/prognostic/3d/U"
             method: "transform"
-            data_types:       # optional, defaults to ['input', 'target']
-                - "input"
-                - "target"
     """
 
-    def __init__(self, scaler_path: str, variables: list[str], method: str, data_types: list[str] = None):
+    def __init__(self, scaler_path: str, variables: list[str], method: str):
 
         super().__init__()
         self.variables = variables
-        self.data_types = data_types or ["input", "target"]
         self.method = method
         self.scaler_path = scaler_path
         self.scaler = load_scaler_dict(scaler_path)
 
-        # Validate data_types at init
-        invalid = set(self.data_types) - set(self.VALID_DATA_TYPES)
-        if invalid:
-            raise ValueError(f"Invalid data_types {invalid}. Valid options are {self.VALID_DATA_TYPES}. ")
-
     def forward(self, batch: dict) -> dict:
-        for var_key in self.variables:
-            source = var_key.split("/")[0]
 
-            if source not in batch:
-                raise KeyError(f"Source '{source}' not found in batch.")
-
-            for data_type in self.data_types:
-                # Silent skip: data_type absent (e.g. 'target' during inference)
-                if data_type not in batch[source]:
-                    continue
-
-                # Silent skip: variable not present in this data_type
-                if var_key not in batch[source][data_type]:
-                    continue
-
-                if var_key not in self.scaler[source][data_type]:
-                    raise KeyError(
-                        f"BridgeScaleTransformer: no fitted scaler for '{var_key}' "
-                        f"in {source}/{data_type}. Check that the scaler was fit on this variable."
-                    )
-
-                x = batch[source][data_type][var_key]
-                s = self.scaler[source][data_type][var_key]
-                if self.method == "inverse":
-                    batch[source][data_type][var_key] = s.inverse_transform(x)
-                elif self.method == "transform":
-                    batch[source][data_type][var_key] = s.transform(x)
-                else:
-                    raise ValueError(f"Unsupported method: {self.method}. Choose 'transform' or 'inverse'.")
-
-        return batch
+        return scale_var_dict(batch, self.scaler, self.method, self.variables)

--- a/credit/preblock/scaler.py
+++ b/credit/preblock/scaler.py
@@ -2,7 +2,7 @@ import torch.nn as nn
 from bridgescaler import load_scaler
 
 
-class Scaler(nn.Module):
+class BridgeScaleTransformer(nn.Module):
     """
     Scaling layer using a bridgescaler object. Supports transform and its inverse.
     """

--- a/credit/preblock/sqrt.py
+++ b/credit/preblock/sqrt.py
@@ -1,0 +1,58 @@
+from credit.preblock.base import BasePreblock
+import torch
+
+
+class SqrtTransform(BasePreblock):
+    """
+    Applies a log transformation to specified variables in a batch dict.
+
+    Expected dict structure:
+        batch[source][data_type]['source/var_type/var_shape/var_name']
+
+    Config example:
+        type: "sqrt_transform"
+        args:
+            variables:
+                - 'ERA5/prognostic/3D/Q'
+            data_types:     # optional, defaults to ['input', 'target']
+                - 'input'
+                - 'target'
+    """
+
+    def __init__(self, variables: list[str], data_types: list[str] = None):
+        super().__init__()
+        self.variables = variables
+        self.data_types = data_types or ["input", "target"]
+
+        # Validate data_types at init
+        invalid = set(self.data_types) - set(self.VALID_DATA_TYPES)
+        if invalid:
+            raise ValueError(
+                f"Invalid data_types {invalid}. "
+                f"Valid options are {self.VALID_DATA_TYPES}. "
+                f"Preblocks never operate on 'metadata'."
+            )
+
+    def forward(self, batch: dict) -> dict:
+        for var_key in self.variables:
+            source = var_key.split("/")[0]
+
+            if source not in batch:
+                raise KeyError(f"SqrtTransform: source '{source}' not found in batch.")
+
+            for data_type in self.data_types:
+                # Silent skip: data_type absent (e.g. 'target' during inference)
+                if data_type not in batch[source]:
+                    continue
+
+                # Silent skip: variable not present in this data_type
+                if var_key not in batch[source][data_type]:
+                    print(batch[source][data_type].keys())
+                    print(f"SqrtTransform: data_type '{data_type}' not found in batch.")
+                    continue
+
+                x = batch[source][data_type][var_key]
+                # Out-of-place: safe for autograd
+                batch[source][data_type][var_key] = torch.sqrt(x)
+
+        return batch

--- a/tests/test_preblock.py
+++ b/tests/test_preblock.py
@@ -5,10 +5,29 @@ import pytest
 import torch
 import xarray as xr
 from bridgescaler.distributed_tensor import DStandardScalerTensor
-from bridgescaler import save_scaler
+from bridgescaler import save_scaler_dict, scale_var_dict
+from credit.preblock.regrid import Regridder
+from credit.preblock.scaler import BridgeScaleTransformer
 
-from credit.preblock.regrid import Regrid
-from credit.preblock.scaler import Scaler
+
+def create_synthetic_data() -> dict:
+    """
+    Creates synthetic data as a nested dictionary of torch tensors.
+
+    Structure: data[source][split][var_name]
+    - source: "ERA5"
+    - split: "input" | "target"
+    - var_name: "era5/pronostic/3d/T" | "era5/pronostic/3d/U" | "era5/pronostic/3d/V"
+    - tensor shape: (100, 16, 1, 8, 8)
+    """
+    shape = (100, 16, 1, 8, 8)
+    var_names = [
+        "era5/pronostic/3d/T",
+        "era5/pronostic/3d/U",
+        "era5/pronostic/3d/V",
+    ]
+
+    return {"era5": {split: {var: torch.randn(*shape) for var in var_names} for split in ("input", "target")}}
 
 
 # ---------------------------------------------------------------------------
@@ -20,17 +39,17 @@ from credit.preblock.scaler import Scaler
 def weight_file(tmp_path):
     """Write a minimal ESMF-compatible weight file and return its path.
 
-    Represents a 2:1 block-average downsampling from a 384×576 source grid to the
-    192×288 CREDIT destination grid.  Each destination cell is the average of the
-    4 corresponding source cells (weight = 0.25 each).
+    Represents a 2:1 block-average downsampling from an 8×8 source grid to a
+    4×4 destination grid, matching create_synthetic_data().  Each destination
+    cell is the average of the 4 corresponding source cells (weight = 0.25 each).
 
     Only the variables read by Regrid.__init__ are written:
       - dst_grid_dims: [nlon, nlat] SCRIP/ESMF convention; Regrid reverses with [::-1]
       - row, col, S:   1-based COO sparse entries
       - mask_a/b:      stubs so xarray exposes the n_a / n_b dimension sizes
     """
-    n_src_lat, n_src_lon = 384, 576
-    n_dst_lat, n_dst_lon = 192, 288
+    n_src_lat, n_src_lon = 8, 8
+    n_dst_lat, n_dst_lon = 4, 4
 
     # Build the COO sparse entries with numpy (vectorized, no Python loop)
     j_dst, i_dst = np.indices((n_dst_lat, n_dst_lon))
@@ -71,37 +90,55 @@ def weight_file(tmp_path):
 
 
 def test_regrid_output_shape(weight_file):
-    """Downsampling regrid produces the destination grid shape."""
+    """Downsampling regrid produces the destination grid shape for all splits."""
     path, n_src_lat, n_src_lon, n_dst_lat, n_dst_lon = weight_file
-    regrid = Regrid(path)
-    x = torch.randn(2, n_src_lat, n_src_lon)
-    assert regrid(x).shape == (2, n_dst_lat, n_dst_lon)
+    variables = ["era5/pronostic/3d/T"]
+    regrid = Regridder(path, variables=variables)
+    batch = create_synthetic_data()
+    result = regrid(batch)
+    for split in ("input", "target"):
+        assert result["era5"][split]["era5/pronostic/3d/T"].shape == (100, 16, 1, n_dst_lat, n_dst_lon)
 
 
 def test_regrid_uniform_input(weight_file):
     """Block-average regrid: uniform input maps to uniform output of the same value."""
     path, n_src_lat, n_src_lon, n_dst_lat, n_dst_lon = weight_file
-    regrid = Regrid(path)
-    x = torch.ones(n_src_lat, n_src_lon)
-    assert torch.allclose(regrid(x), torch.ones(n_dst_lat, n_dst_lon), atol=1e-5)
+    variables = ["era5/pronostic/3d/T"]
+    regrid = Regridder(path, variables=variables)
+    batch = {"era5": {"input": {"era5/pronostic/3d/T": torch.ones(1, 1, 1, n_src_lat, n_src_lon)}}}
+    result = regrid(batch)
+    assert torch.allclose(
+        result["era5"]["input"]["era5/pronostic/3d/T"],
+        torch.ones(1, 1, 1, n_dst_lat, n_dst_lon),
+        atol=1e-5,
+    )
 
 
 def test_regrid_reshape_false(weight_file):
-    """reshape_to_xy=False returns a flat (batch, n_b) tensor."""
+    """reshape_to_xy=False returns a flat (prod(lead_dims), n_b) tensor."""
     path, n_src_lat, n_src_lon, n_dst_lat, n_dst_lon = weight_file
-    regrid = Regrid(path, reshape_to_xy=False)
-    x = torch.randn(2, n_src_lat, n_src_lon)
-    assert regrid(x).shape == (2, n_dst_lat * n_dst_lon)
+    variables = ["era5/pronostic/3d/T"]
+    regrid = Regridder(path, variables=variables, reshape_to_xy=False)
+    batch = create_synthetic_data()
+    result = regrid(batch)
+    assert result["era5"]["input"]["era5/pronostic/3d/T"].shape == (100 * 16 * 1, n_dst_lat * n_dst_lon)
 
 
 def test_regrid_flip_axis(weight_file):
     """flip_axis is applied to the input before regridding."""
+    import copy
+
     path, n_src_lat, n_src_lon, n_dst_lat, n_dst_lon = weight_file
-    regrid = Regrid(path)
-    regrid_flip = Regrid(path, flip_axis=[-1])
-    x = torch.randn(n_src_lat, n_src_lon)
-    # For a non-uniform input, flipping before regridding should give a different result
-    assert not torch.allclose(regrid(x), regrid_flip(x))
+    variables = ["era5/pronostic/3d/T"]
+    regrid = Regridder(path, variables=variables)
+    regrid_flip = Regridder(path, variables=variables, flip_axis=[-1])
+    batch = create_synthetic_data()
+    result = regrid(copy.deepcopy(batch))
+    result_flip = regrid_flip(copy.deepcopy(batch))
+    assert not torch.allclose(
+        result["era5"]["input"]["era5/pronostic/3d/T"],
+        result_flip["era5"]["input"]["era5/pronostic/3d/T"],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -116,40 +153,75 @@ def scaler_file(tmp_path):
     Uses 16 channels to match typical CREDIT usage.  Spatial size is kept small
     (8×8) so the fixture stays fast.
     """
-    n_channels = 16
-    x_fit = torch.from_numpy(np.random.random((100, n_channels, 1, 8, 8)))
+    x_dict = create_synthetic_data()
+    variables = x_dict["era5"]["input"].keys()
     scaler = DStandardScalerTensor(channels_last=False)
-    scaler.fit(x_fit)
+    scaler_dict = scale_var_dict(x_dict, scaler, method="fit")
     path = str(tmp_path / "scaler.json")
-    save_scaler(scaler, path)
-    return path, n_channels
+    save_scaler_dict(scaler_dict, path)
+    return path, variables, x_dict
 
 
 # ---------------------------------------------------------------------------
 # Scaler tests
 # ---------------------------------------------------------------------------
 
+# VAR_NAMES = ["era5/pronostic/3d/T", "era5/pronostic/3d/U", "era5/pronostic/3d/V"]
+
 
 def test_scaler_output_shape(scaler_file):
-    """Transform preserves the input tensor shape."""
-    path, n_channels = scaler_file
-    scaler = Scaler(path)
-    x = torch.from_numpy(np.random.random((2, n_channels, 1, 8, 8)))
-    assert scaler(x).shape == x.shape
+    """Transform preserves the input tensor shape for every variable."""
+    path, variables, data = scaler_file
+    scaler = BridgeScaleTransformer(scaler_path=path, variables=list(variables), method="transform")
+    original_shapes = {v: data["era5"]["input"][v].shape for v in variables}
+    result = scaler(data)
+    for v in variables:
+        assert result["era5"]["input"][v].shape == original_shapes[v]
 
 
 def test_scaler_transform_changes_values(scaler_file):
     """Transform produces different values than the raw input."""
-    path, n_channels = scaler_file
-    scaler = Scaler(path)
-    x = torch.from_numpy(np.random.random((2, n_channels, 1, 8, 8)))
-    assert not torch.allclose(scaler(x).float(), x.float())
+    path, variables, data = scaler_file
+    scaler = BridgeScaleTransformer(scaler_path=path, variables=list(variables), method="transform")
+    var = list(variables)[0]
+    original = data["era5"]["input"][var].clone()
+    result = scaler(data)
+    assert not torch.allclose(result["era5"]["input"][var].float(), original.float())
 
 
 def test_scaler_round_trip(scaler_file):
-    """transform followed by inverse_transform recovers the original tensor."""
-    path, n_channels = scaler_file
-    fwd = Scaler(path, inverse=False)
-    inv = Scaler(path, inverse=True)
-    x = torch.from_numpy(np.random.random((2, n_channels, 1, 8, 8)))
-    assert torch.allclose(inv(fwd(x)).float(), x.float(), atol=1e-5)
+    """transform followed by inverse recovers the original tensor."""
+    path, variables, data = scaler_file
+    var_list = list(variables)
+    fwd = BridgeScaleTransformer(scaler_path=path, variables=var_list, method="transform")
+    inv = BridgeScaleTransformer(scaler_path=path, variables=var_list, method="inverse")
+    var = var_list[0]
+    original = data["era5"]["input"][var].clone()
+    data = fwd(data)
+    data = inv(data)
+    assert torch.allclose(data["era5"]["input"][var].float(), original.float(), atol=1e-5)
+
+
+def test_scaler_invalid_data_type(scaler_file):
+    """Passing an invalid data_type raises ValueError at init."""
+    path, variables, _ = scaler_file
+    with pytest.raises(ValueError, match="Invalid data_types"):
+        BridgeScaleTransformer(
+            scaler_path=path,
+            variables=list(variables),
+            method="transform",
+            data_types=["not_a_valid_type"],
+        )
+
+
+def test_scaler_raises_missing_source(scaler_file):
+    """forward raises KeyError if a variable's source is absent from the batch."""
+    path, variables, data = scaler_file
+    # Use a variable that references a source not in the batch
+    scaler = BridgeScaleTransformer(
+        scaler_path=path,
+        variables=["MISSING_SOURCE/prognostic/3d/T"],
+        method="transform",
+    )
+    with pytest.raises(KeyError):
+        scaler(data)

--- a/tests/test_preblock.py
+++ b/tests/test_preblock.py
@@ -194,34 +194,9 @@ def test_scaler_round_trip(scaler_file):
     path, variables, data = scaler_file
     var_list = list(variables)
     fwd = BridgeScaleTransformer(scaler_path=path, variables=var_list, method="transform")
-    inv = BridgeScaleTransformer(scaler_path=path, variables=var_list, method="inverse")
+    inv = BridgeScaleTransformer(scaler_path=path, variables=var_list, method="inverse_transform")
     var = var_list[0]
     original = data["era5"]["input"][var].clone()
     data = fwd(data)
     data = inv(data)
     assert torch.allclose(data["era5"]["input"][var].float(), original.float(), atol=1e-5)
-
-
-def test_scaler_invalid_data_type(scaler_file):
-    """Passing an invalid data_type raises ValueError at init."""
-    path, variables, _ = scaler_file
-    with pytest.raises(ValueError, match="Invalid data_types"):
-        BridgeScaleTransformer(
-            scaler_path=path,
-            variables=list(variables),
-            method="transform",
-            data_types=["not_a_valid_type"],
-        )
-
-
-def test_scaler_raises_missing_source(scaler_file):
-    """forward raises KeyError if a variable's source is absent from the batch."""
-    path, variables, data = scaler_file
-    # Use a variable that references a source not in the batch
-    scaler = BridgeScaleTransformer(
-        scaler_path=path,
-        variables=["MISSING_SOURCE/prognostic/3d/T"],
-        method="transform",
-    )
-    with pytest.raises(KeyError):
-        scaler(data)

--- a/tests/test_preblock.py
+++ b/tests/test_preblock.py
@@ -7,7 +7,7 @@ import xarray as xr
 from bridgescaler.distributed_tensor import DStandardScalerTensor
 from bridgescaler import save_scaler_dict, scale_var_dict
 from credit.preblock.regrid import Regridder
-from credit.preblock.scaler import BridgeScaleTransformer
+from credit.preblock.scaler import BridgeScalerTransformer
 
 
 def create_synthetic_data() -> dict:
@@ -172,7 +172,7 @@ def scaler_file(tmp_path):
 def test_scaler_output_shape(scaler_file):
     """Transform preserves the input tensor shape for every variable."""
     path, variables, data = scaler_file
-    scaler = BridgeScaleTransformer(scaler_path=path, variables=list(variables), method="transform")
+    scaler = BridgeScalerTransformer(scaler_path=path, variables=list(variables), method="transform")
     original_shapes = {v: data["era5"]["input"][v].shape for v in variables}
     result = scaler(data)
     for v in variables:
@@ -182,7 +182,7 @@ def test_scaler_output_shape(scaler_file):
 def test_scaler_transform_changes_values(scaler_file):
     """Transform produces different values than the raw input."""
     path, variables, data = scaler_file
-    scaler = BridgeScaleTransformer(scaler_path=path, variables=list(variables), method="transform")
+    scaler = BridgeScalerTransformer(scaler_path=path, variables=list(variables), method="transform")
     var = list(variables)[0]
     original = data["era5"]["input"][var].clone()
     result = scaler(data)
@@ -193,8 +193,8 @@ def test_scaler_round_trip(scaler_file):
     """transform followed by inverse recovers the original tensor."""
     path, variables, data = scaler_file
     var_list = list(variables)
-    fwd = BridgeScaleTransformer(scaler_path=path, variables=var_list, method="transform")
-    inv = BridgeScaleTransformer(scaler_path=path, variables=var_list, method="inverse_transform")
+    fwd = BridgeScalerTransformer(scaler_path=path, variables=var_list, method="transform")
+    inv = BridgeScalerTransformer(scaler_path=path, variables=var_list, method="inverse_transform")
     var = var_list[0]
     original = data["era5"]["input"][var].clone()
     data = fwd(data)


### PR DESCRIPTION
## Add config-driven preblock system

Introduces a modular preblock pipeline for applying variable-level transformations to batch dictionaries prior to model ingestion.

### Structure

```
preblocks/
    __init__.py          ← registry, build_preblocks(), apply_preblocks()
    base.py              ← BasePreblock (nn.Module)
    log.py     ← LogTransform
    sqrt.py       ← SqrtTransform
    regrid.py and scaler.py still need updating for config-driven usage
```


### Design

- Batch dicts follow the schema `batch[source][data_type]['source/var_type/var_shape/var_name']`
- Preblocks operate on `input` and `target` data types by default; `metadata` is never modified but always propagated
- `data_types` is configurable per-preblock to support cases where input and target transforms differ
- `target` is silently skipped if absent (inference mode)
- All transforms are out-of-place to preserve autograd compatibility

### Config

Preblocks are defined in the model config and instantiated via `**kwargs` unpacking — adding new args to a transform requires no changes to the registry or instantiation logic:

```yaml
preblocks:
    era5_log_transform:
        type: "log_transform"
        args:
            variables:
                - 'ERA5/prognostic/3d/Q'
            base: 'e'
            eps: 1.0e-8
    era5_sqrt_transform:
        type: "sqrt_transform"
        args:
            variables:
                - 'ERA5/prognostic/3d/U'
                - 'ERA5/prognostic/3d/V'
            data_types:
                - 'input'
```

### Usage

```python
from preblocks import build_preblocks, apply_preblocks

preblocks = build_preblocks(config['preblocks'])

for batch in dataloader:
    batch = apply_preblocks(preblocks, batch)
```

### Adding a new transform

1. Create `preblocks/new_transform.py` subclassing `BasePreblock`
2. Add one import and one registry entry to `__init__.py`

No other changes required.