### PR TITLE
adding a new energy post-block that doesn't use net notation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# local dev / HPC-specific test scripts
+test_energy_fixer_updown.py

--- a/config/example-v2026.1.0.yml
+++ b/config/example-v2026.1.0.yml
@@ -321,6 +321,37 @@ model:
             #     net latent heat flux on the surface [J/m^2]
             surface_energy_flux_name: ['surface_sensible_heat_flux', 'surface_latent_heat_flux',]
 
+        # Global energy fixer using explicit up/down flux decomposition.
+        # Use this instead of global_energy_fixer when the model predicts separate
+        # downwelling and upwelling fluxes (e.g. FSDS_J, FSUS, FLDS_J, FLUS).
+        # Only one of global_energy_fixer / global_energy_fixer_updown should be active.
+        global_energy_fixer_updown:
+            activate: False
+            activate_outside_model: False
+            simple_demo: False
+            denorm: True
+            grid_type: 'sigma'
+            midpoint: True
+            lon_lat_level_name: ['lon2d', 'lat2d', 'coef_a', 'coef_b']
+            surface_pressure_name: ['SP']
+            surface_geopotential_name: ['geopotential_at_surface']
+            air_temperature_name: ['temperature']
+            specific_total_water_name: ['specific_total_water']
+            u_wind_name: ['u_component_of_wind']
+            v_wind_name: ['v_component_of_wind']
+            # TOA fluxes — all in J/m² per timestep (same units as other output vars)
+            TOA_down_solar_name: ['FSDS_TOA']        # incident SW at TOA (SOLIN × DT)
+            TOA_up_solar_name:   ['FSUS_TOA']        # reflected SW at TOA (FSUTOA × DT)
+            TOA_up_OLR_name:     ['FLUT_J']          # outgoing LW at TOA (FLUT × DT)
+            # Surface fluxes — all in J/m² per timestep
+            surf_down_solar_name: ['FSDS_J']         # downwelling SW at surface
+            surf_up_solar_name:   ['FSUS']           # upwelling SW at surface
+            surf_down_LW_name:    ['FLDS_J']         # downwelling LW at surface
+            surf_up_LW_name:      ['FLUS']           # upwelling LW at surface
+            # Turbulent fluxes — positive-upward, J/m² per timestep
+            surf_SH_name: ['SHFLX_J']               # sensible heat flux (positive = surface → atm)
+            surf_LH_name: ['LHFLX_J']               # latent heat flux   (positive = surface → atm)
+
 
 loss: 
     # the main training loss

--- a/credit/parser.py
+++ b/credit/parser.py
@@ -223,9 +223,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 conf["data"]["flag_surface"] = False
             elif len(conf["data"]["surface_variables"]) > 0:
                 conf["data"]["flag_surface"] = True
-                assert "save_loc_surface" in conf["data"], (
-                    "surface var save locations ('save_loc_surface') is missing from conf['data']"
-                )
+                assert (
+                    "save_loc_surface" in conf["data"]
+                ), "surface var save locations ('save_loc_surface') is missing from conf['data']"
             else:
                 conf["data"]["flag_surface"] = False
         else:
@@ -237,9 +237,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 conf["data"]["flag_dyn_forcing"] = False
             elif len(conf["data"]["dynamic_forcing_variables"]) > 0:
                 conf["data"]["flag_dyn_forcing"] = True
-                assert "save_loc_dynamic_forcing" in conf["data"], (
-                    "dynamic forcing var save locations ('save_loc_dynamic_forcing') is missing from conf['data']"
-                )
+                assert (
+                    "save_loc_dynamic_forcing" in conf["data"]
+                ), "dynamic forcing var save locations ('save_loc_dynamic_forcing') is missing from conf['data']"
             else:
                 conf["data"]["flag_dyn_forcing"] = False
         else:
@@ -251,9 +251,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 conf["data"]["flag_diagnostic"] = False
             elif len(conf["data"]["diagnostic_variables"]) > 0:
                 conf["data"]["flag_diagnostic"] = True
-                assert "save_loc_diagnostic" in conf["data"], (
-                    "diagnostic var save locations ('save_loc_diagnostic') is missing from conf['data']"
-                )
+                assert (
+                    "save_loc_diagnostic" in conf["data"]
+                ), "diagnostic var save locations ('save_loc_diagnostic') is missing from conf['data']"
             else:
                 conf["data"]["flag_diagnostic"] = False
         else:
@@ -265,9 +265,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 conf["data"]["flag_forcing"] = False
             elif len(conf["data"]["forcing_variables"]) > 0:
                 conf["data"]["flag_forcing"] = True
-                assert "save_loc_forcing" in conf["data"], (
-                    "forcing var save locations ('save_loc_forcing') is missing from conf['data']"
-                )
+                assert (
+                    "save_loc_forcing" in conf["data"]
+                ), "forcing var save locations ('save_loc_forcing') is missing from conf['data']"
             else:
                 conf["data"]["flag_forcing"] = False
         else:
@@ -279,9 +279,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 conf["data"]["flag_static"] = False
             elif len(conf["data"]["static_variables"]) > 0:
                 conf["data"]["flag_static"] = True
-                assert "save_loc_static" in conf["data"], (
-                    "static var save locations ('save_loc_static') is missing from conf['data']"
-                )
+                assert (
+                    "save_loc_static" in conf["data"]
+                ), "static var save locations ('save_loc_static') is missing from conf['data']"
             else:
                 conf["data"]["flag_static"] = False
         else:
@@ -345,13 +345,13 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
 
             # 'valid_years' is required even for conf['trainer']['skip_validation']: True
             # 'valid_years' and 'train_years' can overlap
-            assert "valid_years" in conf["data"], (
-                "year range for validation ('valid_years') is missing from conf['data']"
-            )
+            assert (
+                "valid_years" in conf["data"]
+            ), "year range for validation ('valid_years') is missing from conf['data']"
 
-            assert "forecast_len" in conf["data"], (
-                "Number of time frames for loss compute ('forecast_len') is missing from conf['data']"
-            )
+            assert (
+                "forecast_len" in conf["data"]
+            ), "Number of time frames for loss compute ('forecast_len') is missing from conf['data']"
 
             if "valid_history_len" not in conf["data"]:
                 # use "history_len" for "valid_history_len"
@@ -375,9 +375,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 conf["data"]["total_time_steps"] = conf["data"]["forecast_len"]
 
         assert "history_len" in conf["data"], "Number of input time frames ('history_len') is missing from conf['data']"
-        assert "lead_time_periods" in conf["data"], (
-            "Number of forecast hours ('lead_time_periods') is missing from conf['data']"
-        )
+        assert (
+            "lead_time_periods" in conf["data"]
+        ), "Number of forecast hours ('lead_time_periods') is missing from conf['data']"
         assert "scaler_type" in conf["data"], "'scaler_type' is missing from conf['data']"
 
         if conf["data"]["scaler_type"] == "std_new":
@@ -458,6 +458,7 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
         "global_mass_fixer",
         "global_water_fixer",
         "global_energy_fixer",
+        "global_energy_fixer_updown",
     ]
 
     # if activate is false, set all post modules to false
@@ -520,13 +521,13 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
 
     # SKEBS
     if conf["model"]["post_conf"]["skebs"]["activate"]:
-        assert "freeze_base_model_weights" in conf["model"]["post_conf"]["skebs"], (
-            "need to specify freeze_base_model_weights in skebs config"
-        )
+        assert (
+            "freeze_base_model_weights" in conf["model"]["post_conf"]["skebs"]
+        ), "need to specify freeze_base_model_weights in skebs config"
 
-        assert conf["trainer"]["train_batch_size"] == conf["trainer"]["valid_batch_size"], (
-            "train and valid batch sizes need to be the same for skebs"
-        )
+        assert (
+            conf["trainer"]["train_batch_size"] == conf["trainer"]["valid_batch_size"]
+        ), "train and valid batch sizes need to be the same for skebs"
 
         # setup backscatter writing
         conf["model"]["post_conf"]["predict"] = {k: v for k, v in conf["predict"].items()}
@@ -614,19 +615,19 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
         conf["model"]["post_conf"]["global_mass_fixer"].setdefault("midpoint", False)
         conf["model"]["post_conf"]["global_mass_fixer"].setdefault("grid_type", "pressure")
 
-        assert "fix_level_num" in conf["model"]["post_conf"]["global_mass_fixer"], (
-            "Must specifiy what level to fix on specific total water"
-        )
+        assert (
+            "fix_level_num" in conf["model"]["post_conf"]["global_mass_fixer"]
+        ), "Must specifiy what level to fix on specific total water"
 
         if conf["model"]["post_conf"]["global_mass_fixer"]["simple_demo"] is False:
-            assert "lon_lat_level_name" in conf["model"]["post_conf"]["global_mass_fixer"], (
-                "Must specifiy var names for lat/lon/level in physics reference file"
-            )
+            assert (
+                "lon_lat_level_name" in conf["model"]["post_conf"]["global_mass_fixer"]
+            ), "Must specifiy var names for lat/lon/level in physics reference file"
 
         if conf["model"]["post_conf"]["global_mass_fixer"]["grid_type"] == "sigma":
-            assert "surface_pressure_name" in conf["model"]["post_conf"]["global_mass_fixer"], (
-                "Must specifiy surface pressure var name when using hybrid sigma-pressure coordinates"
-            )
+            assert (
+                "surface_pressure_name" in conf["model"]["post_conf"]["global_mass_fixer"]
+            ), "Must specifiy surface pressure var name when using hybrid sigma-pressure coordinates"
 
         q_inds = [
             i_var
@@ -660,14 +661,14 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
         conf["model"]["post_conf"]["global_water_fixer"].setdefault("grid_type", "pressure")
 
         if conf["model"]["post_conf"]["global_water_fixer"]["simple_demo"] is False:
-            assert "lon_lat_level_name" in conf["model"]["post_conf"]["global_water_fixer"], (
-                "Must specifiy var names for lat/lon/level in physics reference file"
-            )
+            assert (
+                "lon_lat_level_name" in conf["model"]["post_conf"]["global_water_fixer"]
+            ), "Must specifiy var names for lat/lon/level in physics reference file"
 
         if conf["model"]["post_conf"]["global_water_fixer"]["grid_type"] == "sigma":
-            assert "surface_pressure_name" in conf["model"]["post_conf"]["global_water_fixer"], (
-                "Must specifiy surface pressure var name when using hybrid sigma-pressure coordinates"
-            )
+            assert (
+                "surface_pressure_name" in conf["model"]["post_conf"]["global_water_fixer"]
+            ), "Must specifiy surface pressure var name when using hybrid sigma-pressure coordinates"
         q_inds = [
             i_var
             for i_var, var in enumerate(varname_output)
@@ -717,14 +718,14 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
         conf["model"]["post_conf"]["global_energy_fixer"].setdefault("grid_type", "pressure")
 
         if conf["model"]["post_conf"]["global_energy_fixer"]["simple_demo"] is False:
-            assert "lon_lat_level_name" in conf["model"]["post_conf"]["global_energy_fixer"], (
-                "Must specifiy var names for lat/lon/level in physics reference file"
-            )
+            assert (
+                "lon_lat_level_name" in conf["model"]["post_conf"]["global_energy_fixer"]
+            ), "Must specifiy var names for lat/lon/level in physics reference file"
 
         if conf["model"]["post_conf"]["global_energy_fixer"]["grid_type"] == "sigma":
-            assert "surface_pressure_name" in conf["model"]["post_conf"]["global_energy_fixer"], (
-                "Must specifiy surface pressure var name when using hybrid sigma-pressure coordinates"
-            )
+            assert (
+                "surface_pressure_name" in conf["model"]["post_conf"]["global_energy_fixer"]
+            ), "Must specifiy surface pressure var name when using hybrid sigma-pressure coordinates"
 
         T_inds = [
             i_var
@@ -784,6 +785,50 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
             ]
             conf["model"]["post_conf"]["global_energy_fixer"]["sp_inds"] = sp_inds[0]
 
+    # --------------------------------------------------------------------- #
+    # global energy fixer (up/down flux version)
+    flag_energy_updown = (
+        conf["model"]["post_conf"]["activate"] and conf["model"]["post_conf"]["global_energy_fixer_updown"]["activate"]
+    )
+
+    if flag_energy_updown:
+        cfg_ud = conf["model"]["post_conf"]["global_energy_fixer_updown"]
+
+        cfg_ud.setdefault("activate_outside_model", False)
+        cfg_ud.setdefault("denorm", True)
+        cfg_ud.setdefault("simple_demo", False)
+        cfg_ud.setdefault("midpoint", True)
+        cfg_ud.setdefault("grid_type", "sigma")
+
+        if cfg_ud["simple_demo"] is False:
+            assert "lon_lat_level_name" in cfg_ud, "Must specify var names for lat/lon/level in physics reference file"
+
+        if cfg_ud["grid_type"] == "sigma":
+            assert (
+                "surface_pressure_name" in cfg_ud
+            ), "Must specify surface pressure var name when using hybrid sigma-pressure coordinates"
+
+        def _find_ind(name_key, single=False):
+            inds = [i for i, v in enumerate(varname_output) if v in cfg_ud[name_key]]
+            return inds[0] if single else inds
+
+        cfg_ud["T_inds"] = _find_ind("air_temperature_name")
+        cfg_ud["q_inds"] = _find_ind("specific_total_water_name")
+        cfg_ud["U_inds"] = _find_ind("u_wind_name")
+        cfg_ud["V_inds"] = _find_ind("v_wind_name")
+        cfg_ud["TOA_down_solar_ind"] = _find_ind("TOA_down_solar_name", single=True)
+        cfg_ud["TOA_up_solar_ind"] = _find_ind("TOA_up_solar_name", single=True)
+        cfg_ud["TOA_up_OLR_ind"] = _find_ind("TOA_up_OLR_name", single=True)
+        cfg_ud["surf_down_solar_ind"] = _find_ind("surf_down_solar_name", single=True)
+        cfg_ud["surf_up_solar_ind"] = _find_ind("surf_up_solar_name", single=True)
+        cfg_ud["surf_down_LW_ind"] = _find_ind("surf_down_LW_name", single=True)
+        cfg_ud["surf_up_LW_ind"] = _find_ind("surf_up_LW_name", single=True)
+        cfg_ud["surf_SH_ind"] = _find_ind("surf_SH_name", single=True)
+        cfg_ud["surf_LH_ind"] = _find_ind("surf_LH_name", single=True)
+
+        if cfg_ud["grid_type"] == "sigma":
+            cfg_ud["sp_inds"] = _find_ind("surface_pressure_name", single=True)
+
     # --------------------------------------------------------- #
     # conf['trainer'] section
 
@@ -801,21 +846,21 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
         assert "load_weights" in conf["trainer"], "must specify 'load_weights' in conf['trainer']"
         assert "learning_rate" in conf["trainer"], "must specify 'learning_rate' in conf['trainer']"
 
-        assert "batches_per_epoch" in conf["trainer"], (
-            "Number of training batches per epoch ('batches_per_epoch') is missing from onf['trainer']"
-        )
+        assert (
+            "batches_per_epoch" in conf["trainer"]
+        ), "Number of training batches per epoch ('batches_per_epoch') is missing from onf['trainer']"
 
-        assert "train_batch_size" in conf["trainer"], (
-            "Training set batch size ('train_batch_size') is missing from onf['trainer']"
-        )
+        assert (
+            "train_batch_size" in conf["trainer"]
+        ), "Training set batch size ('train_batch_size') is missing from onf['trainer']"
 
         if "ensemble_size" not in conf["trainer"]:
             conf["trainer"]["ensemble_size"] = 1  # default value of 1 means deterministic training
 
         if conf["trainer"]["ensemble_size"] > 1:
-            assert conf["loss"]["training_loss"] in ["KCRPS", "almost-fair-crps"], (
-                f"""{conf["loss"]["training_loss"]} loss incompatible with ensemble training. ensemble_size is {conf["trainer"]["ensemble_size"]}"""
-            )
+            assert (
+                conf["loss"]["training_loss"] in ["KCRPS", "almost-fair-crps"]
+            ), f"""{conf["loss"]["training_loss"]} loss incompatible with ensemble training. ensemble_size is {conf["trainer"]["ensemble_size"]}"""
 
         if "load_scaler" not in conf["trainer"]:
             conf["trainer"]["load_scaler"] = False
@@ -843,13 +888,13 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
 
         if conf["trainer"]["skip_validation"] is False:
             # do not skip validaiton
-            assert "valid_batch_size" in conf["trainer"], (
-                "Validation set batch size ('valid_batch_size') is missing from conf['trainer']"
-            )
+            assert (
+                "valid_batch_size" in conf["trainer"]
+            ), "Validation set batch size ('valid_batch_size') is missing from conf['trainer']"
 
-            assert "valid_batches_per_epoch" in conf["trainer"], (
-                "Number of validation batches per epoch ('valid_batches_per_epoch') is missing from conf['trainer']"
-            )
+            assert (
+                "valid_batches_per_epoch" in conf["trainer"]
+            ), "Number of validation batches per epoch ('valid_batches_per_epoch') is missing from conf['trainer']"
 
         if "save_metric_vars" not in conf["trainer"]:
             conf["trainer"]["save_metric_vars"] = []  # averaged metrics only
@@ -861,21 +906,21 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 # lr will be controlled by scheduler
                 conf["trainer"]["update_learning_rate"] = False
 
-                assert "scheduler" in conf["trainer"], (
-                    "must specify 'scheduler' in conf['trainer'] when a scheduler is used"
-                )
+                assert (
+                    "scheduler" in conf["trainer"]
+                ), "must specify 'scheduler' in conf['trainer'] when a scheduler is used"
 
-                assert "reload_epoch" in conf["trainer"], (
-                    "must specify 'reload_epoch' in conf['trainer'] when a scheduler is used"
-                )
+                assert (
+                    "reload_epoch" in conf["trainer"]
+                ), "must specify 'reload_epoch' in conf['trainer'] when a scheduler is used"
 
-                assert "load_optimizer" in conf["trainer"], (
-                    "must specify 'load_optimizer' in conf['trainer'] when a scheduler is used"
-                )
+                assert (
+                    "load_optimizer" in conf["trainer"]
+                ), "must specify 'load_optimizer' in conf['trainer'] when a scheduler is used"
 
-                assert "load_scheduler" in conf["trainer"], (
-                    "must specify 'load_scheduler' in conf['trainer'] when a scheduler is used"
-                )
+                assert (
+                    "load_scheduler" in conf["trainer"]
+                ), "must specify 'load_scheduler' in conf['trainer'] when a scheduler is used"
 
             # ------------------------------------------------------------------------------ #
             else:
@@ -944,9 +989,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
             assert "use_variable_weights" in conf["loss"], "must specify 'use_variable_weights' in conf['loss']"
 
             if conf["loss"]["use_variable_weights"]:
-                assert "variable_weights" in conf["loss"], (
-                    "must specify 'variable_weights' in conf['loss'] if 'use_variable_weights': True"
-                )
+                assert (
+                    "variable_weights" in conf["loss"]
+                ), "must specify 'variable_weights' in conf['loss'] if 'use_variable_weights': True"
 
                 # ----------------------------------------------------------------------------------------- #
                 # check and reorganize variable weights
@@ -1029,9 +1074,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
 
         else:
             assert "forecasts" in conf["predict"], "Rollout settings ('forecasts') is missing from conf['predict']"
-            assert "save_forecast" in conf["predict"], (
-                "Rollout save location ('save_forecast') is missing from conf['predict']"
-            )
+            assert (
+                "save_forecast" in conf["predict"]
+            ), "Rollout save location ('save_forecast') is missing from conf['predict']"
 
             conf["predict"]["save_forecast"] = os.path.expandvars(conf["predict"]["save_forecast"])
 
@@ -1143,17 +1188,17 @@ def training_data_check(conf, print_summary=False):
         valid_dyn_forcing_files = [file for file in dyn_forcing_files if any(year in file for year in valid_years)]
 
         for i_year, year in enumerate(train_years):
-            assert year in train_dyn_forcing_files[i_year], (
-                "[Year {}] is missing from [dynamic forcing files {}]".format(
-                    year, conf["data"]["save_loc_dynamic_forcing"]
-                )
+            assert (
+                year in train_dyn_forcing_files[i_year]
+            ), "[Year {}] is missing from [dynamic forcing files {}]".format(
+                year, conf["data"]["save_loc_dynamic_forcing"]
             )
 
         for i_year, year in enumerate(valid_years):
-            assert year in valid_dyn_forcing_files[i_year], (
-                "[Year {}] is missing from [dynamic forcing files {}]".format(
-                    year, conf["data"]["save_loc_dynamic_forcing"]
-                )
+            assert (
+                year in valid_dyn_forcing_files[i_year]
+            ), "[Year {}] is missing from [dynamic forcing files {}]".format(
+                year, conf["data"]["save_loc_dynamic_forcing"]
             )
 
     ## diagnostic files
@@ -1185,9 +1230,9 @@ def training_data_check(conf, print_summary=False):
     ds_upper_air = get_forward_data(train_ERA_files[0])
     varnames_upper_air = list(ds_upper_air.keys())
 
-    assert all(varname in varnames_upper_air for varname in conf["data"]["variables"]), (
-        "upper-air variables [{}] are not fully covered by conf['data']['save_loc']".format(conf["data"]["variables"])
-    )
+    assert all(
+        varname in varnames_upper_air for varname in conf["data"]["variables"]
+    ), "upper-air variables [{}] are not fully covered by conf['data']['save_loc']".format(conf["data"]["variables"])
 
     # assign the upper_air vars in yaml if it can pass checks
     varnames_upper_air = conf["data"]["variables"]
@@ -1201,10 +1246,10 @@ def training_data_check(conf, print_summary=False):
         ds_surface = get_forward_data(train_surface_files[0])
         varnames_surface = list(ds_surface.keys())
 
-        assert all(varname in varnames_surface for varname in conf["data"]["surface_variables"]), (
-            "Surface variables [{}] are not fully covered by conf['data']['save_loc_surface']".format(
-                conf["data"]["surface_variables"]
-            )
+        assert all(
+            varname in varnames_surface for varname in conf["data"]["surface_variables"]
+        ), "Surface variables [{}] are not fully covered by conf['data']['save_loc_surface']".format(
+            conf["data"]["surface_variables"]
         )
 
         all_vars += conf["data"]["surface_variables"]
@@ -1214,10 +1259,10 @@ def training_data_check(conf, print_summary=False):
         ds_dyn_forcing = get_forward_data(train_dyn_forcing_files[0])
         varnames_dyn_forcing = list(ds_dyn_forcing.keys())
 
-        assert all(varname in varnames_dyn_forcing for varname in conf["data"]["dynamic_forcing_variables"]), (
-            "Dynamic forcing variables [{}] are not fully covered by conf['data']['save_loc_dynamic_forcing']".format(
-                conf["data"]["dynamic_forcing_variables"]
-            )
+        assert all(
+            varname in varnames_dyn_forcing for varname in conf["data"]["dynamic_forcing_variables"]
+        ), "Dynamic forcing variables [{}] are not fully covered by conf['data']['save_loc_dynamic_forcing']".format(
+            conf["data"]["dynamic_forcing_variables"]
         )
 
         all_vars += conf["data"]["dynamic_forcing_variables"]
@@ -1227,10 +1272,10 @@ def training_data_check(conf, print_summary=False):
         ds_diagnostic = get_forward_data(train_diagnostic_files[0])
         varnames_diagnostic = list(ds_diagnostic.keys())
 
-        assert all(varname in varnames_diagnostic for varname in conf["data"]["diagnostic_variables"]), (
-            "Diagnostic variables [{}] are not fully covered by conf['data']['save_loc_diagnostic']".format(
-                conf["data"]["diagnostic_variables"]
-            )
+        assert all(
+            varname in varnames_diagnostic for varname in conf["data"]["diagnostic_variables"]
+        ), "Diagnostic variables [{}] are not fully covered by conf['data']['save_loc_diagnostic']".format(
+            conf["data"]["diagnostic_variables"]
         )
 
         all_vars += conf["data"]["diagnostic_variables"]
@@ -1240,10 +1285,10 @@ def training_data_check(conf, print_summary=False):
         ds_forcing = get_forward_data(conf["data"]["save_loc_forcing"])
         varnames_forcing = list(ds_forcing.keys())
 
-        assert all(varname in varnames_forcing for varname in conf["data"]["forcing_variables"]), (
-            "Forcing variables [{}] are not fully covered by conf['data']['save_loc_forcing']".format(
-                conf["data"]["forcing_variables"]
-            )
+        assert all(
+            varname in varnames_forcing for varname in conf["data"]["forcing_variables"]
+        ), "Forcing variables [{}] are not fully covered by conf['data']['save_loc_forcing']".format(
+            conf["data"]["forcing_variables"]
         )
 
     # static variables
@@ -1251,19 +1296,19 @@ def training_data_check(conf, print_summary=False):
         ds_static = get_forward_data(conf["data"]["save_loc_static"])
         varnames_static = list(ds_static.keys())
 
-        assert all(varname in varnames_static for varname in conf["data"]["static_variables"]), (
-            "Static variables [{}] are not fully covered by conf['data']['save_loc_static']".format(
-                conf["data"]["static_variables"]
-            )
+        assert all(
+            varname in varnames_static for varname in conf["data"]["static_variables"]
+        ), "Static variables [{}] are not fully covered by conf['data']['save_loc_static']".format(
+            conf["data"]["static_variables"]
         )
 
     # comparing all_vars against mean, std files
     ds_mean = get_forward_data(conf["data"]["mean_path"])
     varname_ds_mean = list(ds_mean.keys())
 
-    assert all(varname in varname_ds_mean for varname in all_vars), (
-        "Variables are not fully covered by conf['data']['mean_path']"
-    )
+    assert all(
+        varname in varname_ds_mean for varname in all_vars
+    ), "Variables are not fully covered by conf['data']['mean_path']"
 
     ds_std = get_forward_data(conf["data"]["std_path"])
     varname_ds_std = list(ds_std.keys())
@@ -1272,9 +1317,9 @@ def training_data_check(conf, print_summary=False):
         if varname not in varname_ds_std:
             missing_vars.append(varname)
     missing_var_str = ", ".join(missing_vars)
-    assert all(varname in varname_ds_std for varname in all_vars), (
-        f"Variables {missing_var_str} are not fully covered by conf['data']['std_path']"
-    )
+    assert all(
+        varname in varname_ds_std for varname in all_vars
+    ), f"Variables {missing_var_str} are not fully covered by conf['data']['std_path']"
 
     if print_summary:
         print("Variable name checking passed")
@@ -1293,56 +1338,56 @@ def training_data_check(conf, print_summary=False):
         coord_surface = list(ds_surface.coords.keys())
         coord_surface = remove_string_by_pattern(coord_surface, "time")
 
-        assert all(coord_name in coord_upper_air for coord_name in coord_surface), (
-            "Surface file coordinate names mismatched with upper-air files"
-        )
+        assert all(
+            coord_name in coord_upper_air for coord_name in coord_surface
+        ), "Surface file coordinate names mismatched with upper-air files"
 
         for coord_name in coord_surface:
-            assert ds_upper_air.coords[coord_name].equals(ds_surface.coords[coord_name]), (
-                "coordinate {} mismatched between upper-air and surface files".format(coord_name)
-            )
+            assert ds_upper_air.coords[coord_name].equals(
+                ds_surface.coords[coord_name]
+            ), "coordinate {} mismatched between upper-air and surface files".format(coord_name)
 
     # dyn forcing files
     if conf["data"]["flag_dyn_forcing"]:
         coord_dyn_forcing = list(ds_dyn_forcing.coords.keys())
         coord_dyn_forcing = remove_string_by_pattern(coord_dyn_forcing, "time")
 
-        assert all(coord_name in coord_upper_air for coord_name in coord_dyn_forcing), (
-            "Dynamic forcing file coordinate names mismatched with upper-air files"
-        )
+        assert all(
+            coord_name in coord_upper_air for coord_name in coord_dyn_forcing
+        ), "Dynamic forcing file coordinate names mismatched with upper-air files"
 
         for coord_name in coord_dyn_forcing:
-            assert ds_upper_air.coords[coord_name].equals(ds_dyn_forcing.coords[coord_name]), (
-                "coordinate {} mismatched between upper-air and dynamic forcing files".format(coord_name)
-            )
+            assert ds_upper_air.coords[coord_name].equals(
+                ds_dyn_forcing.coords[coord_name]
+            ), "coordinate {} mismatched between upper-air and dynamic forcing files".format(coord_name)
 
     # diagnostic files
     if conf["data"]["flag_diagnostic"]:
         coord_diagnostic = list(ds_diagnostic.coords.keys())
         coord_diagnostic = remove_string_by_pattern(coord_diagnostic, "time")
 
-        assert all(coord_name in coord_upper_air for coord_name in coord_diagnostic), (
-            "Diagnostic file coordinate names mismatched with upper-air files"
-        )
+        assert all(
+            coord_name in coord_upper_air for coord_name in coord_diagnostic
+        ), "Diagnostic file coordinate names mismatched with upper-air files"
 
         for coord_name in coord_diagnostic:
-            assert ds_upper_air.coords[coord_name].equals(ds_diagnostic.coords[coord_name]), (
-                "coordinate {} mismatched between upper-air and diagnostic files".format(coord_name)
-            )
+            assert ds_upper_air.coords[coord_name].equals(
+                ds_diagnostic.coords[coord_name]
+            ), "coordinate {} mismatched between upper-air and diagnostic files".format(coord_name)
 
     # forcing files
     if conf["data"]["flag_forcing"]:
         coord_forcing = list(ds_forcing.coords.keys())
         coord_forcing = remove_string_by_pattern(coord_forcing, "time")
 
-        assert all(coord_name in coord_upper_air for coord_name in coord_forcing), (
-            "Forcing file coordinate names mismatched with upper-air files"
-        )
+        assert all(
+            coord_name in coord_upper_air for coord_name in coord_forcing
+        ), "Forcing file coordinate names mismatched with upper-air files"
 
         for coord_name in coord_forcing:
-            assert ds_upper_air.coords[coord_name].equals(ds_forcing.coords[coord_name]), (
-                "coordinate {} mismatched between upper-air and forcing files".format(coord_name)
-            )
+            assert ds_upper_air.coords[coord_name].equals(
+                ds_forcing.coords[coord_name]
+            ), "coordinate {} mismatched between upper-air and forcing files".format(coord_name)
 
         # ============================================== #
         # !! assumed subdaily inputs, may need to fix !! #
@@ -1354,58 +1399,58 @@ def training_data_check(conf, print_summary=False):
         coord_static = list(ds_static.coords.keys())
         coord_static = remove_string_by_pattern(coord_static, "time")
 
-        assert all(coord_name in coord_upper_air for coord_name in coord_static), (
-            "Static file coordinate names mismatched with upper-air files"
-        )
+        assert all(
+            coord_name in coord_upper_air for coord_name in coord_static
+        ), "Static file coordinate names mismatched with upper-air files"
 
         for coord_name in coord_static:
-            assert ds_upper_air.coords[coord_name].equals(ds_static.coords[coord_name]), (
-                "coordinate {} mismatched between upper-air and static files".format(coord_name)
-            )
+            assert ds_upper_air.coords[coord_name].equals(
+                ds_static.coords[coord_name]
+            ), "coordinate {} mismatched between upper-air and static files".format(coord_name)
 
     # zscore mean file (no time coordinate)
     coord_mean = list(ds_mean.coords.keys())
     coord_mean = remove_string_by_pattern(coord_mean, "time")
 
-    assert all(coord_name in coord_upper_air for coord_name in coord_mean), (
-        "zscore mean file coordinate names mismatched with upper-air files"
-    )
+    assert all(
+        coord_name in coord_upper_air for coord_name in coord_mean
+    ), "zscore mean file coordinate names mismatched with upper-air files"
 
     for coord_name in coord_mean:
-        assert ds_upper_air.coords[coord_name].equals(ds_mean.coords[coord_name]), (
-            "coordinate {} mismatched between upper-air and mean files".format(coord_name)
-        )
+        assert ds_upper_air.coords[coord_name].equals(
+            ds_mean.coords[coord_name]
+        ), "coordinate {} mismatched between upper-air and mean files".format(coord_name)
 
     # zscore std file (no time coordinate)
     coord_std = list(ds_std.coords.keys())
     coord_std = remove_string_by_pattern(coord_std, "time")
 
-    assert all(coord_name in coord_upper_air for coord_name in coord_std), (
-        "zscore std file coordinate names mismatched with upper-air files"
-    )
+    assert all(
+        coord_name in coord_upper_air for coord_name in coord_std
+    ), "zscore std file coordinate names mismatched with upper-air files"
 
     for coord_name in coord_std:
-        assert ds_upper_air.coords[coord_name].equals(ds_std.coords[coord_name]), (
-            "coordinate {} mismatched between upper-air and std files".format(coord_name)
-        )
+        assert ds_upper_air.coords[coord_name].equals(
+            ds_std.coords[coord_name]
+        ), "coordinate {} mismatched between upper-air and std files".format(coord_name)
 
     # lat / lon file
     ds_weights = get_forward_data(conf["loss"]["latitude_weights"])
     coord_latlon = list(ds_weights.coords.keys())
     coord_latlon = remove_string_by_pattern(coord_latlon, "time")
 
-    assert all(coord_name in coord_upper_air for coord_name in coord_latlon), (
-        "conf['loss']['latitude_weights'] file coordinate names mismatched with upper-air files"
-    )
+    assert all(
+        coord_name in coord_upper_air for coord_name in coord_latlon
+    ), "conf['loss']['latitude_weights'] file coordinate names mismatched with upper-air files"
 
     # model level consistency final checks
     N_level_mean = len(ds_mean[varnames_upper_air[0]].values)
     N_level_model = conf["model"]["levels"]
 
-    assert N_level_mean == N_level_model, (
-        "number of upper air levels mismatched between model config {} and input data {}".format(
-            N_level_model, N_level_mean
-        )
+    assert (
+        N_level_mean == N_level_model
+    ), "number of upper air levels mismatched between model config {} and input data {}".format(
+        N_level_model, N_level_mean
     )
 
     if print_summary:
@@ -1489,9 +1534,9 @@ def predict_data_check(conf, print_summary=False):
     ds_upper_air = get_forward_data(pred_ERA_files[0])
     varnames_upper_air = list(ds_upper_air.keys())
 
-    assert all(varname in varnames_upper_air for varname in conf["data"]["variables"]), (
-        "upper-air variables [{}] are not fully covered by conf['data']['save_loc']".format(conf["data"]["variables"])
-    )
+    assert all(
+        varname in varnames_upper_air for varname in conf["data"]["variables"]
+    ), "upper-air variables [{}] are not fully covered by conf['data']['save_loc']".format(conf["data"]["variables"])
 
     # collecting all variables that require zscores
     # deep copy to avoid changing conf['data'] by accident
@@ -1502,10 +1547,10 @@ def predict_data_check(conf, print_summary=False):
         ds_surface = get_forward_data(pred_surface_files[0])
         varnames_surface = list(ds_surface.keys())
 
-        assert all(varname in varnames_surface for varname in conf["data"]["surface_variables"]), (
-            "Surface variables [{}] are not fully covered by conf['data']['save_loc_surface']".format(
-                conf["data"]["surface_variables"]
-            )
+        assert all(
+            varname in varnames_surface for varname in conf["data"]["surface_variables"]
+        ), "Surface variables [{}] are not fully covered by conf['data']['save_loc_surface']".format(
+            conf["data"]["surface_variables"]
         )
 
         all_vars += conf["data"]["surface_variables"]
@@ -1515,10 +1560,10 @@ def predict_data_check(conf, print_summary=False):
         ds_dyn_forcing = get_forward_data(pred_dyn_forcing_files[0])
         varnames_dyn_forcing = list(ds_dyn_forcing.keys())
 
-        assert all(varname in varnames_dyn_forcing for varname in conf["data"]["dynamic_forcing_variables"]), (
-            "Dynamic forcing variables [{}] are not fully covered by conf['data']['save_loc_dynamic_forcing']".format(
-                conf["data"]["dynamic_forcing_variables"]
-            )
+        assert all(
+            varname in varnames_dyn_forcing for varname in conf["data"]["dynamic_forcing_variables"]
+        ), "Dynamic forcing variables [{}] are not fully covered by conf['data']['save_loc_dynamic_forcing']".format(
+            conf["data"]["dynamic_forcing_variables"]
         )
 
         all_vars += conf["data"]["dynamic_forcing_variables"]
@@ -1532,10 +1577,10 @@ def predict_data_check(conf, print_summary=False):
         ds_forcing = get_forward_data(conf["data"]["save_loc_forcing"])
         varnames_forcing = list(ds_forcing.keys())
 
-        assert all(varname in varnames_forcing for varname in conf["data"]["forcing_variables"]), (
-            "Forcing variables [{}] are not fully covered by conf['data']['save_loc_forcing']".format(
-                conf["data"]["forcing_variables"]
-            )
+        assert all(
+            varname in varnames_forcing for varname in conf["data"]["forcing_variables"]
+        ), "Forcing variables [{}] are not fully covered by conf['data']['save_loc_forcing']".format(
+            conf["data"]["forcing_variables"]
         )
 
     # static variables
@@ -1543,26 +1588,26 @@ def predict_data_check(conf, print_summary=False):
         ds_static = get_forward_data(conf["data"]["save_loc_static"])
         varnames_static = list(ds_static.keys())
 
-        assert all(varname in varnames_static for varname in conf["data"]["static_variables"]), (
-            "Static variables [{}] are not fully covered by conf['data']['save_loc_static']".format(
-                conf["data"]["static_variables"]
-            )
+        assert all(
+            varname in varnames_static for varname in conf["data"]["static_variables"]
+        ), "Static variables [{}] are not fully covered by conf['data']['save_loc_static']".format(
+            conf["data"]["static_variables"]
         )
 
     # comparing all_vars against mean, std files
     ds_mean = get_forward_data(conf["data"]["mean_path"])
     varname_ds_mean = list(ds_mean.keys())
 
-    assert all(varname in varname_ds_mean for varname in all_vars), (
-        "Variables are not fully covered by conf['data']['mean_path']"
-    )
+    assert all(
+        varname in varname_ds_mean for varname in all_vars
+    ), "Variables are not fully covered by conf['data']['mean_path']"
 
     ds_std = get_forward_data(conf["data"]["std_path"])
     varname_ds_std = list(ds_std.keys())
 
-    assert all(varname in varname_ds_std for varname in all_vars), (
-        "Variables are not fully covered by conf['data']['std_path']"
-    )
+    assert all(
+        varname in varname_ds_std for varname in all_vars
+    ), "Variables are not fully covered by conf['data']['std_path']"
 
     if print_summary:
         print("Variable name checking passed")
@@ -1581,42 +1626,42 @@ def predict_data_check(conf, print_summary=False):
         coord_surface = list(ds_surface.coords.keys())
         coord_surface = remove_string_by_pattern(coord_surface, "time")
 
-        assert all(coord_name in coord_upper_air for coord_name in coord_surface), (
-            "Surface file coordinate names mismatched with upper-air files"
-        )
+        assert all(
+            coord_name in coord_upper_air for coord_name in coord_surface
+        ), "Surface file coordinate names mismatched with upper-air files"
 
         for coord_name in coord_surface:
-            assert ds_upper_air.coords[coord_name].equals(ds_surface.coords[coord_name]), (
-                "coordinate {} mismatched between upper-air and surface files".format(coord_name)
-            )
+            assert ds_upper_air.coords[coord_name].equals(
+                ds_surface.coords[coord_name]
+            ), "coordinate {} mismatched between upper-air and surface files".format(coord_name)
 
     # dyn forcing files
     if conf["data"]["flag_dyn_forcing"]:
         coord_dyn_forcing = list(ds_dyn_forcing.coords.keys())
         coord_dyn_forcing = remove_string_by_pattern(coord_dyn_forcing, "time")
 
-        assert all(coord_name in coord_upper_air for coord_name in coord_dyn_forcing), (
-            "Dynamic forcing file coordinate names mismatched with upper-air files"
-        )
+        assert all(
+            coord_name in coord_upper_air for coord_name in coord_dyn_forcing
+        ), "Dynamic forcing file coordinate names mismatched with upper-air files"
 
         for coord_name in coord_dyn_forcing:
-            assert ds_upper_air.coords[coord_name].equals(ds_dyn_forcing.coords[coord_name]), (
-                "coordinate {} mismatched between upper-air and dynamic forcing files".format(coord_name)
-            )
+            assert ds_upper_air.coords[coord_name].equals(
+                ds_dyn_forcing.coords[coord_name]
+            ), "coordinate {} mismatched between upper-air and dynamic forcing files".format(coord_name)
 
     # forcing files
     if conf["data"]["flag_forcing"]:
         coord_forcing = list(ds_forcing.coords.keys())
         coord_forcing = remove_string_by_pattern(coord_forcing, "time")
 
-        assert all(coord_name in coord_upper_air for coord_name in coord_forcing), (
-            "Forcing file coordinate names mismatched with upper-air files"
-        )
+        assert all(
+            coord_name in coord_upper_air for coord_name in coord_forcing
+        ), "Forcing file coordinate names mismatched with upper-air files"
 
         for coord_name in coord_forcing:
-            assert ds_upper_air.coords[coord_name].equals(ds_forcing.coords[coord_name]), (
-                "coordinate {} mismatched between upper-air and forcing files".format(coord_name)
-            )
+            assert ds_upper_air.coords[coord_name].equals(
+                ds_forcing.coords[coord_name]
+            ), "coordinate {} mismatched between upper-air and forcing files".format(coord_name)
 
         # ============================================== #
         # !! assumed subdaily inputs, may need to fix !! #
@@ -1628,49 +1673,49 @@ def predict_data_check(conf, print_summary=False):
         coord_static = list(ds_static.coords.keys())
         coord_static = remove_string_by_pattern(coord_static, "time")
 
-        assert all(coord_name in coord_upper_air for coord_name in coord_static), (
-            "Static file coordinate names mismatched with upper-air files"
-        )
+        assert all(
+            coord_name in coord_upper_air for coord_name in coord_static
+        ), "Static file coordinate names mismatched with upper-air files"
 
         for coord_name in coord_static:
-            assert ds_upper_air.coords[coord_name].equals(ds_static.coords[coord_name]), (
-                "coordinate {} mismatched between upper-air and static files".format(coord_name)
-            )
+            assert ds_upper_air.coords[coord_name].equals(
+                ds_static.coords[coord_name]
+            ), "coordinate {} mismatched between upper-air and static files".format(coord_name)
 
     # zscore mean file (no time coordinate)
     coord_mean = list(ds_mean.coords.keys())
     coord_mean = remove_string_by_pattern(coord_mean, "time")
 
-    assert all(coord_name in coord_upper_air for coord_name in coord_mean), (
-        "zscore mean file coordinate names mismatched with upper-air files"
-    )
+    assert all(
+        coord_name in coord_upper_air for coord_name in coord_mean
+    ), "zscore mean file coordinate names mismatched with upper-air files"
 
     for coord_name in coord_mean:
-        assert ds_upper_air.coords[coord_name].equals(ds_mean.coords[coord_name]), (
-            "coordinate {} mismatched between upper-air and mean files".format(coord_name)
-        )
+        assert ds_upper_air.coords[coord_name].equals(
+            ds_mean.coords[coord_name]
+        ), "coordinate {} mismatched between upper-air and mean files".format(coord_name)
 
     # zscore std file (no time coordinate)
     coord_std = list(ds_std.coords.keys())
     coord_std = remove_string_by_pattern(coord_std, "time")
 
-    assert all(coord_name in coord_upper_air for coord_name in coord_std), (
-        "zscore std file coordinate names mismatched with upper-air files"
-    )
+    assert all(
+        coord_name in coord_upper_air for coord_name in coord_std
+    ), "zscore std file coordinate names mismatched with upper-air files"
 
     for coord_name in coord_std:
-        assert ds_upper_air.coords[coord_name].equals(ds_std.coords[coord_name]), (
-            "coordinate {} mismatched between upper-air and std files".format(coord_name)
-        )
+        assert ds_upper_air.coords[coord_name].equals(
+            ds_std.coords[coord_name]
+        ), "coordinate {} mismatched between upper-air and std files".format(coord_name)
 
     # lat / lon file
     ds_weights = get_forward_data(conf["loss"]["latitude_weights"])
     coord_latlon = list(ds_weights.coords.keys())
     coord_latlon = remove_string_by_pattern(coord_latlon, "time")
 
-    assert all(coord_name in coord_upper_air for coord_name in coord_latlon), (
-        "conf['loss']['latitude_weights'] file coordinate names mismatched with upper-air files"
-    )
+    assert all(
+        coord_name in coord_upper_air for coord_name in coord_latlon
+    ), "conf['loss']['latitude_weights'] file coordinate names mismatched with upper-air files"
 
     if print_summary:
         print("Coordinate checking passed")

--- a/credit/parser.py
+++ b/credit/parser.py
@@ -223,9 +223,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 conf["data"]["flag_surface"] = False
             elif len(conf["data"]["surface_variables"]) > 0:
                 conf["data"]["flag_surface"] = True
-                assert (
-                    "save_loc_surface" in conf["data"]
-                ), "surface var save locations ('save_loc_surface') is missing from conf['data']"
+                assert "save_loc_surface" in conf["data"], (
+                    "surface var save locations ('save_loc_surface') is missing from conf['data']"
+                )
             else:
                 conf["data"]["flag_surface"] = False
         else:
@@ -237,9 +237,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 conf["data"]["flag_dyn_forcing"] = False
             elif len(conf["data"]["dynamic_forcing_variables"]) > 0:
                 conf["data"]["flag_dyn_forcing"] = True
-                assert (
-                    "save_loc_dynamic_forcing" in conf["data"]
-                ), "dynamic forcing var save locations ('save_loc_dynamic_forcing') is missing from conf['data']"
+                assert "save_loc_dynamic_forcing" in conf["data"], (
+                    "dynamic forcing var save locations ('save_loc_dynamic_forcing') is missing from conf['data']"
+                )
             else:
                 conf["data"]["flag_dyn_forcing"] = False
         else:
@@ -251,9 +251,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 conf["data"]["flag_diagnostic"] = False
             elif len(conf["data"]["diagnostic_variables"]) > 0:
                 conf["data"]["flag_diagnostic"] = True
-                assert (
-                    "save_loc_diagnostic" in conf["data"]
-                ), "diagnostic var save locations ('save_loc_diagnostic') is missing from conf['data']"
+                assert "save_loc_diagnostic" in conf["data"], (
+                    "diagnostic var save locations ('save_loc_diagnostic') is missing from conf['data']"
+                )
             else:
                 conf["data"]["flag_diagnostic"] = False
         else:
@@ -265,9 +265,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 conf["data"]["flag_forcing"] = False
             elif len(conf["data"]["forcing_variables"]) > 0:
                 conf["data"]["flag_forcing"] = True
-                assert (
-                    "save_loc_forcing" in conf["data"]
-                ), "forcing var save locations ('save_loc_forcing') is missing from conf['data']"
+                assert "save_loc_forcing" in conf["data"], (
+                    "forcing var save locations ('save_loc_forcing') is missing from conf['data']"
+                )
             else:
                 conf["data"]["flag_forcing"] = False
         else:
@@ -279,9 +279,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 conf["data"]["flag_static"] = False
             elif len(conf["data"]["static_variables"]) > 0:
                 conf["data"]["flag_static"] = True
-                assert (
-                    "save_loc_static" in conf["data"]
-                ), "static var save locations ('save_loc_static') is missing from conf['data']"
+                assert "save_loc_static" in conf["data"], (
+                    "static var save locations ('save_loc_static') is missing from conf['data']"
+                )
             else:
                 conf["data"]["flag_static"] = False
         else:
@@ -345,13 +345,13 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
 
             # 'valid_years' is required even for conf['trainer']['skip_validation']: True
             # 'valid_years' and 'train_years' can overlap
-            assert (
-                "valid_years" in conf["data"]
-            ), "year range for validation ('valid_years') is missing from conf['data']"
+            assert "valid_years" in conf["data"], (
+                "year range for validation ('valid_years') is missing from conf['data']"
+            )
 
-            assert (
-                "forecast_len" in conf["data"]
-            ), "Number of time frames for loss compute ('forecast_len') is missing from conf['data']"
+            assert "forecast_len" in conf["data"], (
+                "Number of time frames for loss compute ('forecast_len') is missing from conf['data']"
+            )
 
             if "valid_history_len" not in conf["data"]:
                 # use "history_len" for "valid_history_len"
@@ -375,9 +375,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 conf["data"]["total_time_steps"] = conf["data"]["forecast_len"]
 
         assert "history_len" in conf["data"], "Number of input time frames ('history_len') is missing from conf['data']"
-        assert (
-            "lead_time_periods" in conf["data"]
-        ), "Number of forecast hours ('lead_time_periods') is missing from conf['data']"
+        assert "lead_time_periods" in conf["data"], (
+            "Number of forecast hours ('lead_time_periods') is missing from conf['data']"
+        )
         assert "scaler_type" in conf["data"], "'scaler_type' is missing from conf['data']"
 
         if conf["data"]["scaler_type"] == "std_new":
@@ -521,13 +521,13 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
 
     # SKEBS
     if conf["model"]["post_conf"]["skebs"]["activate"]:
-        assert (
-            "freeze_base_model_weights" in conf["model"]["post_conf"]["skebs"]
-        ), "need to specify freeze_base_model_weights in skebs config"
+        assert "freeze_base_model_weights" in conf["model"]["post_conf"]["skebs"], (
+            "need to specify freeze_base_model_weights in skebs config"
+        )
 
-        assert (
-            conf["trainer"]["train_batch_size"] == conf["trainer"]["valid_batch_size"]
-        ), "train and valid batch sizes need to be the same for skebs"
+        assert conf["trainer"]["train_batch_size"] == conf["trainer"]["valid_batch_size"], (
+            "train and valid batch sizes need to be the same for skebs"
+        )
 
         # setup backscatter writing
         conf["model"]["post_conf"]["predict"] = {k: v for k, v in conf["predict"].items()}
@@ -615,19 +615,19 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
         conf["model"]["post_conf"]["global_mass_fixer"].setdefault("midpoint", False)
         conf["model"]["post_conf"]["global_mass_fixer"].setdefault("grid_type", "pressure")
 
-        assert (
-            "fix_level_num" in conf["model"]["post_conf"]["global_mass_fixer"]
-        ), "Must specifiy what level to fix on specific total water"
+        assert "fix_level_num" in conf["model"]["post_conf"]["global_mass_fixer"], (
+            "Must specifiy what level to fix on specific total water"
+        )
 
         if conf["model"]["post_conf"]["global_mass_fixer"]["simple_demo"] is False:
-            assert (
-                "lon_lat_level_name" in conf["model"]["post_conf"]["global_mass_fixer"]
-            ), "Must specifiy var names for lat/lon/level in physics reference file"
+            assert "lon_lat_level_name" in conf["model"]["post_conf"]["global_mass_fixer"], (
+                "Must specifiy var names for lat/lon/level in physics reference file"
+            )
 
         if conf["model"]["post_conf"]["global_mass_fixer"]["grid_type"] == "sigma":
-            assert (
-                "surface_pressure_name" in conf["model"]["post_conf"]["global_mass_fixer"]
-            ), "Must specifiy surface pressure var name when using hybrid sigma-pressure coordinates"
+            assert "surface_pressure_name" in conf["model"]["post_conf"]["global_mass_fixer"], (
+                "Must specifiy surface pressure var name when using hybrid sigma-pressure coordinates"
+            )
 
         q_inds = [
             i_var
@@ -661,14 +661,14 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
         conf["model"]["post_conf"]["global_water_fixer"].setdefault("grid_type", "pressure")
 
         if conf["model"]["post_conf"]["global_water_fixer"]["simple_demo"] is False:
-            assert (
-                "lon_lat_level_name" in conf["model"]["post_conf"]["global_water_fixer"]
-            ), "Must specifiy var names for lat/lon/level in physics reference file"
+            assert "lon_lat_level_name" in conf["model"]["post_conf"]["global_water_fixer"], (
+                "Must specifiy var names for lat/lon/level in physics reference file"
+            )
 
         if conf["model"]["post_conf"]["global_water_fixer"]["grid_type"] == "sigma":
-            assert (
-                "surface_pressure_name" in conf["model"]["post_conf"]["global_water_fixer"]
-            ), "Must specifiy surface pressure var name when using hybrid sigma-pressure coordinates"
+            assert "surface_pressure_name" in conf["model"]["post_conf"]["global_water_fixer"], (
+                "Must specifiy surface pressure var name when using hybrid sigma-pressure coordinates"
+            )
         q_inds = [
             i_var
             for i_var, var in enumerate(varname_output)
@@ -718,14 +718,14 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
         conf["model"]["post_conf"]["global_energy_fixer"].setdefault("grid_type", "pressure")
 
         if conf["model"]["post_conf"]["global_energy_fixer"]["simple_demo"] is False:
-            assert (
-                "lon_lat_level_name" in conf["model"]["post_conf"]["global_energy_fixer"]
-            ), "Must specifiy var names for lat/lon/level in physics reference file"
+            assert "lon_lat_level_name" in conf["model"]["post_conf"]["global_energy_fixer"], (
+                "Must specifiy var names for lat/lon/level in physics reference file"
+            )
 
         if conf["model"]["post_conf"]["global_energy_fixer"]["grid_type"] == "sigma":
-            assert (
-                "surface_pressure_name" in conf["model"]["post_conf"]["global_energy_fixer"]
-            ), "Must specifiy surface pressure var name when using hybrid sigma-pressure coordinates"
+            assert "surface_pressure_name" in conf["model"]["post_conf"]["global_energy_fixer"], (
+                "Must specifiy surface pressure var name when using hybrid sigma-pressure coordinates"
+            )
 
         T_inds = [
             i_var
@@ -804,9 +804,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
             assert "lon_lat_level_name" in cfg_ud, "Must specify var names for lat/lon/level in physics reference file"
 
         if cfg_ud["grid_type"] == "sigma":
-            assert (
-                "surface_pressure_name" in cfg_ud
-            ), "Must specify surface pressure var name when using hybrid sigma-pressure coordinates"
+            assert "surface_pressure_name" in cfg_ud, (
+                "Must specify surface pressure var name when using hybrid sigma-pressure coordinates"
+            )
 
         def _find_ind(name_key, single=False):
             inds = [i for i, v in enumerate(varname_output) if v in cfg_ud[name_key]]
@@ -846,21 +846,21 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
         assert "load_weights" in conf["trainer"], "must specify 'load_weights' in conf['trainer']"
         assert "learning_rate" in conf["trainer"], "must specify 'learning_rate' in conf['trainer']"
 
-        assert (
-            "batches_per_epoch" in conf["trainer"]
-        ), "Number of training batches per epoch ('batches_per_epoch') is missing from onf['trainer']"
+        assert "batches_per_epoch" in conf["trainer"], (
+            "Number of training batches per epoch ('batches_per_epoch') is missing from onf['trainer']"
+        )
 
-        assert (
-            "train_batch_size" in conf["trainer"]
-        ), "Training set batch size ('train_batch_size') is missing from onf['trainer']"
+        assert "train_batch_size" in conf["trainer"], (
+            "Training set batch size ('train_batch_size') is missing from onf['trainer']"
+        )
 
         if "ensemble_size" not in conf["trainer"]:
             conf["trainer"]["ensemble_size"] = 1  # default value of 1 means deterministic training
 
         if conf["trainer"]["ensemble_size"] > 1:
-            assert (
-                conf["loss"]["training_loss"] in ["KCRPS", "almost-fair-crps"]
-            ), f"""{conf["loss"]["training_loss"]} loss incompatible with ensemble training. ensemble_size is {conf["trainer"]["ensemble_size"]}"""
+            assert conf["loss"]["training_loss"] in ["KCRPS", "almost-fair-crps"], (
+                f"""{conf["loss"]["training_loss"]} loss incompatible with ensemble training. ensemble_size is {conf["trainer"]["ensemble_size"]}"""
+            )
 
         if "load_scaler" not in conf["trainer"]:
             conf["trainer"]["load_scaler"] = False
@@ -888,13 +888,13 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
 
         if conf["trainer"]["skip_validation"] is False:
             # do not skip validaiton
-            assert (
-                "valid_batch_size" in conf["trainer"]
-            ), "Validation set batch size ('valid_batch_size') is missing from conf['trainer']"
+            assert "valid_batch_size" in conf["trainer"], (
+                "Validation set batch size ('valid_batch_size') is missing from conf['trainer']"
+            )
 
-            assert (
-                "valid_batches_per_epoch" in conf["trainer"]
-            ), "Number of validation batches per epoch ('valid_batches_per_epoch') is missing from conf['trainer']"
+            assert "valid_batches_per_epoch" in conf["trainer"], (
+                "Number of validation batches per epoch ('valid_batches_per_epoch') is missing from conf['trainer']"
+            )
 
         if "save_metric_vars" not in conf["trainer"]:
             conf["trainer"]["save_metric_vars"] = []  # averaged metrics only
@@ -906,21 +906,21 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
                 # lr will be controlled by scheduler
                 conf["trainer"]["update_learning_rate"] = False
 
-                assert (
-                    "scheduler" in conf["trainer"]
-                ), "must specify 'scheduler' in conf['trainer'] when a scheduler is used"
+                assert "scheduler" in conf["trainer"], (
+                    "must specify 'scheduler' in conf['trainer'] when a scheduler is used"
+                )
 
-                assert (
-                    "reload_epoch" in conf["trainer"]
-                ), "must specify 'reload_epoch' in conf['trainer'] when a scheduler is used"
+                assert "reload_epoch" in conf["trainer"], (
+                    "must specify 'reload_epoch' in conf['trainer'] when a scheduler is used"
+                )
 
-                assert (
-                    "load_optimizer" in conf["trainer"]
-                ), "must specify 'load_optimizer' in conf['trainer'] when a scheduler is used"
+                assert "load_optimizer" in conf["trainer"], (
+                    "must specify 'load_optimizer' in conf['trainer'] when a scheduler is used"
+                )
 
-                assert (
-                    "load_scheduler" in conf["trainer"]
-                ), "must specify 'load_scheduler' in conf['trainer'] when a scheduler is used"
+                assert "load_scheduler" in conf["trainer"], (
+                    "must specify 'load_scheduler' in conf['trainer'] when a scheduler is used"
+                )
 
             # ------------------------------------------------------------------------------ #
             else:
@@ -989,9 +989,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
             assert "use_variable_weights" in conf["loss"], "must specify 'use_variable_weights' in conf['loss']"
 
             if conf["loss"]["use_variable_weights"]:
-                assert (
-                    "variable_weights" in conf["loss"]
-                ), "must specify 'variable_weights' in conf['loss'] if 'use_variable_weights': True"
+                assert "variable_weights" in conf["loss"], (
+                    "must specify 'variable_weights' in conf['loss'] if 'use_variable_weights': True"
+                )
 
                 # ----------------------------------------------------------------------------------------- #
                 # check and reorganize variable weights
@@ -1074,9 +1074,9 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
 
         else:
             assert "forecasts" in conf["predict"], "Rollout settings ('forecasts') is missing from conf['predict']"
-            assert (
-                "save_forecast" in conf["predict"]
-            ), "Rollout save location ('save_forecast') is missing from conf['predict']"
+            assert "save_forecast" in conf["predict"], (
+                "Rollout save location ('save_forecast') is missing from conf['predict']"
+            )
 
             conf["predict"]["save_forecast"] = os.path.expandvars(conf["predict"]["save_forecast"])
 
@@ -1188,17 +1188,17 @@ def training_data_check(conf, print_summary=False):
         valid_dyn_forcing_files = [file for file in dyn_forcing_files if any(year in file for year in valid_years)]
 
         for i_year, year in enumerate(train_years):
-            assert (
-                year in train_dyn_forcing_files[i_year]
-            ), "[Year {}] is missing from [dynamic forcing files {}]".format(
-                year, conf["data"]["save_loc_dynamic_forcing"]
+            assert year in train_dyn_forcing_files[i_year], (
+                "[Year {}] is missing from [dynamic forcing files {}]".format(
+                    year, conf["data"]["save_loc_dynamic_forcing"]
+                )
             )
 
         for i_year, year in enumerate(valid_years):
-            assert (
-                year in valid_dyn_forcing_files[i_year]
-            ), "[Year {}] is missing from [dynamic forcing files {}]".format(
-                year, conf["data"]["save_loc_dynamic_forcing"]
+            assert year in valid_dyn_forcing_files[i_year], (
+                "[Year {}] is missing from [dynamic forcing files {}]".format(
+                    year, conf["data"]["save_loc_dynamic_forcing"]
+                )
             )
 
     ## diagnostic files
@@ -1230,9 +1230,9 @@ def training_data_check(conf, print_summary=False):
     ds_upper_air = get_forward_data(train_ERA_files[0])
     varnames_upper_air = list(ds_upper_air.keys())
 
-    assert all(
-        varname in varnames_upper_air for varname in conf["data"]["variables"]
-    ), "upper-air variables [{}] are not fully covered by conf['data']['save_loc']".format(conf["data"]["variables"])
+    assert all(varname in varnames_upper_air for varname in conf["data"]["variables"]), (
+        "upper-air variables [{}] are not fully covered by conf['data']['save_loc']".format(conf["data"]["variables"])
+    )
 
     # assign the upper_air vars in yaml if it can pass checks
     varnames_upper_air = conf["data"]["variables"]
@@ -1246,10 +1246,10 @@ def training_data_check(conf, print_summary=False):
         ds_surface = get_forward_data(train_surface_files[0])
         varnames_surface = list(ds_surface.keys())
 
-        assert all(
-            varname in varnames_surface for varname in conf["data"]["surface_variables"]
-        ), "Surface variables [{}] are not fully covered by conf['data']['save_loc_surface']".format(
-            conf["data"]["surface_variables"]
+        assert all(varname in varnames_surface for varname in conf["data"]["surface_variables"]), (
+            "Surface variables [{}] are not fully covered by conf['data']['save_loc_surface']".format(
+                conf["data"]["surface_variables"]
+            )
         )
 
         all_vars += conf["data"]["surface_variables"]
@@ -1259,10 +1259,10 @@ def training_data_check(conf, print_summary=False):
         ds_dyn_forcing = get_forward_data(train_dyn_forcing_files[0])
         varnames_dyn_forcing = list(ds_dyn_forcing.keys())
 
-        assert all(
-            varname in varnames_dyn_forcing for varname in conf["data"]["dynamic_forcing_variables"]
-        ), "Dynamic forcing variables [{}] are not fully covered by conf['data']['save_loc_dynamic_forcing']".format(
-            conf["data"]["dynamic_forcing_variables"]
+        assert all(varname in varnames_dyn_forcing for varname in conf["data"]["dynamic_forcing_variables"]), (
+            "Dynamic forcing variables [{}] are not fully covered by conf['data']['save_loc_dynamic_forcing']".format(
+                conf["data"]["dynamic_forcing_variables"]
+            )
         )
 
         all_vars += conf["data"]["dynamic_forcing_variables"]
@@ -1272,10 +1272,10 @@ def training_data_check(conf, print_summary=False):
         ds_diagnostic = get_forward_data(train_diagnostic_files[0])
         varnames_diagnostic = list(ds_diagnostic.keys())
 
-        assert all(
-            varname in varnames_diagnostic for varname in conf["data"]["diagnostic_variables"]
-        ), "Diagnostic variables [{}] are not fully covered by conf['data']['save_loc_diagnostic']".format(
-            conf["data"]["diagnostic_variables"]
+        assert all(varname in varnames_diagnostic for varname in conf["data"]["diagnostic_variables"]), (
+            "Diagnostic variables [{}] are not fully covered by conf['data']['save_loc_diagnostic']".format(
+                conf["data"]["diagnostic_variables"]
+            )
         )
 
         all_vars += conf["data"]["diagnostic_variables"]
@@ -1285,10 +1285,10 @@ def training_data_check(conf, print_summary=False):
         ds_forcing = get_forward_data(conf["data"]["save_loc_forcing"])
         varnames_forcing = list(ds_forcing.keys())
 
-        assert all(
-            varname in varnames_forcing for varname in conf["data"]["forcing_variables"]
-        ), "Forcing variables [{}] are not fully covered by conf['data']['save_loc_forcing']".format(
-            conf["data"]["forcing_variables"]
+        assert all(varname in varnames_forcing for varname in conf["data"]["forcing_variables"]), (
+            "Forcing variables [{}] are not fully covered by conf['data']['save_loc_forcing']".format(
+                conf["data"]["forcing_variables"]
+            )
         )
 
     # static variables
@@ -1296,19 +1296,19 @@ def training_data_check(conf, print_summary=False):
         ds_static = get_forward_data(conf["data"]["save_loc_static"])
         varnames_static = list(ds_static.keys())
 
-        assert all(
-            varname in varnames_static for varname in conf["data"]["static_variables"]
-        ), "Static variables [{}] are not fully covered by conf['data']['save_loc_static']".format(
-            conf["data"]["static_variables"]
+        assert all(varname in varnames_static for varname in conf["data"]["static_variables"]), (
+            "Static variables [{}] are not fully covered by conf['data']['save_loc_static']".format(
+                conf["data"]["static_variables"]
+            )
         )
 
     # comparing all_vars against mean, std files
     ds_mean = get_forward_data(conf["data"]["mean_path"])
     varname_ds_mean = list(ds_mean.keys())
 
-    assert all(
-        varname in varname_ds_mean for varname in all_vars
-    ), "Variables are not fully covered by conf['data']['mean_path']"
+    assert all(varname in varname_ds_mean for varname in all_vars), (
+        "Variables are not fully covered by conf['data']['mean_path']"
+    )
 
     ds_std = get_forward_data(conf["data"]["std_path"])
     varname_ds_std = list(ds_std.keys())
@@ -1317,9 +1317,9 @@ def training_data_check(conf, print_summary=False):
         if varname not in varname_ds_std:
             missing_vars.append(varname)
     missing_var_str = ", ".join(missing_vars)
-    assert all(
-        varname in varname_ds_std for varname in all_vars
-    ), f"Variables {missing_var_str} are not fully covered by conf['data']['std_path']"
+    assert all(varname in varname_ds_std for varname in all_vars), (
+        f"Variables {missing_var_str} are not fully covered by conf['data']['std_path']"
+    )
 
     if print_summary:
         print("Variable name checking passed")
@@ -1338,56 +1338,56 @@ def training_data_check(conf, print_summary=False):
         coord_surface = list(ds_surface.coords.keys())
         coord_surface = remove_string_by_pattern(coord_surface, "time")
 
-        assert all(
-            coord_name in coord_upper_air for coord_name in coord_surface
-        ), "Surface file coordinate names mismatched with upper-air files"
+        assert all(coord_name in coord_upper_air for coord_name in coord_surface), (
+            "Surface file coordinate names mismatched with upper-air files"
+        )
 
         for coord_name in coord_surface:
-            assert ds_upper_air.coords[coord_name].equals(
-                ds_surface.coords[coord_name]
-            ), "coordinate {} mismatched between upper-air and surface files".format(coord_name)
+            assert ds_upper_air.coords[coord_name].equals(ds_surface.coords[coord_name]), (
+                "coordinate {} mismatched between upper-air and surface files".format(coord_name)
+            )
 
     # dyn forcing files
     if conf["data"]["flag_dyn_forcing"]:
         coord_dyn_forcing = list(ds_dyn_forcing.coords.keys())
         coord_dyn_forcing = remove_string_by_pattern(coord_dyn_forcing, "time")
 
-        assert all(
-            coord_name in coord_upper_air for coord_name in coord_dyn_forcing
-        ), "Dynamic forcing file coordinate names mismatched with upper-air files"
+        assert all(coord_name in coord_upper_air for coord_name in coord_dyn_forcing), (
+            "Dynamic forcing file coordinate names mismatched with upper-air files"
+        )
 
         for coord_name in coord_dyn_forcing:
-            assert ds_upper_air.coords[coord_name].equals(
-                ds_dyn_forcing.coords[coord_name]
-            ), "coordinate {} mismatched between upper-air and dynamic forcing files".format(coord_name)
+            assert ds_upper_air.coords[coord_name].equals(ds_dyn_forcing.coords[coord_name]), (
+                "coordinate {} mismatched between upper-air and dynamic forcing files".format(coord_name)
+            )
 
     # diagnostic files
     if conf["data"]["flag_diagnostic"]:
         coord_diagnostic = list(ds_diagnostic.coords.keys())
         coord_diagnostic = remove_string_by_pattern(coord_diagnostic, "time")
 
-        assert all(
-            coord_name in coord_upper_air for coord_name in coord_diagnostic
-        ), "Diagnostic file coordinate names mismatched with upper-air files"
+        assert all(coord_name in coord_upper_air for coord_name in coord_diagnostic), (
+            "Diagnostic file coordinate names mismatched with upper-air files"
+        )
 
         for coord_name in coord_diagnostic:
-            assert ds_upper_air.coords[coord_name].equals(
-                ds_diagnostic.coords[coord_name]
-            ), "coordinate {} mismatched between upper-air and diagnostic files".format(coord_name)
+            assert ds_upper_air.coords[coord_name].equals(ds_diagnostic.coords[coord_name]), (
+                "coordinate {} mismatched between upper-air and diagnostic files".format(coord_name)
+            )
 
     # forcing files
     if conf["data"]["flag_forcing"]:
         coord_forcing = list(ds_forcing.coords.keys())
         coord_forcing = remove_string_by_pattern(coord_forcing, "time")
 
-        assert all(
-            coord_name in coord_upper_air for coord_name in coord_forcing
-        ), "Forcing file coordinate names mismatched with upper-air files"
+        assert all(coord_name in coord_upper_air for coord_name in coord_forcing), (
+            "Forcing file coordinate names mismatched with upper-air files"
+        )
 
         for coord_name in coord_forcing:
-            assert ds_upper_air.coords[coord_name].equals(
-                ds_forcing.coords[coord_name]
-            ), "coordinate {} mismatched between upper-air and forcing files".format(coord_name)
+            assert ds_upper_air.coords[coord_name].equals(ds_forcing.coords[coord_name]), (
+                "coordinate {} mismatched between upper-air and forcing files".format(coord_name)
+            )
 
         # ============================================== #
         # !! assumed subdaily inputs, may need to fix !! #
@@ -1399,58 +1399,58 @@ def training_data_check(conf, print_summary=False):
         coord_static = list(ds_static.coords.keys())
         coord_static = remove_string_by_pattern(coord_static, "time")
 
-        assert all(
-            coord_name in coord_upper_air for coord_name in coord_static
-        ), "Static file coordinate names mismatched with upper-air files"
+        assert all(coord_name in coord_upper_air for coord_name in coord_static), (
+            "Static file coordinate names mismatched with upper-air files"
+        )
 
         for coord_name in coord_static:
-            assert ds_upper_air.coords[coord_name].equals(
-                ds_static.coords[coord_name]
-            ), "coordinate {} mismatched between upper-air and static files".format(coord_name)
+            assert ds_upper_air.coords[coord_name].equals(ds_static.coords[coord_name]), (
+                "coordinate {} mismatched between upper-air and static files".format(coord_name)
+            )
 
     # zscore mean file (no time coordinate)
     coord_mean = list(ds_mean.coords.keys())
     coord_mean = remove_string_by_pattern(coord_mean, "time")
 
-    assert all(
-        coord_name in coord_upper_air for coord_name in coord_mean
-    ), "zscore mean file coordinate names mismatched with upper-air files"
+    assert all(coord_name in coord_upper_air for coord_name in coord_mean), (
+        "zscore mean file coordinate names mismatched with upper-air files"
+    )
 
     for coord_name in coord_mean:
-        assert ds_upper_air.coords[coord_name].equals(
-            ds_mean.coords[coord_name]
-        ), "coordinate {} mismatched between upper-air and mean files".format(coord_name)
+        assert ds_upper_air.coords[coord_name].equals(ds_mean.coords[coord_name]), (
+            "coordinate {} mismatched between upper-air and mean files".format(coord_name)
+        )
 
     # zscore std file (no time coordinate)
     coord_std = list(ds_std.coords.keys())
     coord_std = remove_string_by_pattern(coord_std, "time")
 
-    assert all(
-        coord_name in coord_upper_air for coord_name in coord_std
-    ), "zscore std file coordinate names mismatched with upper-air files"
+    assert all(coord_name in coord_upper_air for coord_name in coord_std), (
+        "zscore std file coordinate names mismatched with upper-air files"
+    )
 
     for coord_name in coord_std:
-        assert ds_upper_air.coords[coord_name].equals(
-            ds_std.coords[coord_name]
-        ), "coordinate {} mismatched between upper-air and std files".format(coord_name)
+        assert ds_upper_air.coords[coord_name].equals(ds_std.coords[coord_name]), (
+            "coordinate {} mismatched between upper-air and std files".format(coord_name)
+        )
 
     # lat / lon file
     ds_weights = get_forward_data(conf["loss"]["latitude_weights"])
     coord_latlon = list(ds_weights.coords.keys())
     coord_latlon = remove_string_by_pattern(coord_latlon, "time")
 
-    assert all(
-        coord_name in coord_upper_air for coord_name in coord_latlon
-    ), "conf['loss']['latitude_weights'] file coordinate names mismatched with upper-air files"
+    assert all(coord_name in coord_upper_air for coord_name in coord_latlon), (
+        "conf['loss']['latitude_weights'] file coordinate names mismatched with upper-air files"
+    )
 
     # model level consistency final checks
     N_level_mean = len(ds_mean[varnames_upper_air[0]].values)
     N_level_model = conf["model"]["levels"]
 
-    assert (
-        N_level_mean == N_level_model
-    ), "number of upper air levels mismatched between model config {} and input data {}".format(
-        N_level_model, N_level_mean
+    assert N_level_mean == N_level_model, (
+        "number of upper air levels mismatched between model config {} and input data {}".format(
+            N_level_model, N_level_mean
+        )
     )
 
     if print_summary:
@@ -1534,9 +1534,9 @@ def predict_data_check(conf, print_summary=False):
     ds_upper_air = get_forward_data(pred_ERA_files[0])
     varnames_upper_air = list(ds_upper_air.keys())
 
-    assert all(
-        varname in varnames_upper_air for varname in conf["data"]["variables"]
-    ), "upper-air variables [{}] are not fully covered by conf['data']['save_loc']".format(conf["data"]["variables"])
+    assert all(varname in varnames_upper_air for varname in conf["data"]["variables"]), (
+        "upper-air variables [{}] are not fully covered by conf['data']['save_loc']".format(conf["data"]["variables"])
+    )
 
     # collecting all variables that require zscores
     # deep copy to avoid changing conf['data'] by accident
@@ -1547,10 +1547,10 @@ def predict_data_check(conf, print_summary=False):
         ds_surface = get_forward_data(pred_surface_files[0])
         varnames_surface = list(ds_surface.keys())
 
-        assert all(
-            varname in varnames_surface for varname in conf["data"]["surface_variables"]
-        ), "Surface variables [{}] are not fully covered by conf['data']['save_loc_surface']".format(
-            conf["data"]["surface_variables"]
+        assert all(varname in varnames_surface for varname in conf["data"]["surface_variables"]), (
+            "Surface variables [{}] are not fully covered by conf['data']['save_loc_surface']".format(
+                conf["data"]["surface_variables"]
+            )
         )
 
         all_vars += conf["data"]["surface_variables"]
@@ -1560,10 +1560,10 @@ def predict_data_check(conf, print_summary=False):
         ds_dyn_forcing = get_forward_data(pred_dyn_forcing_files[0])
         varnames_dyn_forcing = list(ds_dyn_forcing.keys())
 
-        assert all(
-            varname in varnames_dyn_forcing for varname in conf["data"]["dynamic_forcing_variables"]
-        ), "Dynamic forcing variables [{}] are not fully covered by conf['data']['save_loc_dynamic_forcing']".format(
-            conf["data"]["dynamic_forcing_variables"]
+        assert all(varname in varnames_dyn_forcing for varname in conf["data"]["dynamic_forcing_variables"]), (
+            "Dynamic forcing variables [{}] are not fully covered by conf['data']['save_loc_dynamic_forcing']".format(
+                conf["data"]["dynamic_forcing_variables"]
+            )
         )
 
         all_vars += conf["data"]["dynamic_forcing_variables"]
@@ -1577,10 +1577,10 @@ def predict_data_check(conf, print_summary=False):
         ds_forcing = get_forward_data(conf["data"]["save_loc_forcing"])
         varnames_forcing = list(ds_forcing.keys())
 
-        assert all(
-            varname in varnames_forcing for varname in conf["data"]["forcing_variables"]
-        ), "Forcing variables [{}] are not fully covered by conf['data']['save_loc_forcing']".format(
-            conf["data"]["forcing_variables"]
+        assert all(varname in varnames_forcing for varname in conf["data"]["forcing_variables"]), (
+            "Forcing variables [{}] are not fully covered by conf['data']['save_loc_forcing']".format(
+                conf["data"]["forcing_variables"]
+            )
         )
 
     # static variables
@@ -1588,26 +1588,26 @@ def predict_data_check(conf, print_summary=False):
         ds_static = get_forward_data(conf["data"]["save_loc_static"])
         varnames_static = list(ds_static.keys())
 
-        assert all(
-            varname in varnames_static for varname in conf["data"]["static_variables"]
-        ), "Static variables [{}] are not fully covered by conf['data']['save_loc_static']".format(
-            conf["data"]["static_variables"]
+        assert all(varname in varnames_static for varname in conf["data"]["static_variables"]), (
+            "Static variables [{}] are not fully covered by conf['data']['save_loc_static']".format(
+                conf["data"]["static_variables"]
+            )
         )
 
     # comparing all_vars against mean, std files
     ds_mean = get_forward_data(conf["data"]["mean_path"])
     varname_ds_mean = list(ds_mean.keys())
 
-    assert all(
-        varname in varname_ds_mean for varname in all_vars
-    ), "Variables are not fully covered by conf['data']['mean_path']"
+    assert all(varname in varname_ds_mean for varname in all_vars), (
+        "Variables are not fully covered by conf['data']['mean_path']"
+    )
 
     ds_std = get_forward_data(conf["data"]["std_path"])
     varname_ds_std = list(ds_std.keys())
 
-    assert all(
-        varname in varname_ds_std for varname in all_vars
-    ), "Variables are not fully covered by conf['data']['std_path']"
+    assert all(varname in varname_ds_std for varname in all_vars), (
+        "Variables are not fully covered by conf['data']['std_path']"
+    )
 
     if print_summary:
         print("Variable name checking passed")
@@ -1626,42 +1626,42 @@ def predict_data_check(conf, print_summary=False):
         coord_surface = list(ds_surface.coords.keys())
         coord_surface = remove_string_by_pattern(coord_surface, "time")
 
-        assert all(
-            coord_name in coord_upper_air for coord_name in coord_surface
-        ), "Surface file coordinate names mismatched with upper-air files"
+        assert all(coord_name in coord_upper_air for coord_name in coord_surface), (
+            "Surface file coordinate names mismatched with upper-air files"
+        )
 
         for coord_name in coord_surface:
-            assert ds_upper_air.coords[coord_name].equals(
-                ds_surface.coords[coord_name]
-            ), "coordinate {} mismatched between upper-air and surface files".format(coord_name)
+            assert ds_upper_air.coords[coord_name].equals(ds_surface.coords[coord_name]), (
+                "coordinate {} mismatched between upper-air and surface files".format(coord_name)
+            )
 
     # dyn forcing files
     if conf["data"]["flag_dyn_forcing"]:
         coord_dyn_forcing = list(ds_dyn_forcing.coords.keys())
         coord_dyn_forcing = remove_string_by_pattern(coord_dyn_forcing, "time")
 
-        assert all(
-            coord_name in coord_upper_air for coord_name in coord_dyn_forcing
-        ), "Dynamic forcing file coordinate names mismatched with upper-air files"
+        assert all(coord_name in coord_upper_air for coord_name in coord_dyn_forcing), (
+            "Dynamic forcing file coordinate names mismatched with upper-air files"
+        )
 
         for coord_name in coord_dyn_forcing:
-            assert ds_upper_air.coords[coord_name].equals(
-                ds_dyn_forcing.coords[coord_name]
-            ), "coordinate {} mismatched between upper-air and dynamic forcing files".format(coord_name)
+            assert ds_upper_air.coords[coord_name].equals(ds_dyn_forcing.coords[coord_name]), (
+                "coordinate {} mismatched between upper-air and dynamic forcing files".format(coord_name)
+            )
 
     # forcing files
     if conf["data"]["flag_forcing"]:
         coord_forcing = list(ds_forcing.coords.keys())
         coord_forcing = remove_string_by_pattern(coord_forcing, "time")
 
-        assert all(
-            coord_name in coord_upper_air for coord_name in coord_forcing
-        ), "Forcing file coordinate names mismatched with upper-air files"
+        assert all(coord_name in coord_upper_air for coord_name in coord_forcing), (
+            "Forcing file coordinate names mismatched with upper-air files"
+        )
 
         for coord_name in coord_forcing:
-            assert ds_upper_air.coords[coord_name].equals(
-                ds_forcing.coords[coord_name]
-            ), "coordinate {} mismatched between upper-air and forcing files".format(coord_name)
+            assert ds_upper_air.coords[coord_name].equals(ds_forcing.coords[coord_name]), (
+                "coordinate {} mismatched between upper-air and forcing files".format(coord_name)
+            )
 
         # ============================================== #
         # !! assumed subdaily inputs, may need to fix !! #
@@ -1673,49 +1673,49 @@ def predict_data_check(conf, print_summary=False):
         coord_static = list(ds_static.coords.keys())
         coord_static = remove_string_by_pattern(coord_static, "time")
 
-        assert all(
-            coord_name in coord_upper_air for coord_name in coord_static
-        ), "Static file coordinate names mismatched with upper-air files"
+        assert all(coord_name in coord_upper_air for coord_name in coord_static), (
+            "Static file coordinate names mismatched with upper-air files"
+        )
 
         for coord_name in coord_static:
-            assert ds_upper_air.coords[coord_name].equals(
-                ds_static.coords[coord_name]
-            ), "coordinate {} mismatched between upper-air and static files".format(coord_name)
+            assert ds_upper_air.coords[coord_name].equals(ds_static.coords[coord_name]), (
+                "coordinate {} mismatched between upper-air and static files".format(coord_name)
+            )
 
     # zscore mean file (no time coordinate)
     coord_mean = list(ds_mean.coords.keys())
     coord_mean = remove_string_by_pattern(coord_mean, "time")
 
-    assert all(
-        coord_name in coord_upper_air for coord_name in coord_mean
-    ), "zscore mean file coordinate names mismatched with upper-air files"
+    assert all(coord_name in coord_upper_air for coord_name in coord_mean), (
+        "zscore mean file coordinate names mismatched with upper-air files"
+    )
 
     for coord_name in coord_mean:
-        assert ds_upper_air.coords[coord_name].equals(
-            ds_mean.coords[coord_name]
-        ), "coordinate {} mismatched between upper-air and mean files".format(coord_name)
+        assert ds_upper_air.coords[coord_name].equals(ds_mean.coords[coord_name]), (
+            "coordinate {} mismatched between upper-air and mean files".format(coord_name)
+        )
 
     # zscore std file (no time coordinate)
     coord_std = list(ds_std.coords.keys())
     coord_std = remove_string_by_pattern(coord_std, "time")
 
-    assert all(
-        coord_name in coord_upper_air for coord_name in coord_std
-    ), "zscore std file coordinate names mismatched with upper-air files"
+    assert all(coord_name in coord_upper_air for coord_name in coord_std), (
+        "zscore std file coordinate names mismatched with upper-air files"
+    )
 
     for coord_name in coord_std:
-        assert ds_upper_air.coords[coord_name].equals(
-            ds_std.coords[coord_name]
-        ), "coordinate {} mismatched between upper-air and std files".format(coord_name)
+        assert ds_upper_air.coords[coord_name].equals(ds_std.coords[coord_name]), (
+            "coordinate {} mismatched between upper-air and std files".format(coord_name)
+        )
 
     # lat / lon file
     ds_weights = get_forward_data(conf["loss"]["latitude_weights"])
     coord_latlon = list(ds_weights.coords.keys())
     coord_latlon = remove_string_by_pattern(coord_latlon, "time")
 
-    assert all(
-        coord_name in coord_upper_air for coord_name in coord_latlon
-    ), "conf['loss']['latitude_weights'] file coordinate names mismatched with upper-air files"
+    assert all(coord_name in coord_upper_air for coord_name in coord_latlon), (
+        "conf['loss']['latitude_weights'] file coordinate names mismatched with upper-air files"
+    )
 
     if print_summary:
         print("Coordinate checking passed")

--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -1,4 +1,11 @@
-from credit.postblock._postblock import PostBlock, TracerFixer, GlobalMassFixer, GlobalWaterFixer, GlobalEnergyFixer
+from credit.postblock._postblock import (
+    PostBlock,
+    TracerFixer,
+    GlobalMassFixer,
+    GlobalWaterFixer,
+    GlobalEnergyFixer,
+    GlobalEnergyFixerUpDown,
+)
 from credit.postblock.wet_mask_samudra import WetMaskBlock
 
 __all__ = [
@@ -7,5 +14,6 @@ __all__ = [
     "GlobalMassFixer",
     "GlobalWaterFixer",
     "GlobalEnergyFixer",
+    "GlobalEnergyFixerUpDown",
     "WetMaskBlock",
 ]

--- a/credit/postblock/_postblock.py
+++ b/credit/postblock/_postblock.py
@@ -47,6 +47,7 @@ class PostBlock(nn.Module):
             - TracerFixer
             - GlobalMassFixer
             - GlobalEnergyFixer
+            - GlobalEnergyFixerUpDown
 
         """
         super().__init__()
@@ -81,11 +82,18 @@ class PostBlock(nn.Module):
                 opt = GlobalWaterFixer(post_conf)
                 self.operations.append(opt)
 
-        # global energy fixer
+        # global energy fixer (net-flux version)
         if post_conf["global_energy_fixer"]["activate"]:
             if post_conf["global_energy_fixer"]["activate_outside_model"] is False:
                 logger.info("GlobalEnergyFixer registered")
                 opt = GlobalEnergyFixer(post_conf)
+                self.operations.append(opt)
+
+        # global energy fixer (up/down flux version)
+        if post_conf.get("global_energy_fixer_updown", {}).get("activate", False):
+            if post_conf["global_energy_fixer_updown"].get("activate_outside_model", False) is False:
+                logger.info("GlobalEnergyFixerUpDown registered")
+                opt = GlobalEnergyFixerUpDown(post_conf)
                 self.operations.append(opt)
 
     def forward(self, x):
@@ -811,6 +819,216 @@ class GlobalEnergyFixer(nn.Module):
         x["y_pred"] = y_pred
 
         # return dict, 'x' is not touched
+        return x
+
+
+class GlobalEnergyFixerUpDown(nn.Module):
+    """
+    Global energy conservation fixer using explicit up/down flux decomposition.
+
+    Identical correction logic to ``GlobalEnergyFixer`` but uses separate downwelling
+    and upwelling flux indices rather than pre-computed net fluxes.  The net TOA and
+    surface imbalances are formed as:
+
+    .. code-block:: text
+
+        R_T  = (DSWRFtoa  - USWRFtoa  - ULWRFtoa) / N_seconds
+        F_S  = (FSDS_J    - FSUS      + FLDS_J    - FLUS - SHF - LHF) / N_seconds
+
+    where ``*_J`` variables are in J/m² (energy over the timestep) and ``SHF``/``LHF``
+    are positive-upward surface turbulent heat fluxes also in J/m².
+
+    Args:
+        post_conf (dict): config dictionary.  The sub-key ``global_energy_fixer_updown``
+            must be present and contain all specs listed below.
+
+    Config keys (under ``global_energy_fixer_updown``):
+        - ``activate`` / ``activate_outside_model`` / ``simple_demo``
+        - ``midpoint``, ``denorm``, ``surface_geopotential_name``
+        - ``T_inds``, ``q_inds``, ``U_inds``, ``V_inds``
+        - ``sp_inds``  (required when ``grid_type == 'sigma'``)
+        - ``TOA_down_solar_ind``  — DSWRFtoa index in y_pred
+        - ``TOA_up_solar_ind``   — USWRFtoa index in y_pred
+        - ``TOA_up_OLR_ind``     — ULWRFtoa index in y_pred
+        - ``surf_down_solar_ind`` — FSDS_J index in y_pred
+        - ``surf_up_solar_ind``  — FSUS index in y_pred
+        - ``surf_down_LW_ind``   — FLDS_J index in y_pred
+        - ``surf_up_LW_ind``     — FLUS index in y_pred
+        - ``surf_SH_ind``        — SHF  index in y_pred  (positive-upward)
+        - ``surf_LH_ind``        — LHF  index in y_pred  (positive-upward)
+    """
+
+    def __init__(self, post_conf):
+        super().__init__()
+
+        cfg = post_conf["global_energy_fixer_updown"]
+
+        # ------------------------------------------------------------------ #
+        # Grid / physics setup — reuse the same logic as GlobalEnergyFixer
+        if cfg["simple_demo"]:
+            y_demo = np.array([90, 70, 50, 30, 10, -10, -30, -50, -70, -90])
+            x_demo = np.array([0, 20, 40, 60, 80, 100, 120, 140, 160, 180, 200, 220, 240, 260, 280, 300, 320, 340])
+            lon_demo, lat_demo = np.meshgrid(x_demo, y_demo)
+            lon_demo = torch.from_numpy(lon_demo)
+            lat_demo = torch.from_numpy(lat_demo)
+            p_level_demo = torch.from_numpy(np.array([100, 30000, 50000, 70000, 80000, 90000, 100000]))
+            self.flag_sigma_level = False
+            self.flag_midpoint = cfg["midpoint"]
+            self.core_compute = physics_pressure_level(lon_demo, lat_demo, p_level_demo, midpoint=self.flag_midpoint)
+            self.N_seconds = int(post_conf["data"]["lead_time_periods"]) * 3600
+            gph_surf_demo = np.ones((10, 18))
+            self.GPH_surf = torch.from_numpy(gph_surf_demo)
+        else:
+            ds_physics = get_forward_data(post_conf["data"]["save_loc_physics"])
+            lon_lat_level_names = post_conf["global_mass_fixer"]["lon_lat_level_name"]
+            lon2d = torch.from_numpy(ds_physics[lon_lat_level_names[0]].values).float()
+            lat2d = torch.from_numpy(ds_physics[lon_lat_level_names[1]].values).float()
+
+            self.flag_midpoint = post_conf["global_mass_fixer"]["midpoint"]
+
+            if post_conf["global_mass_fixer"]["grid_type"] == "sigma":
+                self.flag_sigma_level = True
+                self.coef_a = torch.from_numpy(ds_physics[lon_lat_level_names[2]].values).float()
+                self.coef_b = torch.from_numpy(ds_physics[lon_lat_level_names[3]].values).float()
+                self.N_levels = len(self.coef_a)
+                if self.flag_midpoint:
+                    self.N_levels = self.N_levels - 1
+                self.core_compute = physics_hybrid_sigma_level(
+                    lon2d, lat2d, self.coef_a, self.coef_b, midpoint=self.flag_midpoint
+                )
+            else:
+                self.flag_sigma_level = False
+                p_level = torch.from_numpy(ds_physics[lon_lat_level_names[2]].values).float()
+                self.N_levels = len(p_level)
+                self.core_compute = physics_pressure_level(lon2d, lat2d, p_level, midpoint=self.flag_midpoint)
+
+            self.N_seconds = int(post_conf["data"]["lead_time_periods"]) * 3600
+
+            varname_gph = cfg["surface_geopotential_name"]
+            self.GPH_surf = torch.from_numpy(ds_physics[varname_gph[0]].values).float()
+
+        # ------------------------------------------------------------------ #
+        # Variable indices — atmosphere state
+        self.T_ind_start = int(cfg["T_inds"][0])
+        self.T_ind_end = int(cfg["T_inds"][-1]) + 1
+        self.q_ind_start = int(cfg["q_inds"][0])
+        self.q_ind_end = int(cfg["q_inds"][-1]) + 1
+        self.U_ind_start = int(cfg["U_inds"][0])
+        self.U_ind_end = int(cfg["U_inds"][-1]) + 1
+        self.V_ind_start = int(cfg["V_inds"][0])
+        self.V_ind_end = int(cfg["V_inds"][-1]) + 1
+
+        if self.flag_sigma_level:
+            self.sp_ind = int(cfg["sp_inds"])
+
+        # ------------------------------------------------------------------ #
+        # Variable indices — up/down fluxes
+        self.TOA_down_solar_ind = int(cfg["TOA_down_solar_ind"])
+        self.TOA_up_solar_ind = int(cfg["TOA_up_solar_ind"])
+        self.TOA_up_OLR_ind = int(cfg["TOA_up_OLR_ind"])
+
+        self.surf_down_solar_ind = int(cfg["surf_down_solar_ind"])
+        self.surf_up_solar_ind = int(cfg["surf_up_solar_ind"])
+        self.surf_down_LW_ind = int(cfg["surf_down_LW_ind"])
+        self.surf_up_LW_ind = int(cfg["surf_up_LW_ind"])
+        self.surf_SH_ind = int(cfg["surf_SH_ind"])
+        self.surf_LH_ind = int(cfg["surf_LH_ind"])
+
+        # ------------------------------------------------------------------ #
+        # Optional denorm scaler
+        if cfg["denorm"]:
+            self.state_trans = load_transforms(post_conf, scaler_only=True)
+        else:
+            self.state_trans = None
+
+    def forward(self, x):
+        x_input = x["x"]
+        y_pred = x["y_pred"]
+        x_input = x_input.detach().to(y_pred.device)
+
+        GPH_surf = self.GPH_surf.to(y_pred.device)
+        N_vars = y_pred.shape[1]
+
+        if self.state_trans:
+            x_input = self.state_trans.inverse_transform_input(x_input)
+            y_pred = self.state_trans.inverse_transform(y_pred)
+
+        # ------------------------------------------------------------------ #
+        # Atmosphere state at t0 and t1
+        T_input = x_input[:, self.T_ind_start : self.T_ind_end, -1, ...]
+        q_input = x_input[:, self.q_ind_start : self.q_ind_end, -1, ...]
+        U_input = x_input[:, self.U_ind_start : self.U_ind_end, -1, ...]
+        V_input = x_input[:, self.V_ind_start : self.V_ind_end, -1, ...]
+
+        T_pred = y_pred[:, self.T_ind_start : self.T_ind_end, 0, ...]
+        q_pred = y_pred[:, self.q_ind_start : self.q_ind_end, 0, ...]
+        U_pred = y_pred[:, self.U_ind_start : self.U_ind_end, 0, ...]
+        V_pred = y_pred[:, self.V_ind_start : self.V_ind_end, 0, ...]
+
+        if self.flag_sigma_level:
+            sp_input = x_input[:, self.sp_ind, -1, ...]
+            sp_pred = y_pred[:, self.sp_ind, 0, ...]
+
+        # ------------------------------------------------------------------ #
+        # Latent heat, potential energy, kinetic energy
+        CP_t0 = (1 - q_input) * CP_DRY + q_input * CP_VAPOR
+        CP_t1 = (1 - q_pred) * CP_DRY + q_pred * CP_VAPOR
+
+        ken_t0 = 0.5 * (U_input**2 + V_input**2)
+        ken_t1 = 0.5 * (U_pred**2 + V_pred**2)
+
+        E_qgk_t0 = LH_WATER * q_input + GPH_surf + ken_t0
+        E_qgk_t1 = LH_WATER * q_pred + GPH_surf + ken_t1
+
+        # ------------------------------------------------------------------ #
+        # TOA net flux: down_SW - up_SW - up_LW  (positive = energy in)
+        TOA_down_solar = y_pred[:, self.TOA_down_solar_ind, 0, ...]
+        TOA_up_solar = y_pred[:, self.TOA_up_solar_ind, 0, ...]
+        TOA_up_OLR = y_pred[:, self.TOA_up_OLR_ind, 0, ...]
+        R_T = (TOA_down_solar - TOA_up_solar - TOA_up_OLR) / self.N_seconds
+        R_T_sum = self.core_compute.weighted_sum(R_T, axis=(-2, -1))
+
+        # Surface net flux: (down_SW - up_SW) + (down_LW - up_LW) - SHF - LHF
+        # (positive = energy into atmosphere from surface)
+        surf_down_solar = y_pred[:, self.surf_down_solar_ind, 0, ...]
+        surf_up_solar = y_pred[:, self.surf_up_solar_ind, 0, ...]
+        surf_down_LW = y_pred[:, self.surf_down_LW_ind, 0, ...]
+        surf_up_LW = y_pred[:, self.surf_up_LW_ind, 0, ...]
+        surf_SH = y_pred[:, self.surf_SH_ind, 0, ...]
+        surf_LH = y_pred[:, self.surf_LH_ind, 0, ...]
+        F_S = (surf_down_solar - surf_up_solar + surf_down_LW - surf_up_LW - surf_SH - surf_LH) / self.N_seconds
+        F_S_sum = self.core_compute.weighted_sum(F_S, axis=(-2, -1))
+
+        # ------------------------------------------------------------------ #
+        # Column total energy and correction ratio
+        E_level_t0 = CP_t0 * T_input + E_qgk_t0
+        E_level_t1 = CP_t1 * T_pred + E_qgk_t1
+
+        if self.flag_sigma_level:
+            TE_t0 = self.core_compute.integral(E_level_t0, sp_input) / GRAVITY
+            TE_t1 = self.core_compute.integral(E_level_t1, sp_pred) / GRAVITY
+        else:
+            TE_t0 = self.core_compute.integral(E_level_t0) / GRAVITY
+            TE_t1 = self.core_compute.integral(E_level_t1) / GRAVITY
+
+        global_TE_t0 = self.core_compute.weighted_sum(TE_t0, axis=(-2, -1))
+        global_TE_t1 = self.core_compute.weighted_sum(TE_t1, axis=(-2, -1))
+
+        E_correct_ratio = (self.N_seconds * (R_T_sum - F_S_sum) + global_TE_t0) / global_TE_t1
+        E_correct_ratio = E_correct_ratio.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
+
+        E_t1_correct = E_level_t1 * E_correct_ratio
+        T_pred = (E_t1_correct - E_qgk_t1) / CP_t1
+
+        # ------------------------------------------------------------------ #
+        # Write corrected T back to y_pred
+        T_pred = T_pred.unsqueeze(2)
+        y_pred = concat_fix(y_pred, T_pred, self.T_ind_start, self.T_ind_end, N_vars)
+
+        if self.state_trans:
+            y_pred = self.state_trans.transform_array(y_pred)
+
+        x["y_pred"] = y_pred
         return x
 
 

--- a/tests/test_postblock.py
+++ b/tests/test_postblock.py
@@ -11,7 +11,7 @@ import logging
 import torch
 from credit.postblock import GlobalWaterFixer, PostBlock
 from credit.skebs import BackscatterFCNN
-from credit.postblock import TracerFixer, GlobalMassFixer, GlobalEnergyFixer
+from credit.postblock import TracerFixer, GlobalMassFixer, GlobalEnergyFixer, GlobalEnergyFixerUpDown
 from credit.parser import credit_main_parser
 
 
@@ -210,6 +210,53 @@ def test_GlobalEnergyFixer_rand():
     input_dict = {"y_pred": y_pred, "x": x}
     # corrected output
     y_pred_fix = postblock(input_dict)
+
+    assert y_pred_fix.shape == y_pred.shape
+
+
+def test_GlobalEnergyFixerUpDown_rand():
+    """Provides an I/O size and registration test on GlobalEnergyFixerUpDown."""
+    # demo grid: 7 pressure levels, midpoint=True → 6 midpoint levels
+    LEV = 6
+
+    conf = {"post_conf": {"skebs": {"activate": False}}}
+    conf["post_conf"]["tracer_fixer"] = {"activate": False}
+    conf["post_conf"]["global_mass_fixer"] = {"activate": False}
+    conf["post_conf"]["global_water_fixer"] = {"activate": False}
+    conf["post_conf"]["global_energy_fixer"] = {"activate": False}
+
+    conf["post_conf"]["global_energy_fixer_updown"] = {
+        "activate": True,
+        "activate_outside_model": False,
+        "simple_demo": True,
+        "midpoint": True,
+        "denorm": False,
+        "T_inds": [0, LEV - 1],
+        "q_inds": [LEV, 2 * LEV - 1],
+        "U_inds": [2 * LEV, 3 * LEV - 1],
+        "V_inds": [3 * LEV, 4 * LEV - 1],
+        "TOA_down_solar_ind": 4 * LEV,
+        "TOA_up_solar_ind": 4 * LEV + 1,
+        "TOA_up_OLR_ind": 4 * LEV + 2,
+        "surf_down_solar_ind": 4 * LEV + 3,
+        "surf_up_solar_ind": 4 * LEV + 4,
+        "surf_down_LW_ind": 4 * LEV + 5,
+        "surf_up_LW_ind": 4 * LEV + 6,
+        "surf_SH_ind": 4 * LEV + 7,
+        "surf_LH_ind": 4 * LEV + 8,
+    }
+
+    conf["post_conf"]["data"] = {"lead_time_periods": 6}
+
+    postblock = PostBlock(**conf)
+
+    assert any([isinstance(m, GlobalEnergyFixerUpDown) for m in postblock.modules()])
+
+    N_VARS = 4 * LEV + 9
+    x = torch.randn((1, 4 * LEV, 2, 10, 18))
+    y_pred = torch.randn((1, N_VARS, 1, 10, 18))
+
+    y_pred_fix = postblock({"y_pred": y_pred, "x": x})
 
     assert y_pred_fix.shape == y_pred.shape
 


### PR DESCRIPTION
This PR adds a new energy post-block that does a down minus up rather than net. This is required for coupling frameworks 

In the config, to use this you now select: 

 global_energy_fixer_updown:
            activate: True
            activate_outside_model: True
            simple_demo: False
            denorm: True
            grid_type: 'sigma'
            midpoint: True
            lon_lat_level_name: ['lon2d', 'lat2d', 'coef_a', 'coef_b']
            surface_pressure_name: ['SP']
            surface_geopotential_name: ['geopotential_at_surface']
            air_temperature_name: ['temperature']
            specific_total_water_name: ['specific_total_water']
            u_wind_name: ['u_component_of_wind']
            v_wind_name: ['v_component_of_wind']
            # TOA fluxes — all in J/m² per timestep (same units as other output vars)
            TOA_down_solar_name: ['FSDS_TOA']        # incident SW at TOA (SOLIN × DT)
            TOA_up_solar_name:   ['FSUS_TOA']        # reflected SW at TOA (FSUTOA × DT)
            TOA_up_OLR_name:     ['FLUT_J']          # outgoing LW at TOA (FLUT × DT)
            # Surface fluxes — all in J/m² per timestep
            surf_down_solar_name: ['FSDS_J']         # downwelling SW at surface
            surf_up_solar_name:   ['FSUS']           # upwelling SW at surface
            surf_down_LW_name:    ['FLDS_J']         # downwelling LW at surface
            surf_up_LW_name:      ['FLUS']           # upwelling LW at surface
            # Turbulent fluxes — positive-upward, J/m² per timestep
            surf_SH_name: ['SHFLX_J']               # sensible heat flux (positive = surface → atm)
            surf_LH_name: ['LHFLX_J']               # latent heat flux   (positive = surface → atm)


└──> /glade/work/wchapman/conda-envs/credit-coupling/bin/python test_energy_fixer_updown.py --full
Using device: cuda

============================================================
TEST 1: simple_demo (toy grid, no zarr needed)
============================================================
  TE_t0           = +1.492085e+24 J/m²
  TE_t1 (before)  = +1.492126e+24 J/m²
  TE_expected     = +1.500558e+24 J/m²
  imbalance before fix = -8.4328e+21 J/m²
  TE_t1 (after)   = +1.500558e+24 J/m²
  imbalance after  fix = -1.8920e+16 J/m²
  relative error       = 1.26e-08
  PASS 

============================================================
TEST 2: full zarr test  (device=cuda)
============================================================
  loading zarr ...
  using timestep indices 10 (input) and 11 (pred)
  TE_t0           = +1.377322e+24
  TE_t1 (before)  = +1.377457e+24
  TE_expected     = +1.377407e+24
  R_T global mean = +3093171022069760.0000 W/m²
  F_S global mean = -865242099744768.0000 W/m²
  imbalance before fix = +4.9864e+19  (0.004%)
  TE_t1 (after)   = +1.377407e+24
  imbalance after  fix = +0.0000e+00  (0.000e+00%)
  |delta T| max=0.0128 K  mean=0.008788 K
  PASS 

I have added a test to our module 