### PR TITLE
[v2.1] WeatherBench2 verification: eval CLI, scorecard plots & test suite

### DIFF
--- a/applications/ensemble_wb2_verif.py
+++ b/applications/ensemble_wb2_verif.py
@@ -139,7 +139,7 @@ def main():
     parser.add_argument("--out", default=DEFAULT_OUT)
     parser.add_argument("--cesm", default=DEFAULT_CESM_GLOB)
     parser.add_argument("--clim", default=DEFAULT_CLIM_PATH)
-    parser.add_argument("--tag", default="ensemble", help="Tag appended to output filenames (e.g. 'wxformer_v2_ens')")
+    parser.add_argument("--tag", default="ensemble", help="Tag appended to output filenames (e.g. 'wxformer_ens')")
     parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args()
 

--- a/applications/ensemble_wb2_verif.py
+++ b/applications/ensemble_wb2_verif.py
@@ -1,0 +1,328 @@
+"""
+CREDIT ensemble WeatherBench-style verification: CRPS, spread, RMSE, ACC.
+
+Compares 100-member CREDIT ensemble forecasts vs ERA5 cesm_stage1.
+
+Output format matches wxformer_wb2_verif.py:
+  ACC_006h_240h_{tag}.nc    : dims (days, time=40), vars Z500/T500/U500/V500/Q500/SP/t2m
+  RMSE_006h_240h_{tag}.nc   : ensemble-mean RMSE
+  CRPS_006h_240h_{tag}.nc   : spatially-averaged CRPS
+  SPREAD_006h_240h_{tag}.nc : spatially-averaged ensemble std
+
+CRPS uses the sorted-ensemble formula (O(n log n), memory-efficient):
+  CRPS = E[|X - y|] - 0.5 * E[|X - X'|]
+  E[|X - X'|] = (2/n²) * sum_i (2i - n + 1) * x_{(i)}  (i: 0-indexed sorted members)
+
+Usage
+-----
+python applications/ensemble_wb2_verif.py \\
+    --forecast /glade/derecho/scratch/schreck/CREDIT_runs/ensemble/scheduler/netcdf_pressure_interp \\
+    --out /glade/work/schreck/CREDIT_verif/ensemble
+"""
+
+import argparse
+import glob
+import logging
+import os
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_FORECAST = "/glade/derecho/scratch/schreck/CREDIT_runs/ensemble/scheduler/netcdf_pressure_interp"
+DEFAULT_CESM_GLOB = (
+    "/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_cesm_stage1/all_in_one/ERA5_mlevel_cesm_6h_lev16_*.zarr"
+)
+DEFAULT_CLIM_PATH = "/glade/campaign/cisl/aiml/ksha/CREDIT_CESM/VERIF/ERA5_clim/ERA5_clim_1990_2019_6h_cesm_interp.nc"
+DEFAULT_OUT = "/glade/work/schreck/CREDIT_verif/ensemble"
+
+# 40 lead times: 6h..240h (matches det verification convention)
+LEAD_HOURS = list(range(6, 241, 6))
+
+# Level index in ERA5_clim for 500 hPa (levels 50..1000 hPa, 13 levels; 500 hPa = index 7)
+CLIM_LEV_500 = 7
+
+
+# ---------------------------------------------------------------------------
+# Spatial averaging — identical to wxformer_wb2_verif.py
+# ---------------------------------------------------------------------------
+def _sp_avg(da, w_lat):
+    return da.weighted(w_lat).mean(["latitude", "longitude"], skipna=False)
+
+
+def _make_w_lat_xr(da):
+    w = np.cos(np.deg2rad(da.latitude.values))
+    return xr.DataArray(w / w.mean(), dims=["latitude"], coords={"latitude": da.latitude})
+
+
+def _acc(pred_anom, true_anom, w_lat):
+    top = _sp_avg(pred_anom * true_anom, w_lat)
+    bottom = np.sqrt(_sp_avg(pred_anom**2, w_lat) * _sp_avg(true_anom**2, w_lat))
+    return top / (bottom + 1e-12)
+
+
+def _rmse(pred, truth, w_lat):
+    return np.sqrt(_sp_avg((pred - truth) ** 2, w_lat))
+
+
+# ---------------------------------------------------------------------------
+# CRPS + spread — vectorized sorted-ensemble formula
+# ---------------------------------------------------------------------------
+def _crps_spread(pred_ens_np, truth_np, w_np):
+    """
+    Spatially-averaged CRPS and ensemble spread for one lead time.
+
+    Parameters
+    ----------
+    pred_ens_np : (n_members, lat, lon)  float64
+    truth_np    : (lat, lon)             float64
+    w_np        : (lat,)                 normalized cos-lat weights
+
+    Returns
+    -------
+    crps   : scalar
+    spread : scalar  (spatial avg of ensemble std, ddof=1)
+    """
+    n, n_lat, n_lon = pred_ens_np.shape
+    w2d = w_np[:, None]  # (lat, 1)
+
+    def sp_avg(arr2d):
+        return (arr2d * w2d).sum() / (n_lat * n_lon)
+
+    # E[|X - y|]: mean over members, then spatial avg
+    abs_err = np.abs(pred_ens_np - truth_np[None]).mean(axis=0)  # (lat, lon)
+    term1 = sp_avg(abs_err)
+
+    # E[|X - X'|] via sorted ensemble: O(n log n), memory O(n * lat * lon)
+    sorted_ens = np.sort(pred_ens_np, axis=0)
+    wk = (2 * np.arange(n) - n + 1).reshape(n, 1, 1).astype(np.float64)
+    energy_map = (2.0 / (n * n)) * (sorted_ens * wk).sum(axis=0)
+    term2 = sp_avg(energy_map)
+
+    crps = float(term1 - 0.5 * term2)
+
+    std_map = pred_ens_np.std(axis=0, ddof=1)
+    spread = float(sp_avg(std_map))
+
+    return crps, spread
+
+
+# ---------------------------------------------------------------------------
+# Build output dataset — same format as wxformer_wb2_verif.py
+# ---------------------------------------------------------------------------
+def _build_dataset(results_list, kind):
+    var_names = list(results_list[0][kind].keys())
+    doy = np.array([r["dayofyear"] for r in results_list])
+    hour = np.array([r["hour"] for r in results_list])
+
+    ds = xr.Dataset()
+    for v in var_names:
+        data = np.array([r[kind][v] for r in results_list])  # (days, time)
+        ds[v] = xr.DataArray(data, dims=["days", "time"])
+    ds = ds.assign_coords(
+        dayofyear=(["days", "time"], doy),
+        hour=(["days", "time"], hour),
+    )
+    return ds
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(description="CREDIT ensemble WeatherBench CRPS/RMSE/ACC verification")
+    parser.add_argument(
+        "--forecast", default=DEFAULT_FORECAST, help="Root dir of ensemble NetCDFs (one subdir per init date)"
+    )
+    parser.add_argument("--out", default=DEFAULT_OUT)
+    parser.add_argument("--cesm", default=DEFAULT_CESM_GLOB)
+    parser.add_argument("--clim", default=DEFAULT_CLIM_PATH)
+    parser.add_argument("--tag", default="ensemble", help="Tag appended to output filenames (e.g. 'wxformer_v2_ens')")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    os.makedirs(args.out, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Collect init dirs and verify lead file availability
+    # ------------------------------------------------------------------
+    init_dirs = sorted(
+        [
+            os.path.join(args.forecast, d)
+            for d in os.listdir(args.forecast)
+            if os.path.isdir(os.path.join(args.forecast, d))
+        ]
+    )
+    logger.info(f"{len(init_dirs)} init dirs found")
+
+    init_to_meta = {}
+    all_times = set()
+    for init_dir in init_dirs:
+        name = os.path.basename(init_dir)
+        lead_files, ok = [], True
+        for lh in LEAD_HOURS:
+            m = glob.glob(os.path.join(init_dir, f"pred_{name}_{lh:03d}.nc"))
+            if not m:
+                ok = False
+                break
+            lead_files.append(m[0])
+        if not ok:
+            logger.warning(f"Missing lead files for {name}, skipping")
+            continue
+        t0 = pd.Timestamp(name.replace("T", " ").replace("Z", ""))
+        vtimes = [np.datetime64(t0 + pd.Timedelta(hours=lh)) for lh in LEAD_HOURS]
+        init_to_meta[init_dir] = (lead_files, vtimes)
+        all_times.update(vtimes)
+
+    # ------------------------------------------------------------------
+    # Pre-load truth for all verification times at once
+    # cesm_stage1 has T500/U500/V500/Q500/Z500/SP/t2m pre-computed — no interpolation
+    # ------------------------------------------------------------------
+    all_times_sorted = sorted(all_times)
+    logger.info(f"Loading {len(all_times_sorted)} truth timesteps from cesm_stage1...")
+    cesm_files = sorted(glob.glob(args.cesm))
+    ds_cesm = xr.open_mfdataset(cesm_files, combine="by_coords", engine="zarr")
+    truth_vars = ["Z500", "T500", "U500", "V500", "Q500", "SP", "t2m"]
+    ds_truth_all = ds_cesm[truth_vars].sel(time=all_times_sorted).load()
+    logger.info("cesm load complete")
+
+    logger.info("Loading climatology...")
+    ds_clim_full = xr.open_dataset(args.clim).load()
+    logger.info("Climatology loaded")
+
+    # latitude weights from truth grid
+    w_np = np.cos(np.deg2rad(ds_truth_all.latitude.values))
+    w_np = w_np / w_np.mean()
+    w_xr = xr.DataArray(w_np, dims=["latitude"], coords={"latitude": ds_truth_all.latitude})
+
+    # Climatology variable name + level index for each output variable
+    clim_var_map = {
+        "Z500": ("geopotential", CLIM_LEV_500),
+        "T500": ("temperature", CLIM_LEV_500),
+        "U500": ("u_component_of_wind", CLIM_LEV_500),
+        "V500": ("v_component_of_wind", CLIM_LEV_500),
+        "Q500": ("specific_humidity", CLIM_LEV_500),
+        "SP": ("surface_pressure", None),
+        "t2m": ("2m_temperature", None),
+    }
+
+    # Ensemble forecast variable + pressure selector for each output variable
+    fc_var_map = {
+        "Z500": ("Z_PRES", 500.0),
+        "T500": ("T_PRES", 500.0),
+        "U500": ("U_PRES", 500.0),
+        "V500": ("V_PRES", 500.0),
+        "Q500": ("Q_PRES", 500.0),
+        "SP": ("SP", None),
+        "t2m": ("t2m", None),
+    }
+
+    # ------------------------------------------------------------------
+    # Main loop: one init at a time
+    # ------------------------------------------------------------------
+    results, n_inits = [], len(init_to_meta)
+
+    for i, (init_dir, (lead_files, vtimes)) in enumerate(sorted(init_to_meta.items())):
+        name = os.path.basename(init_dir)
+        truth_times = np.array(vtimes)
+        ds_truth = ds_truth_all.sel(time=truth_times)
+
+        dt_idx = pd.DatetimeIndex(truth_times)
+        doy_arr = dt_idx.day_of_year.values
+        hour_arr = dt_idx.hour.values
+
+        clim_list = [ds_clim_full.sel(dayofyear=int(d), hour=int(h)) for d, h in zip(doy_arr, hour_arr)]
+        ds_clim = xr.concat(clim_list, dim="time")
+        ds_clim["time"] = ds_truth.time
+
+        crps_v = {v: np.zeros(len(LEAD_HOURS)) for v in fc_var_map}
+        spread_v = {v: np.zeros(len(LEAD_HOURS)) for v in fc_var_map}
+        rmse_v = {v: np.zeros(len(LEAD_HOURS)) for v in fc_var_map}
+        acc_v = {v: np.zeros(len(LEAD_HOURS)) for v in fc_var_map}
+
+        for li, lf in enumerate(lead_files):
+            ds_lf = xr.open_dataset(lf, engine="netcdf4")
+
+            for vname, (fc_var, pres) in fc_var_map.items():
+                # forecast ensemble: (n_ens, lat, lon)
+                if pres is not None:
+                    pred_da = ds_lf[fc_var].sel(pressure=pres).squeeze("time")
+                else:
+                    pred_da = ds_lf[fc_var].squeeze("time")
+                pred_np = pred_da.values.astype(np.float64)  # (n_ens, lat, lon)
+
+                truth_da = ds_truth[vname].isel(time=li)
+                truth_np = truth_da.values.astype(np.float64)
+
+                clim_var, clim_lev = clim_var_map[vname]
+                if clim_lev is not None:
+                    clim_da = ds_clim[clim_var].isel(level=clim_lev, time=li)
+                else:
+                    clim_da = ds_clim[clim_var].isel(time=li)
+
+                crps_val, spread_val = _crps_spread(pred_np, truth_np, w_np)
+                crps_v[vname][li] = crps_val
+                spread_v[vname][li] = spread_val
+
+                # ensemble mean for RMSE + ACC
+                pred_mean_da = xr.DataArray(
+                    pred_np.mean(axis=0),
+                    dims=["latitude", "longitude"],
+                    coords={"latitude": truth_da.latitude, "longitude": truth_da.longitude},
+                )
+                rmse_v[vname][li] = float(_rmse(pred_mean_da, truth_da, w_xr).values)
+                acc_v[vname][li] = float(_acc(pred_mean_da - clim_da, truth_da - clim_da, w_xr).values)
+
+            ds_lf.close()
+
+        results.append(
+            {
+                "crps": crps_v,
+                "spread": spread_v,
+                "rmse": rmse_v,
+                "acc": acc_v,
+                "dayofyear": doy_arr,
+                "hour": hour_arr,
+            }
+        )
+
+        if (i + 1) % 10 == 0 or (i + 1) == n_inits:
+            logger.info(
+                f"[{i + 1}/{n_inits}] {name}  Z500_crps6h={crps_v['Z500'][0]:.1f}  Z500_acc6h={acc_v['Z500'][0]:.5f}"
+            )
+
+    logger.info(f"Processed {len(results)} inits")
+    results.sort(key=lambda r: (r["dayofyear"][0], r["hour"][0]))
+
+    # ------------------------------------------------------------------
+    # Save outputs: combined + per-100-init batch files
+    # ------------------------------------------------------------------
+    tag = args.tag
+    for kind in ("crps", "spread", "rmse", "acc"):
+        ds_out = _build_dataset(results, kind)
+        path = os.path.join(args.out, f"{kind.upper()}_006h_240h_{tag}.nc")
+        ds_out.to_netcdf(path)
+        logger.info(f"{kind.upper()} → {path}")
+
+        n = len(results)
+        for start in range(0, n, 100):
+            end = min(start + 100, n)
+            batch = results[start:end]
+            _build_dataset(batch, kind).to_netcdf(
+                os.path.join(
+                    args.out,
+                    f"combined_{kind}_{start:04d}_{end:04d}_006h_240h_{tag}.nc",
+                )
+            )
+
+    logger.info("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/applications/eval_weatherbench.py
+++ b/applications/eval_weatherbench.py
@@ -299,7 +299,7 @@ def compute_netcdf_scores(forecast_dir, era5_glob, clim_path=None, lead_time_hou
 
     for step in sorted(step_files.keys()):
         files = step_files[step]
-        lead_h = step * lead_time_hours
+        lead_h = step  # filename suffix is already lead-time hours (e.g. _006.nc = 6h)
         logger.info(f"Step {step} ({lead_h}h): {len(files)} forecasts")
 
         pred_list, true_list = [], []

--- a/applications/eval_weatherbench.py
+++ b/applications/eval_weatherbench.py
@@ -1,0 +1,505 @@
+"""
+WeatherBench2-style deterministic evaluation for CREDIT forecasts.
+
+Two input modes:
+  --csv   : aggregate pre-computed per-init metrics CSVs (fast, no GPU/ERA5 needed)
+  --netcdf: compute metrics directly from forecast netCDFs against ERA5 zarr (full path)
+
+Outputs a single CSV with RMSE, ACC, bias by variable and lead time, plus
+latitude-region breakdowns (global / tropics / extratropics).
+
+Usage
+-----
+# From existing per-init CSVs (fast path):
+python eval_weatherbench.py --csv /path/to/metrics/ --out wb2_scores.csv
+
+# From raw forecast netCDFs + ERA5:
+python eval_weatherbench.py --netcdf /path/to/forecasts/ \\
+    --era5 /glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h* \\
+    --out wb2_scores.csv
+"""
+
+import argparse
+import glob
+import logging
+import os
+import re
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from credit.verification.deterministic import latitude_slices
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# WB2 standard variable definitions
+# level_idx: index into CREDIT's 18-level pressure axis
+# ---------------------------------------------------------------------------
+# Default climatology (1990-2019, 6-hourly, from Ankur's CREDIT verification data)
+DEFAULT_CLIM_PATH = "/glade/campaign/cisl/aiml/akn7/CREDIT_CESM/VERIF/ERA5_clim/ERA5_clim_1990_2019_6h_cesm_interp.nc"
+
+LEVEL_IDS = [
+    1.0,
+    9.0,
+    19.0,
+    29.0,
+    39.0,
+    49.0,
+    59.0,
+    69.0,
+    79.0,
+    89.0,
+    97.0,
+    104.0,
+    111.0,
+    116.0,
+    122.0,
+    126.0,
+    131.0,
+    136.0,
+]
+
+# WB2 target levels (hPa) mapped to CREDIT level indices (approximate)
+# CREDIT uses model levels; these are the closest to standard WB2 pressure levels
+WB2_TARGET_LEVELS = {
+    "Z500": ("Z", 69),  # level_id 69 ≈ 500 hPa
+    "T500": ("T", 69),
+    "U500": ("U", 69),
+    "V500": ("V", 69),
+    "Q500": ("Q", 69),
+    "Z850": ("Z", 89),  # level_id 89 ≈ 850 hPa
+    "T850": ("T", 89),
+    "U850": ("U", 89),
+    "V850": ("V", 89),
+    "Z250": ("Z", 49),  # level_id 49 ≈ 250 hPa
+    "U250": ("U", 49),
+}
+
+WB2_SURFACE_VARS = ["t2m", "SP", "U500", "V500"]
+
+# ERA5 variable name mapping (zarr → CREDIT short name used in CSVs)
+ERA5_VAR_MAP = {
+    "u_component_of_wind": "U",
+    "v_component_of_wind": "V",
+    "temperature": "T",
+    "specific_humidity": "Q",
+    "VAR_2T": "t2m",
+    "SP": "SP",
+    "VAR_10U": "u10",
+    "VAR_10V": "v10",
+}
+
+
+# ---------------------------------------------------------------------------
+# CSV fast path
+# ---------------------------------------------------------------------------
+
+
+def load_csv_metrics(csv_dir):
+    """Load all per-init CSV files from csv_dir, return concatenated DataFrame."""
+    files = [
+        f
+        for f in glob.glob(os.path.join(csv_dir, "*.csv"))
+        if "average" not in os.path.basename(f) and "ensemble" not in os.path.basename(f)
+    ]
+    if not files:
+        raise FileNotFoundError(f"No per-init CSV files found in {csv_dir}")
+    logger.info(f"Loading {len(files)} init date CSVs from {csv_dir}")
+    dfs = [pd.read_csv(f) for f in files]
+    return pd.concat(dfs, ignore_index=True)
+
+
+def csv_to_wb2_scores(df, lead_time_hours=6):
+    """
+    Aggregate per-init CSV metrics into WB2-style scores by lead time.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Concatenated per-init metrics (from load_csv_metrics).
+    lead_time_hours : int
+        Hours per forecast step (default 6).
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns: lead_time_hours, variable, rmse, acc, mae, n_inits
+    """
+    # identify variable columns
+    var_pattern = re.compile(r"^(rmse|acc|mae|bias|std)_(.+)$")
+    vars_found = set()
+    for col in df.columns:
+        m = var_pattern.match(col)
+        if m:
+            vars_found.add(m.group(2))
+
+    # aggregate by forecast_step
+    records = []
+    grouped = df.groupby("forecast_step")
+    for step, grp in grouped:
+        lead_h = step * lead_time_hours
+        n = len(grp)
+        row = {"lead_time_hours": lead_h, "forecast_step": step, "n_inits": n}
+        for var in vars_found:
+            for metric in ["rmse", "mae", "std"]:
+                col = f"{metric}_{var}"
+                if col in grp.columns:
+                    row[col] = grp[col].mean()
+            # acc_* columns in per-init CSVs are Pearson correlations, not true
+            # WB2 anomaly ACC — store as pearson_r_* to avoid confusion
+            acc_col = f"acc_{var}"
+            if acc_col in grp.columns:
+                row[f"pearson_r_{var}"] = grp[acc_col].mean()
+        records.append(row)
+
+    result = pd.DataFrame(records).sort_values("lead_time_hours").reset_index(drop=True)
+    return result
+
+
+def load_climatology(clim_path=None):
+    """
+    Load ERA5 climatology for ACC computation.
+
+    Returns an xr.Dataset with dims (hour, dayofyear, [level,] latitude, longitude).
+    Default: Ankur's 1990-2019 6-hourly climatology on campaign storage.
+    """
+    path = clim_path or DEFAULT_CLIM_PATH
+    logger.info(f"Loading climatology from {path}")
+    return xr.open_dataset(path)
+
+
+def select_clim(ds_clim, valid_times, variable, level=None):
+    """
+    Select climatology values matching a set of valid forecast times.
+
+    Parameters
+    ----------
+    ds_clim : xr.Dataset
+        Climatology with dims (hour, dayofyear, ...).
+    valid_times : array-like of np.datetime64
+        Forecast valid times to match.
+    variable : str
+        Variable name in ds_clim.
+    level : float, optional
+        Pressure level to select (for 3D variables).
+
+    Returns
+    -------
+    xr.DataArray
+        Climatology values with a 'time' dimension matching valid_times.
+    """
+    times = pd.DatetimeIndex(valid_times)
+    clim_slices = []
+    for t in times:
+        doy = t.dayofyear
+        hour = t.hour
+        da = ds_clim[variable].sel(dayofyear=doy, hour=hour)
+        if level is not None and "level" in da.dims:
+            da = da.sel(level=level, method="nearest")
+        clim_slices.append(da)
+    da_clim = xr.concat(clim_slices, dim="time")
+    da_clim["time"] = valid_times
+    return da_clim
+
+
+def print_wb2_summary(scores_df):
+    """Print WB2-style scorecard for key variables and lead times."""
+    key_vars = ["Z500", "T500", "t2m", "U500", "V500"]
+    key_days = [1, 3, 5, 7, 10]
+    key_steps = {d: d * 24 // 6 for d in key_days}  # assumes 6h steps
+
+    print("\n" + "=" * 70)
+    print("WeatherBench2-style scorecard (mean over all init dates)")
+    print("=" * 70)
+
+    for var in key_vars:
+        rmse_col = f"rmse_{var}"
+        acc_col = f"acc_{var}"
+        if rmse_col not in scores_df.columns:
+            continue
+        print(f"\n  {var}")
+        print(f"  {'Day':>4}  {'RMSE':>10}  {'ACC':>8}")
+        print(f"  {'-' * 4}  {'-' * 10}  {'-' * 8}")
+        for day, step in key_steps.items():
+            row = scores_df[scores_df["forecast_step"] == step]
+            if row.empty:
+                continue
+            rmse = row[rmse_col].values[0]
+            acc = row[acc_col].values[0] if acc_col in row.columns else float("nan")
+            print(f"  {day:>4}  {rmse:>10.2f}  {acc:>8.4f}")
+
+    print("\n" + "=" * 70)
+
+
+# ---------------------------------------------------------------------------
+# NetCDF full path
+# ---------------------------------------------------------------------------
+
+
+def open_era5_year(era5_glob, year):
+    """Open ERA5 zarr/nc for the given year."""
+    pattern = str(era5_glob).replace("*", f"*{year}*")
+    files = sorted(glob.glob(pattern))
+    if not files:
+        # fallback: open all and select year
+        files = sorted(glob.glob(str(era5_glob)))
+    if not files:
+        raise FileNotFoundError(f"No ERA5 files matching {era5_glob}")
+    ds = xr.open_mfdataset(
+        files, engine="zarr" if files[0].endswith(".zarr") else "netcdf4", combine="by_coords", chunks={"time": 4}
+    )
+    if year is not None:
+        ds = ds.sel(time=str(year))
+    return ds
+
+
+def compute_netcdf_scores(forecast_dir, era5_glob, clim_path=None, lead_time_hours=6, max_inits=None):
+    """
+    Compute WB2 deterministic scores from forecast netCDFs against ERA5.
+
+    Expects forecast_dir structured as:
+        forecast_dir/{init_datetime}/pred_{init}_{step:03d}.nc
+
+    Parameters
+    ----------
+    forecast_dir : str or Path
+        Root directory of forecast netCDFs.
+    era5_glob : str
+        Glob pattern for ERA5 zarr files.
+    lead_time_hours : int
+        Hours per step.
+    max_inits : int, optional
+        Limit number of init dates (for testing).
+
+    Returns
+    -------
+    pd.DataFrame
+        WB2 scores by lead time and variable.
+    """
+    forecast_dir = Path(forecast_dir)
+    init_dirs = sorted([d for d in forecast_dir.iterdir() if d.is_dir()])
+    if max_inits:
+        init_dirs = init_dirs[:max_inits]
+    logger.info(f"Found {len(init_dirs)} init dates in {forecast_dir}")
+
+    # load climatology once
+    ds_clim = None
+    try:
+        ds_clim = load_climatology(clim_path)
+        logger.info("Climatology loaded — will compute true anomaly ACC")
+    except Exception as e:
+        logger.warning(f"Could not load climatology ({e}); ACC will be skipped in netcdf mode")
+
+    # collect all forecast files, grouped by step
+    step_files = {}
+    for init_dir in init_dirs:
+        for f in sorted(init_dir.glob("pred_*.nc")):
+            # extract step from filename: pred_INIT_SSS.nc
+            parts = f.stem.split("_")
+            step = int(parts[-1])
+            step_files.setdefault(step, []).append(f)
+
+    all_records = []
+    era5_cache = {}
+
+    for step in sorted(step_files.keys()):
+        files = step_files[step]
+        lead_h = step * lead_time_hours
+        logger.info(f"Step {step} ({lead_h}h): {len(files)} forecasts")
+
+        pred_list, true_list = [], []
+        for f in files:
+            ds_pred = xr.open_dataset(f)
+            # collapse ensemble dim if present — use ensemble mean for deterministic scores
+            if "ensemble" in ds_pred.dims:
+                ds_pred = ds_pred.mean(dim="ensemble")
+            valid_time = ds_pred.time.values[0]
+            year = pd.Timestamp(valid_time).year
+
+            # load/cache ERA5 for this year
+            if year not in era5_cache:
+                logger.info(f"Opening ERA5 for {year}")
+                era5_cache[year] = open_era5_year(era5_glob, year)
+                # keep cache small
+                if len(era5_cache) > 2:
+                    oldest = min(era5_cache.keys())
+                    del era5_cache[oldest]
+
+            ds_true = era5_cache[year].sel(time=valid_time, method="nearest")
+            pred_list.append(ds_pred)
+            true_list.append(ds_true)
+
+        if not pred_list:
+            continue
+
+        # concatenate over init dates as "time" axis
+        ds_pred_all = xr.concat(pred_list, dim="time")
+        ds_true_all = xr.concat(true_list, dim="time")
+
+        row = {"lead_time_hours": lead_h, "forecast_step": step, "n_inits": len(files)}
+
+        valid_times = ds_pred_all.time.values
+
+        # score upper-air variables at WB2 target levels
+        for label, (var_credit, level_id) in WB2_TARGET_LEVELS.items():
+            era5_var = next((k for k, v in ERA5_VAR_MAP.items() if v == var_credit), None)
+            if era5_var is None or era5_var not in ds_true_all:
+                continue
+            if var_credit not in ds_pred_all:
+                continue
+            da_pred = ds_pred_all[var_credit].sel(level=level_id, method="nearest")
+            da_true = ds_true_all[era5_var].sel(level=level_id, method="nearest")
+            da_clim_var = None
+            if ds_clim is not None and era5_var in ds_clim:
+                da_clim_var = select_clim(ds_clim, valid_times, era5_var, level=level_id)
+                da_clim_var = da_clim_var.interp(latitude=da_pred.latitude, longitude=da_pred.longitude)
+            _add_scores(row, da_pred, da_true, label, da_clim=da_clim_var)
+
+        # score surface variables
+        surface_map = {"t2m": ("VAR_2T", "2m_temperature"), "SP": ("SP", "SP")}
+        for credit_var, (era5_var, clim_var) in surface_map.items():
+            if credit_var not in ds_pred_all or era5_var not in ds_true_all:
+                continue
+            da_pred = ds_pred_all[credit_var]
+            da_true = ds_true_all[era5_var]
+            da_clim_var = None
+            if ds_clim is not None and clim_var in ds_clim:
+                da_clim_var = select_clim(ds_clim, valid_times, clim_var)
+                da_clim_var = da_clim_var.interp(latitude=da_pred.latitude, longitude=da_pred.longitude)
+            _add_scores(row, da_pred, da_true, credit_var, da_clim=da_clim_var)
+
+        all_records.append(row)
+
+    result = pd.DataFrame(all_records).sort_values("lead_time_hours").reset_index(drop=True)
+    return result
+
+
+def _add_scores(row, da_pred, da_true, label, da_clim=None):
+    """
+    Compute RMSE, bias, and ACC per region and add to row dict in-place.
+
+    ACC uses anomaly correlation if da_clim is provided (true WB2 ACC).
+    Without climatology, ACC is Pearson correlation (reported as acc_pearson_*).
+    """
+    w_lat = np.cos(np.deg2rad(da_pred.latitude))
+    sq_err = (da_pred - da_true) ** 2
+    diff = da_pred - da_true
+
+    for region, s in latitude_slices.items():
+        w_r = w_lat.sel(latitude=s)
+        sq_r = sq_err.sel(latitude=s)
+        diff_r = diff.sel(latitude=s)
+        w_sum = float(w_r.sum())
+
+        rmse_val = float(np.sqrt((sq_r.mean(dim="longitude") * w_r).sum(dim="latitude") / w_sum).mean(dim="time"))
+        bias_val = float((diff_r.mean(dim="longitude") * w_r).sum(dim="latitude").mean(dim="time") / w_sum)
+
+        row[f"rmse_{label}_{region}"] = rmse_val
+        row[f"bias_{label}_{region}"] = bias_val
+
+        # true ACC (anomaly correlation)
+        if da_clim is not None:
+            pred_anom = da_pred.sel(latitude=s) - da_clim.sel(latitude=s)
+            true_anom = da_true.sel(latitude=s) - da_clim.sel(latitude=s)
+            num = (w_r * pred_anom * true_anom).sum(dim=["latitude", "longitude"])
+            denom = np.sqrt(
+                (w_r * pred_anom**2).sum(dim=["latitude", "longitude"])
+                * (w_r * true_anom**2).sum(dim=["latitude", "longitude"])
+            )
+            row[f"acc_{label}_{region}"] = float((num / (denom + 1e-12)).mean(dim="time"))
+
+    # global columns (matches existing CSV format)
+    w_sum_global = float(w_lat.sum())
+    row[f"rmse_{label}"] = float(
+        np.sqrt((sq_err.mean(dim="longitude") * w_lat).sum(dim="latitude") / w_sum_global).mean(dim="time")
+    )
+    row[f"bias_{label}"] = float(
+        (diff.mean(dim="longitude") * w_lat).sum(dim="latitude").mean(dim="time") / w_sum_global
+    )
+
+    if da_clim is not None:
+        pred_anom = da_pred - da_clim
+        true_anom = da_true - da_clim
+        num = (w_lat * pred_anom * true_anom).sum(dim=["latitude", "longitude"])
+        denom = np.sqrt(
+            (w_lat * pred_anom**2).sum(dim=["latitude", "longitude"])
+            * (w_lat * true_anom**2).sum(dim=["latitude", "longitude"])
+        )
+        row[f"acc_{label}"] = float((num / (denom + 1e-12)).mean(dim="time"))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description="WeatherBench2-style evaluation for CREDIT forecasts")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--csv", type=str, help="Directory of per-init metrics CSVs (fast path)")
+    group.add_argument("--netcdf", type=str, help="Directory of forecast netCDFs (full path)")
+
+    parser.add_argument(
+        "--era5",
+        type=str,
+        default="/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h*",
+        help="Glob pattern for ERA5 zarr files (required for --netcdf mode)",
+    )
+    parser.add_argument(
+        "--clim",
+        type=str,
+        default=None,
+        help=f"Path to ERA5 climatology netCDF for true ACC. Defaults to {DEFAULT_CLIM_PATH}",
+    )
+    parser.add_argument("--out", type=str, default="wb2_scores.csv", help="Output CSV path")
+    parser.add_argument("--lead-time-hours", type=int, default=6, help="Hours per forecast step")
+    parser.add_argument("--max-inits", type=int, default=None, help="Limit init dates (for testing)")
+    parser.add_argument(
+        "--plot",
+        type=str,
+        default=None,
+        metavar="PLOT_DIR",
+        help="If set, also generate WB2 scorecard figures in this directory",
+    )
+    parser.add_argument(
+        "--label", type=str, default="CREDIT", help="Model label used in plot legends (default: CREDIT)"
+    )
+    parser.add_argument("--no-refs", action="store_true", help="Omit IFS/Pangu/GraphCast reference lines in plots")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s:%(name)s:%(message)s",
+    )
+
+    if args.csv:
+        df_raw = load_csv_metrics(args.csv)
+        scores = csv_to_wb2_scores(df_raw, lead_time_hours=args.lead_time_hours)
+    else:
+        if not args.era5:
+            parser.error("--era5 is required when using --netcdf mode")
+        scores = compute_netcdf_scores(
+            args.netcdf,
+            args.era5,
+            clim_path=args.clim,
+            lead_time_hours=args.lead_time_hours,
+            max_inits=args.max_inits,
+        )
+
+    scores.to_csv(args.out, index=False)
+    logger.info(f"Saved WB2 scores to {args.out}")
+
+    print_wb2_summary(scores)
+
+    if args.plot:
+        from plot_weatherbench import plot_all
+
+        plot_all(args.out, args.plot, label=args.label, show_refs=not args.no_refs)
+
+
+if __name__ == "__main__":
+    main()

--- a/applications/eval_weatherbench.py
+++ b/applications/eval_weatherbench.py
@@ -258,7 +258,7 @@ def _score_step_worker(args):
     Parameters
     ----------
     args : tuple
-        (step, files, era5_glob, clim_path)
+        (step, files, era5_glob, clim_path, lead_time_hours)
 
     Returns
     -------
@@ -268,8 +268,8 @@ def _score_step_worker(args):
 
     _log = _logging.getLogger(__name__)
 
-    step, files, era5_glob, clim_path = args
-    lead_h = step  # filename suffix is already lead-time hours
+    step, files, era5_glob, clim_path, lead_time_hours = args
+    lead_h = step * lead_time_hours
 
     # Load climatology inside worker (no shared state across processes)
     ds_clim = None
@@ -393,7 +393,7 @@ def compute_netcdf_scores(forecast_dir, era5_glob, clim_path=None, lead_time_hou
     n_workers = workers or os.cpu_count() or 1
     logger.info(f"Scoring {n_steps} steps with {n_workers} workers")
 
-    work_items = [(step, files, era5_glob, clim_path) for step, files in sorted(step_files.items())]
+    work_items = [(step, files, era5_glob, clim_path, lead_time_hours) for step, files in sorted(step_files.items())]
 
     all_records = []
     with ProcessPoolExecutor(max_workers=n_workers) as pool:

--- a/applications/eval_weatherbench.py
+++ b/applications/eval_weatherbench.py
@@ -41,47 +41,39 @@ logger = logging.getLogger(__name__)
 # Default climatology (1990-2019, 6-hourly, from Ankur's CREDIT verification data)
 DEFAULT_CLIM_PATH = "/glade/campaign/cisl/aiml/akn7/CREDIT_CESM/VERIF/ERA5_clim/ERA5_clim_1990_2019_6h_cesm_interp.nc"
 
-LEVEL_IDS = [
-    1.0,
-    9.0,
-    19.0,
-    29.0,
-    39.0,
-    49.0,
-    59.0,
-    69.0,
-    79.0,
-    89.0,
-    97.0,
-    104.0,
-    111.0,
-    116.0,
-    122.0,
-    126.0,
-    131.0,
-    136.0,
-]
-
-# WB2 target levels (hPa) mapped to CREDIT level indices (approximate)
-# CREDIT uses model levels; these are the closest to standard WB2 pressure levels
+# WB2 target levels.
+# Each entry: label → (era5_var, credit_var, era5_level, credit_coord, credit_level)
+#   era5_var     : variable name in ERA5 zarr (long names)
+#   credit_var   : variable name in CREDIT forecast netCDF
+#   era5_level   : value of the ERA5 model-level coord (CREDIT model-level index, e.g. 69≈500hPa)
+#   credit_coord : 'pressure' for _PRES vars, 'level' for model-level vars
+#   credit_level : coordinate value to select in the forecast (pressure in hPa or model-level idx)
+# ERA5 mlevel zarr has no geopotential, so Z500 is omitted.
 WB2_TARGET_LEVELS = {
-    "Z500": ("Z", 69),  # level_id 69 ≈ 500 hPa
-    "T500": ("T", 69),
-    "U500": ("U", 69),
-    "V500": ("V", 69),
-    "Q500": ("Q", 69),
-    "Z850": ("Z", 89),  # level_id 89 ≈ 850 hPa
-    "T850": ("T", 89),
-    "U850": ("U", 89),
-    "V850": ("V", 89),
-    "Z250": ("Z", 49),  # level_id 49 ≈ 250 hPa
-    "U250": ("U", 49),
+    "T500": ("temperature", "T_PRES", 69.0, "pressure", 500.0),
+    "T700": ("temperature", "T_PRES", 79.0, "pressure", 700.0),
+    "T850": ("temperature", "T_PRES", 89.0, "pressure", 850.0),
+    "U500": ("u_component_of_wind", "U", 69.0, "level", 69.0),
+    "V500": ("v_component_of_wind", "V", 69.0, "level", 69.0),
+    "U850": ("u_component_of_wind", "U", 89.0, "level", 89.0),
+    "V850": ("v_component_of_wind", "V", 89.0, "level", 89.0),
+    "Q500": ("specific_humidity", "Q", 69.0, "level", 69.0),
+    "Q850": ("specific_humidity", "Q", 89.0, "level", 89.0),
 }
 
 WB2_SURFACE_VARS = ["t2m", "SP", "U500", "V500"]
 
 # ERA5 variable name mapping (zarr → CREDIT short name used in CSVs)
+# CREDIT ERA5 mlevel zarr files use the same short names as CREDIT output,
+# so upper-air variables are identity-mapped.
 ERA5_VAR_MAP = {
+    # upper-air (model-level ERA5 zarr uses CREDIT short names directly)
+    "Z": "Z",
+    "T": "T",
+    "U": "U",
+    "V": "V",
+    "Q": "Q",
+    # surface / diagnostic
     "u_component_of_wind": "U",
     "v_component_of_wind": "V",
     "temperature": "T",
@@ -207,7 +199,7 @@ def select_clim(ds_clim, valid_times, variable, level=None):
 
 def print_wb2_summary(scores_df):
     """Print WB2-style scorecard for key variables and lead times."""
-    key_vars = ["Z500", "T500", "t2m", "U500", "V500"]
+    key_vars = ["T500", "T850", "t2m", "U500", "V500", "Q850"]
     key_days = [1, 3, 5, 7, 10]
     key_steps = {d: d * 24 // 6 for d in key_days}  # assumes 6h steps
 
@@ -344,17 +336,23 @@ def compute_netcdf_scores(forecast_dir, era5_glob, clim_path=None, lead_time_hou
         valid_times = ds_pred_all.time.values
 
         # score upper-air variables at WB2 target levels
-        for label, (var_credit, level_id) in WB2_TARGET_LEVELS.items():
-            era5_var = next((k for k, v in ERA5_VAR_MAP.items() if v == var_credit), None)
-            if era5_var is None or era5_var not in ds_true_all:
+        for label, (era5_var, credit_var, era5_level, credit_coord, credit_level) in WB2_TARGET_LEVELS.items():
+            if era5_var not in ds_true_all:
+                logger.debug(f"Skipping {label}: ERA5 var '{era5_var}' not in dataset")
                 continue
-            if var_credit not in ds_pred_all:
+            if credit_var not in ds_pred_all:
+                logger.debug(f"Skipping {label}: forecast var '{credit_var}' not in dataset")
                 continue
-            da_pred = ds_pred_all[var_credit].sel(level=level_id, method="nearest")
-            da_true = ds_true_all[era5_var].sel(level=level_id, method="nearest")
+            da_pred = ds_pred_all[credit_var].sel({credit_coord: credit_level}, method="nearest")
+            da_true = ds_true_all[era5_var].sel(level=era5_level, method="nearest")
+            # Regrid ERA5 to forecast grid if coordinates differ (e.g. 192x288 vs 181x360)
+            if da_true.latitude.shape != da_pred.latitude.shape or not np.allclose(
+                da_true.latitude.values, da_pred.latitude.values, atol=0.1
+            ):
+                da_true = da_true.interp(latitude=da_pred.latitude, longitude=da_pred.longitude, method="linear")
             da_clim_var = None
             if ds_clim is not None and era5_var in ds_clim:
-                da_clim_var = select_clim(ds_clim, valid_times, era5_var, level=level_id)
+                da_clim_var = select_clim(ds_clim, valid_times, era5_var, level=era5_level)
                 da_clim_var = da_clim_var.interp(latitude=da_pred.latitude, longitude=da_pred.longitude)
             _add_scores(row, da_pred, da_true, label, da_clim=da_clim_var)
 
@@ -365,6 +363,11 @@ def compute_netcdf_scores(forecast_dir, era5_glob, clim_path=None, lead_time_hou
                 continue
             da_pred = ds_pred_all[credit_var]
             da_true = ds_true_all[era5_var]
+            # Regrid ERA5 to forecast grid if needed
+            if da_true.latitude.shape != da_pred.latitude.shape or not np.allclose(
+                da_true.latitude.values, da_pred.latitude.values, atol=0.1
+            ):
+                da_true = da_true.interp(latitude=da_pred.latitude, longitude=da_pred.longitude, method="linear")
             da_clim_var = None
             if ds_clim is not None and clim_var in ds_clim:
                 da_clim_var = select_clim(ds_clim, valid_times, clim_var)
@@ -496,6 +499,9 @@ def main():
     print_wb2_summary(scores)
 
     if args.plot:
+        import sys
+
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
         from plot_weatherbench import plot_all
 
         plot_all(args.out, args.plot, label=args.label, show_refs=not args.no_refs)

--- a/applications/eval_weatherbench.py
+++ b/applications/eval_weatherbench.py
@@ -24,6 +24,7 @@ import glob
 import logging
 import os
 import re
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 import numpy as np
@@ -248,9 +249,110 @@ def open_era5_year(era5_glob, year):
     return ds
 
 
-def compute_netcdf_scores(forecast_dir, era5_glob, clim_path=None, lead_time_hours=6, max_inits=None):
+def _score_step_worker(args):
+    """
+    Top-level worker for ProcessPoolExecutor (must be picklable).
+
+    Scores all forecasts at a single lead-time step against ERA5.
+
+    Parameters
+    ----------
+    args : tuple
+        (step, files, era5_glob, clim_path)
+
+    Returns
+    -------
+    dict  Row of WB2 scores for this step, or None on failure.
+    """
+    import logging as _logging
+
+    _log = _logging.getLogger(__name__)
+
+    step, files, era5_glob, clim_path = args
+    lead_h = step  # filename suffix is already lead-time hours
+
+    # Load climatology inside worker (no shared state across processes)
+    ds_clim = None
+    try:
+        ds_clim = load_climatology(clim_path)
+    except Exception as e:
+        _log.warning(f"Step {step}: could not load climatology ({e}); ACC skipped")
+
+    # Per-worker ERA5 cache (keyed by year; at most 2 years per step in practice)
+    era5_cache = {}
+
+    pred_list, true_list = [], []
+    for f in files:
+        try:
+            ds_pred = xr.open_dataset(f)
+        except Exception as e:
+            _log.warning(f"Step {step}: failed to open {f}: {e}")
+            continue
+        if "ensemble" in ds_pred.dims:
+            ds_pred = ds_pred.mean(dim="ensemble")
+        valid_time = ds_pred.time.values[0]
+        year = pd.Timestamp(valid_time).year
+
+        if year not in era5_cache:
+            era5_cache[year] = open_era5_year(era5_glob, year)
+            if len(era5_cache) > 2:
+                del era5_cache[min(era5_cache.keys())]
+
+        ds_true = era5_cache[year].sel(time=valid_time, method="nearest")
+        pred_list.append(ds_pred)
+        true_list.append(ds_true)
+
+    if not pred_list:
+        return None
+
+    ds_pred_all = xr.concat(pred_list, dim="time")
+    ds_true_all = xr.concat(true_list, dim="time")
+
+    row = {"lead_time_hours": lead_h, "forecast_step": step, "n_inits": len(pred_list)}
+    valid_times = ds_pred_all.time.values
+
+    # upper-air
+    for label, (era5_var, credit_var, era5_level, credit_coord, credit_level) in WB2_TARGET_LEVELS.items():
+        if era5_var not in ds_true_all or credit_var not in ds_pred_all:
+            continue
+        da_pred = ds_pred_all[credit_var].sel({credit_coord: credit_level}, method="nearest")
+        da_true = ds_true_all[era5_var].sel(level=era5_level, method="nearest")
+        if da_true.latitude.shape != da_pred.latitude.shape or not np.allclose(
+            da_true.latitude.values, da_pred.latitude.values, atol=0.1
+        ):
+            da_true = da_true.interp(latitude=da_pred.latitude, longitude=da_pred.longitude, method="linear")
+        da_clim_var = None
+        if ds_clim is not None and era5_var in ds_clim:
+            da_clim_var = select_clim(ds_clim, valid_times, era5_var, level=era5_level)
+            da_clim_var = da_clim_var.interp(latitude=da_pred.latitude, longitude=da_pred.longitude)
+        _add_scores(row, da_pred, da_true, label, da_clim=da_clim_var)
+
+    # surface
+    surface_map = {"t2m": ("VAR_2T", "2m_temperature"), "SP": ("SP", "SP")}
+    for credit_var, (era5_var, clim_var) in surface_map.items():
+        if credit_var not in ds_pred_all or era5_var not in ds_true_all:
+            continue
+        da_pred = ds_pred_all[credit_var]
+        da_true = ds_true_all[era5_var]
+        if da_true.latitude.shape != da_pred.latitude.shape or not np.allclose(
+            da_true.latitude.values, da_pred.latitude.values, atol=0.1
+        ):
+            da_true = da_true.interp(latitude=da_pred.latitude, longitude=da_pred.longitude, method="linear")
+        da_clim_var = None
+        if ds_clim is not None and clim_var in ds_clim:
+            da_clim_var = select_clim(ds_clim, valid_times, clim_var)
+            da_clim_var = da_clim_var.interp(latitude=da_pred.latitude, longitude=da_pred.longitude)
+        _add_scores(row, da_pred, da_true, credit_var, da_clim=da_clim_var)
+
+    _log.info(f"Step {step} ({lead_h}h): done ({len(pred_list)} inits)")
+    return row
+
+
+def compute_netcdf_scores(forecast_dir, era5_glob, clim_path=None, lead_time_hours=6, max_inits=None, workers=None):
     """
     Compute WB2 deterministic scores from forecast netCDFs against ERA5.
+
+    Each lead-time step is scored in parallel via ProcessPoolExecutor.
 
     Expects forecast_dir structured as:
         forecast_dir/{init_datetime}/pred_{init}_{step:03d}.nc
@@ -262,9 +364,11 @@ def compute_netcdf_scores(forecast_dir, era5_glob, clim_path=None, lead_time_hou
     era5_glob : str
         Glob pattern for ERA5 zarr files.
     lead_time_hours : int
-        Hours per step.
+        Hours per step (kept for signature compatibility; step suffix is authoritative).
     max_inits : int, optional
         Limit number of init dates (for testing).
+    workers : int, optional
+        Number of parallel workers.  Defaults to os.cpu_count().
 
     Returns
     -------
@@ -277,104 +381,31 @@ def compute_netcdf_scores(forecast_dir, era5_glob, clim_path=None, lead_time_hou
         init_dirs = init_dirs[:max_inits]
     logger.info(f"Found {len(init_dirs)} init dates in {forecast_dir}")
 
-    # load climatology once
-    ds_clim = None
-    try:
-        ds_clim = load_climatology(clim_path)
-        logger.info("Climatology loaded — will compute true anomaly ACC")
-    except Exception as e:
-        logger.warning(f"Could not load climatology ({e}); ACC will be skipped in netcdf mode")
-
-    # collect all forecast files, grouped by step
+    # collect forecast files grouped by step
     step_files = {}
     for init_dir in init_dirs:
         for f in sorted(init_dir.glob("pred_*.nc")):
-            # extract step from filename: pred_INIT_SSS.nc
             parts = f.stem.split("_")
             step = int(parts[-1])
             step_files.setdefault(step, []).append(f)
 
+    n_steps = len(step_files)
+    n_workers = workers or os.cpu_count() or 1
+    logger.info(f"Scoring {n_steps} steps with {n_workers} workers")
+
+    work_items = [(step, files, era5_glob, clim_path) for step, files in sorted(step_files.items())]
+
     all_records = []
-    era5_cache = {}
-
-    for step in sorted(step_files.keys()):
-        files = step_files[step]
-        lead_h = step  # filename suffix is already lead-time hours (e.g. _006.nc = 6h)
-        logger.info(f"Step {step} ({lead_h}h): {len(files)} forecasts")
-
-        pred_list, true_list = [], []
-        for f in files:
-            ds_pred = xr.open_dataset(f)
-            # collapse ensemble dim if present — use ensemble mean for deterministic scores
-            if "ensemble" in ds_pred.dims:
-                ds_pred = ds_pred.mean(dim="ensemble")
-            valid_time = ds_pred.time.values[0]
-            year = pd.Timestamp(valid_time).year
-
-            # load/cache ERA5 for this year
-            if year not in era5_cache:
-                logger.info(f"Opening ERA5 for {year}")
-                era5_cache[year] = open_era5_year(era5_glob, year)
-                # keep cache small
-                if len(era5_cache) > 2:
-                    oldest = min(era5_cache.keys())
-                    del era5_cache[oldest]
-
-            ds_true = era5_cache[year].sel(time=valid_time, method="nearest")
-            pred_list.append(ds_pred)
-            true_list.append(ds_true)
-
-        if not pred_list:
-            continue
-
-        # concatenate over init dates as "time" axis
-        ds_pred_all = xr.concat(pred_list, dim="time")
-        ds_true_all = xr.concat(true_list, dim="time")
-
-        row = {"lead_time_hours": lead_h, "forecast_step": step, "n_inits": len(files)}
-
-        valid_times = ds_pred_all.time.values
-
-        # score upper-air variables at WB2 target levels
-        for label, (era5_var, credit_var, era5_level, credit_coord, credit_level) in WB2_TARGET_LEVELS.items():
-            if era5_var not in ds_true_all:
-                logger.debug(f"Skipping {label}: ERA5 var '{era5_var}' not in dataset")
-                continue
-            if credit_var not in ds_pred_all:
-                logger.debug(f"Skipping {label}: forecast var '{credit_var}' not in dataset")
-                continue
-            da_pred = ds_pred_all[credit_var].sel({credit_coord: credit_level}, method="nearest")
-            da_true = ds_true_all[era5_var].sel(level=era5_level, method="nearest")
-            # Regrid ERA5 to forecast grid if coordinates differ (e.g. 192x288 vs 181x360)
-            if da_true.latitude.shape != da_pred.latitude.shape or not np.allclose(
-                da_true.latitude.values, da_pred.latitude.values, atol=0.1
-            ):
-                da_true = da_true.interp(latitude=da_pred.latitude, longitude=da_pred.longitude, method="linear")
-            da_clim_var = None
-            if ds_clim is not None and era5_var in ds_clim:
-                da_clim_var = select_clim(ds_clim, valid_times, era5_var, level=era5_level)
-                da_clim_var = da_clim_var.interp(latitude=da_pred.latitude, longitude=da_pred.longitude)
-            _add_scores(row, da_pred, da_true, label, da_clim=da_clim_var)
-
-        # score surface variables
-        surface_map = {"t2m": ("VAR_2T", "2m_temperature"), "SP": ("SP", "SP")}
-        for credit_var, (era5_var, clim_var) in surface_map.items():
-            if credit_var not in ds_pred_all or era5_var not in ds_true_all:
-                continue
-            da_pred = ds_pred_all[credit_var]
-            da_true = ds_true_all[era5_var]
-            # Regrid ERA5 to forecast grid if needed
-            if da_true.latitude.shape != da_pred.latitude.shape or not np.allclose(
-                da_true.latitude.values, da_pred.latitude.values, atol=0.1
-            ):
-                da_true = da_true.interp(latitude=da_pred.latitude, longitude=da_pred.longitude, method="linear")
-            da_clim_var = None
-            if ds_clim is not None and clim_var in ds_clim:
-                da_clim_var = select_clim(ds_clim, valid_times, clim_var)
-                da_clim_var = da_clim_var.interp(latitude=da_pred.latitude, longitude=da_pred.longitude)
-            _add_scores(row, da_pred, da_true, credit_var, da_clim=da_clim_var)
-
-        all_records.append(row)
+    with ProcessPoolExecutor(max_workers=n_workers) as pool:
+        futures = {pool.submit(_score_step_worker, item): item[0] for item in work_items}
+        for fut in as_completed(futures):
+            step = futures[fut]
+            try:
+                row = fut.result()
+                if row is not None:
+                    all_records.append(row)
+            except Exception as exc:
+                logger.error(f"Step {step} raised: {exc}")
 
     result = pd.DataFrame(all_records).sort_values("lead_time_hours").reset_index(drop=True)
     return result
@@ -471,6 +502,12 @@ def main():
         "--label", type=str, default="CREDIT", help="Model label used in plot legends (default: CREDIT)"
     )
     parser.add_argument("--no-refs", action="store_true", help="Omit IFS/Pangu/GraphCast reference lines in plots")
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=None,
+        help="Parallel workers for --netcdf mode (default: os.cpu_count())",
+    )
     parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args()
 
@@ -491,6 +528,7 @@ def main():
             clim_path=args.clim,
             lead_time_hours=args.lead_time_hours,
             max_inits=args.max_inits,
+            workers=args.workers,
         )
 
     scores.to_csv(args.out, index=False)

--- a/applications/hres_wb2_verif.py
+++ b/applications/hres_wb2_verif.py
@@ -1,0 +1,314 @@
+"""
+HRES deterministic WeatherBench-style ACC + RMSE verification.
+
+Compares IFS HRES forecasts (from HRES.zarr) vs ERA5 cesm_stage1 analysis,
+evaluated at the CREDIT 1.25° (192×288) Gaussian grid via xesmf bilinear regridding.
+
+Output format matches wxformer_wb2_verif.py:
+  ACC_006h_240h_{tag}.nc  : dims (days, time=40), vars Z500/T500/U500/V500/Q500/SP/t2m
+  RMSE_006h_240h_{tag}.nc : same
+
+Usage
+-----
+python applications/hres_wb2_verif.py \\
+    [--hres /glade/derecho/scratch/schreck/HRES.zarr] \\
+    [--out /glade/work/schreck/CREDIT_verif/hres] \\
+    [--year 2022] [--init-hour 0]
+"""
+
+import argparse
+import glob
+import logging
+import os
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+import xesmf as xe
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HRES = "/glade/derecho/scratch/schreck/HRES.zarr"
+DEFAULT_CESM_GLOB = (
+    "/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_cesm_stage1/all_in_one/ERA5_mlevel_cesm_6h_lev16_*.zarr"
+)
+DEFAULT_CLIM_PATH = "/glade/campaign/cisl/aiml/ksha/CREDIT_CESM/VERIF/ERA5_clim/ERA5_clim_1990_2019_6h_cesm_interp.nc"
+DEFAULT_OUT = "/glade/work/schreck/CREDIT_verif/hres"
+
+LEAD_HOURS = list(range(6, 241, 6))  # 40 leads, 6h..240h
+CLIM_LEV_500 = 7  # 500 hPa index in ERA5_clim (0-indexed)
+
+
+# ---------------------------------------------------------------------------
+# Spatial averaging — identical to wxformer_wb2_verif.py
+# ---------------------------------------------------------------------------
+def _sp_avg(da, w_lat):
+    return da.weighted(w_lat).mean(["latitude", "longitude"], skipna=False)
+
+
+def _make_w_lat_xr(lats):
+    w = np.cos(np.deg2rad(lats))
+    return xr.DataArray(w / w.mean(), dims=["latitude"], coords={"latitude": lats})
+
+
+def _acc(pred_anom, true_anom, w_lat):
+    top = _sp_avg(pred_anom * true_anom, w_lat)
+    bottom = np.sqrt(_sp_avg(pred_anom**2, w_lat) * _sp_avg(true_anom**2, w_lat))
+    return top / (bottom + 1e-12)
+
+
+def _rmse(pred, truth, w_lat):
+    return np.sqrt(_sp_avg((pred - truth) ** 2, w_lat))
+
+
+# ---------------------------------------------------------------------------
+# Build output dataset — same format as wxformer_wb2_verif.py
+# ---------------------------------------------------------------------------
+def _build_dataset(results_list, kind):
+    var_names = list(results_list[0][kind].keys())
+    doy = np.array([r["dayofyear"] for r in results_list])
+    hour = np.array([r["hour"] for r in results_list])
+
+    ds = xr.Dataset()
+    for v in var_names:
+        data = np.array([r[kind][v] for r in results_list])  # (days, time)
+        ds[v] = xr.DataArray(data, dims=["days", "time"])
+    ds = ds.assign_coords(
+        dayofyear=(["days", "time"], doy),
+        hour=(["days", "time"], hour),
+    )
+    return ds
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(description="HRES deterministic WeatherBench ACC/RMSE verification")
+    parser.add_argument("--hres", default=DEFAULT_HRES, help="Path to HRES.zarr")
+    parser.add_argument("--out", default=DEFAULT_OUT)
+    parser.add_argument("--cesm", default=DEFAULT_CESM_GLOB)
+    parser.add_argument("--clim", default=DEFAULT_CLIM_PATH)
+    parser.add_argument("--tag", default="hres", help="Tag appended to output filenames (e.g. 'hres_2022')")
+    parser.add_argument("--year", type=int, default=None, help="Restrict to a single calendar year (e.g. 2022)")
+    parser.add_argument(
+        "--init-hour", type=int, default=None, help="Restrict to specific init hour: 0 (00Z) or 12 (12Z)"
+    )
+    parser.add_argument("--weights-dir", default="/tmp", help="Cache dir for xesmf regridder weight files")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    os.makedirs(args.out, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Open data sources lazily
+    # ------------------------------------------------------------------
+    logger.info("Opening HRES.zarr (lazy)...")
+    ds_hres = xr.open_zarr(args.hres)
+
+    logger.info("Opening cesm_stage1 zarr (lazy)...")
+    cesm_files = sorted(glob.glob(args.cesm))
+    ds_cesm = xr.open_mfdataset(cesm_files, combine="by_coords", engine="zarr")
+    truth_vars = ["Z500", "T500", "U500", "V500", "Q500", "SP", "t2m"]
+
+    logger.info("Loading climatology...")
+    ds_clim_full = xr.open_dataset(args.clim).load()
+    logger.info("Climatology loaded")
+
+    # ------------------------------------------------------------------
+    # Filter HRES init times
+    # ------------------------------------------------------------------
+    hres_times = pd.DatetimeIndex(ds_hres.time.values)
+    mask = np.ones(len(hres_times), dtype=bool)
+    if args.year is not None:
+        mask &= hres_times.year == args.year
+    if args.init_hour is not None:
+        mask &= hres_times.hour == args.init_hour
+    hres_times_sel = hres_times[mask]
+    logger.info(f"{len(hres_times_sel)} HRES init times selected")
+
+    if len(hres_times_sel) == 0:
+        raise ValueError("No HRES init times matched filter criteria.")
+
+    # ------------------------------------------------------------------
+    # Build xesmf regridder: HRES (0.25°, 721×1440) → cesm_stage1 (192×288)
+    # Rename latitude/longitude → lat/lon for xesmf
+    # ------------------------------------------------------------------
+    logger.info("Building xesmf regridder (HRES → cesm_stage1)...")
+    ds_hres_grid = xr.Dataset(
+        {
+            "lat": ("lat", ds_hres.latitude.values.astype(np.float64)),
+            "lon": ("lon", ds_hres.longitude.values.astype(np.float64)),
+        }
+    )
+    cesm_lats = ds_cesm.latitude.values
+    cesm_lons = ds_cesm.longitude.values
+    ds_out_grid = xr.Dataset(
+        {
+            "lat": ("lat", cesm_lats.astype(np.float64)),
+            "lon": ("lon", cesm_lons.astype(np.float64)),
+        }
+    )
+    weights_file = os.path.join(
+        args.weights_dir,
+        f"xesmf_hres{len(ds_hres.latitude)}x{len(ds_hres.longitude)}"
+        f"_to_credit{len(cesm_lats)}x{len(cesm_lons)}_bilinear.nc",
+    )
+    regridder = xe.Regridder(
+        ds_hres_grid,
+        ds_out_grid,
+        method="bilinear",
+        periodic=True,
+        filename=weights_file,
+        reuse_weights=os.path.exists(weights_file),
+    )
+    logger.info(f"Regridder ready (weights: {weights_file})")
+
+    w_xr = _make_w_lat_xr(cesm_lats)
+
+    # HRES variable name + pressure level (hPa int, or None for 2D vars)
+    hres_var_map = {
+        "Z500": ("geopotential", 500),
+        "T500": ("temperature", 500),
+        "U500": ("u_component_of_wind", 500),
+        "V500": ("v_component_of_wind", 500),
+        "Q500": ("specific_humidity", 500),
+        "SP": ("surface_pressure", None),
+        "t2m": ("2m_temperature", None),
+    }
+
+    # Climatology variable name + level index for ACC computation
+    clim_var_map = {
+        "Z500": ("geopotential", CLIM_LEV_500),
+        "T500": ("temperature", CLIM_LEV_500),
+        "U500": ("u_component_of_wind", CLIM_LEV_500),
+        "V500": ("v_component_of_wind", CLIM_LEV_500),
+        "Q500": ("specific_humidity", CLIM_LEV_500),
+        "SP": ("surface_pressure", None),
+        "t2m": ("2m_temperature", None),
+    }
+
+    # Pre-build timedeltas for HRES lead times
+    hres_tds = [pd.Timedelta(hours=lh) for lh in LEAD_HOURS]
+
+    # ------------------------------------------------------------------
+    # Main loop: one HRES init at a time
+    # ------------------------------------------------------------------
+    results, n_inits = [], len(hres_times_sel)
+
+    for i, t0_pd in enumerate(hres_times_sel):
+        t0_np = np.datetime64(t0_pd)
+        vtimes = np.array([t0_np + np.timedelta64(lh, "h") for lh in LEAD_HOURS])
+
+        # load 40 truth timesteps; skip if any are outside cesm_stage1 coverage
+        try:
+            ds_truth = ds_cesm[truth_vars].sel(time=vtimes).load()
+        except (KeyError, ValueError):
+            logger.debug(f"  {t0_pd}: truth coverage incomplete, skipping")
+            continue
+
+        dt_idx = pd.DatetimeIndex(vtimes)
+        doy_arr = dt_idx.day_of_year.values
+        hour_arr = dt_idx.hour.values
+
+        clim_list = [ds_clim_full.sel(dayofyear=int(d), hour=int(h)) for d, h in zip(doy_arr, hour_arr)]
+        ds_clim = xr.concat(clim_list, dim="time")
+        ds_clim["time"] = ds_truth.time
+
+        rmse_v = {v: np.zeros(len(LEAD_HOURS)) for v in hres_var_map}
+        acc_v = {v: np.zeros(len(LEAD_HOURS)) for v in hres_var_map}
+
+        for li, (lh, td) in enumerate(zip(LEAD_HOURS, hres_tds)):
+            hres_slice = ds_hres.sel(
+                time=t0_pd,
+                prediction_timedelta=np.timedelta64(int(td.total_seconds() * 1e9), "ns"),
+            )
+
+            for vname, (hres_var, hres_lev) in hres_var_map.items():
+                if hres_lev is not None:
+                    fc_raw = hres_slice[hres_var].sel(level=hres_lev).load()
+                else:
+                    fc_raw = hres_slice[hres_var].load()
+
+                # regrid HRES (0.25°) → cesm_stage1 (1.25°)
+                ds_in = xr.Dataset(
+                    {
+                        "data": xr.DataArray(
+                            fc_raw.values.astype(np.float64),
+                            dims=["lat", "lon"],
+                            coords={
+                                "lat": ds_hres.latitude.values.astype(np.float64),
+                                "lon": ds_hres.longitude.values.astype(np.float64),
+                            },
+                        )
+                    }
+                )
+                fc_out = xr.DataArray(
+                    regridder(ds_in)["data"].values,
+                    dims=["latitude", "longitude"],
+                    coords={"latitude": cesm_lats, "longitude": cesm_lons},
+                )
+
+                truth_da = ds_truth[vname].isel(time=li)
+                clim_var, clim_lev = clim_var_map[vname]
+                if clim_lev is not None:
+                    clim_da = ds_clim[clim_var].isel(level=clim_lev, time=li)
+                else:
+                    clim_da = ds_clim[clim_var].isel(time=li)
+
+                rmse_v[vname][li] = float(_rmse(fc_out, truth_da, w_xr).values)
+                acc_v[vname][li] = float(_acc(fc_out - clim_da, truth_da - clim_da, w_xr).values)
+
+        results.append(
+            {
+                "rmse": rmse_v,
+                "acc": acc_v,
+                "dayofyear": doy_arr,
+                "hour": hour_arr,
+            }
+        )
+
+        if (i + 1) % 50 == 0 or (i + 1) == n_inits:
+            logger.info(
+                f"[{i + 1}/{n_inits}] {t0_pd.strftime('%Y-%m-%dT%HZ')}  "
+                f"Z500_rmse6h={rmse_v['Z500'][0]:.1f}  "
+                f"Z500_acc6h={acc_v['Z500'][0]:.5f}"
+            )
+
+    logger.info(f"Processed {len(results)} inits")
+    if not results:
+        logger.warning("No results to save.")
+        return
+
+    results.sort(key=lambda r: (r["dayofyear"][0], r["hour"][0]))
+
+    # ------------------------------------------------------------------
+    # Save outputs: combined + per-100-init batch files
+    # ------------------------------------------------------------------
+    tag = args.tag
+    for kind in ("rmse", "acc"):
+        ds_out = _build_dataset(results, kind)
+        path = os.path.join(args.out, f"{kind.upper()}_006h_240h_{tag}.nc")
+        ds_out.to_netcdf(path)
+        logger.info(f"{kind.upper()} → {path}")
+
+        n = len(results)
+        for start in range(0, n, 100):
+            end = min(start + 100, n)
+            batch = results[start:end]
+            _build_dataset(batch, kind).to_netcdf(
+                os.path.join(
+                    args.out,
+                    f"combined_{kind}_{start:04d}_{end:04d}_006h_240h_{tag}.nc",
+                )
+            )
+
+    logger.info("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/applications/plot_weatherbench.py
+++ b/applications/plot_weatherbench.py
@@ -17,10 +17,14 @@ python plot_weatherbench.py --scores wb2_scores.csv --label "WXFormer v2" --out 
 import argparse
 import logging
 import os
+from concurrent.futures import ProcessPoolExecutor
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
+matplotlib.use("Agg")  # non-interactive backend; safe for multiprocessing
 
 from credit.verification.wb2_references import WB2_SCORES, WB2_STYLE
 
@@ -74,71 +78,22 @@ def _add_ref_lines(ax, varname, metric, label_refs=True):
         )
 
 
-def plot_rmse(df, out_dir, label="CREDIT", show_refs=True):
-    """RMSE vs lead time for each variable — one panel per variable."""
+def plot_rmse(df, out_dir, label="CREDIT", show_refs=True, workers=None):
+    """RMSE vs lead time for each variable — one panel per variable, parallel."""
     os.makedirs(out_dir, exist_ok=True)
-    for var, meta in PLOT_VARS.items():
-        col = f"rmse_{var}"
-        if col not in df.columns:
-            continue
-
-        fig, ax = plt.subplots(figsize=(8, 5))
-        lt = df["lead_time_hours"].values
-        ax.plot(lt, df[col].values, "k-o", linewidth=2, markersize=4, label=label, zorder=5)
-
-        if show_refs:
-            _add_ref_lines(ax, var, "rmse")
-
-        max_lt = lt.max()
-        _day_ticks(ax, max_lt)
-        ax.set_xlabel("Lead time")
-        ax.set_ylabel(f"RMSE [{meta['rmse_unit']}]")
-        ax.set_title(f"{meta['title']} — RMSE")
-        ax.legend(loc="upper left", fontsize=9)
-        ax.grid(True, alpha=0.3)
-        ax.set_xlim(0, max_lt + 12)
-        ax.set_ylim(bottom=0)
-
-        path = os.path.join(out_dir, f"rmse_{var}.png")
-        fig.savefig(path, dpi=150, bbox_inches="tight")
-        plt.close(fig)
-        logger.info(f"Saved {path}")
+    df_dict = df.to_dict(orient="list")
+    tasks = [(var, meta, df_dict, out_dir, label, show_refs) for var, meta in PLOT_VARS.items()]
+    with ProcessPoolExecutor(max_workers=workers or os.cpu_count()) as pool:
+        list(pool.map(_plot_rmse_worker, tasks))
 
 
-def plot_acc(df, out_dir, label="CREDIT", show_refs=True):
-    """ACC vs lead time for variables where ACC is in the scores CSV."""
+def plot_acc(df, out_dir, label="CREDIT", show_refs=True, workers=None):
+    """ACC vs lead time for variables where ACC is in the scores CSV, parallel."""
     os.makedirs(out_dir, exist_ok=True)
-    for var, meta in PLOT_VARS.items():
-        if not meta["acc"]:
-            continue
-        col = f"acc_{var}"
-        if col not in df.columns:
-            continue
-
-        fig, ax = plt.subplots(figsize=(8, 5))
-        lt = df["lead_time_hours"].values
-        ax.plot(lt, df[col].values, "k-o", linewidth=2, markersize=4, label=label, zorder=5)
-
-        if show_refs:
-            _add_ref_lines(ax, var, "acc")
-
-        # ACC = 0.6 is a common "skill limit" line
-        max_lt = lt.max()
-        ax.axhline(0.6, color="gray", linestyle="--", linewidth=1, alpha=0.7, label="ACC = 0.6")
-
-        _day_ticks(ax, max_lt)
-        ax.set_xlabel("Lead time")
-        ax.set_ylabel("ACC")
-        ax.set_title(f"{meta['title']} — Anomaly Correlation Coefficient")
-        ax.legend(loc="upper right", fontsize=9)
-        ax.grid(True, alpha=0.3)
-        ax.set_xlim(0, max_lt + 12)
-        ax.set_ylim(0.4, 1.02)
-
-        path = os.path.join(out_dir, f"acc_{var}.png")
-        fig.savefig(path, dpi=150, bbox_inches="tight")
-        plt.close(fig)
-        logger.info(f"Saved {path}")
+    df_dict = df.to_dict(orient="list")
+    tasks = [(var, meta, df_dict, out_dir, label, show_refs) for var, meta in PLOT_VARS.items()]
+    with ProcessPoolExecutor(max_workers=workers or os.cpu_count()) as pool:
+        list(pool.map(_plot_acc_worker, tasks))
 
 
 def plot_bias(df, out_dir, label="CREDIT"):
@@ -242,49 +197,114 @@ def plot_scorecard(df, out_dir, label="CREDIT"):
     logger.info(f"Saved {path}")
 
 
-def plot_regional_rmse(df, out_dir, label="CREDIT"):
-    """Regional RMSE breakdown: one figure per variable, four lines for regions."""
+def plot_regional_rmse(df, out_dir, label="CREDIT", workers=None):
+    """Regional RMSE breakdown: one figure per variable, four lines for regions, parallel."""
     os.makedirs(out_dir, exist_ok=True)
+    df_dict = df.to_dict(orient="list")
+    tasks = [(var, meta, df_dict, out_dir, label) for var, meta in PLOT_VARS.items()]
+    with ProcessPoolExecutor(max_workers=workers or os.cpu_count()) as pool:
+        list(pool.map(_plot_regional_rmse_worker, tasks))
+
+
+def _plot_rmse_worker(args):
+    var, meta, df_dict, out_dir, label, show_refs = args
+    df = pd.DataFrame(df_dict)
+    col = f"rmse_{var}"
+    if col not in df.columns:
+        return
+    fig, ax = plt.subplots(figsize=(8, 5))
+    lt = df["lead_time_hours"].values
+    ax.plot(lt, df[col].values, "k-o", linewidth=2, markersize=4, label=label, zorder=5)
+    if show_refs:
+        _add_ref_lines(ax, var, "rmse")
+    max_lt = lt.max()
+    _day_ticks(ax, max_lt)
+    ax.set_xlabel("Lead time")
+    ax.set_ylabel(f"RMSE [{meta['rmse_unit']}]")
+    ax.set_title(f"{meta['title']} — RMSE")
+    ax.legend(loc="upper left", fontsize=9)
+    ax.grid(True, alpha=0.3)
+    ax.set_xlim(0, max_lt + 12)
+    ax.set_ylim(bottom=0)
+    path = os.path.join(out_dir, f"rmse_{var}.png")
+    fig.savefig(path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _plot_acc_worker(args):
+    var, meta, df_dict, out_dir, label, show_refs = args
+    if not meta["acc"]:
+        return
+    df = pd.DataFrame(df_dict)
+    col = f"acc_{var}"
+    if col not in df.columns:
+        return
+    fig, ax = plt.subplots(figsize=(8, 5))
+    lt = df["lead_time_hours"].values
+    ax.plot(lt, df[col].values, "k-o", linewidth=2, markersize=4, label=label, zorder=5)
+    if show_refs:
+        _add_ref_lines(ax, var, "acc")
+    max_lt = lt.max()
+    ax.axhline(0.6, color="gray", linestyle="--", linewidth=1, alpha=0.7, label="ACC = 0.6")
+    _day_ticks(ax, max_lt)
+    ax.set_xlabel("Lead time")
+    ax.set_ylabel("ACC")
+    ax.set_title(f"{meta['title']} — Anomaly Correlation Coefficient")
+    ax.legend(loc="upper right", fontsize=9)
+    ax.grid(True, alpha=0.3)
+    ax.set_xlim(0, max_lt + 12)
+    ax.set_ylim(0.4, 1.02)
+    path = os.path.join(out_dir, f"acc_{var}.png")
+    fig.savefig(path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _plot_regional_rmse_worker(args):
+    var, meta, df_dict, out_dir, label = args
+    df = pd.DataFrame(df_dict)
     colors = {"global": "black", "tropics": "#d62728", "n_extratropics": "#1f77b4", "s_extratropics": "#9467bd"}
-
-    for var in PLOT_VARS:
-        # Check if regional columns exist
-        region_cols = [f"rmse_{var}_{r}" for r in REGIONS]
-        if not any(c in df.columns for c in region_cols):
+    region_cols = [f"rmse_{var}_{r}" for r in REGIONS]
+    if not any(c in df.columns for c in region_cols):
+        return
+    fig, ax = plt.subplots(figsize=(8, 5))
+    lt = df["lead_time_hours"].values
+    for region in REGIONS:
+        col = f"rmse_{var}_{region}"
+        if col not in df.columns:
             continue
-
-        fig, ax = plt.subplots(figsize=(8, 5))
-        lt = df["lead_time_hours"].values
-        for region in REGIONS:
-            col = f"rmse_{var}_{region}"
-            if col not in df.columns:
-                continue
-            ax.plot(lt, df[col].values, label=REGION_LABELS[region], color=colors[region], linewidth=1.8)
-
-        meta = PLOT_VARS.get(var, {})
-        _day_ticks(ax, lt.max())
-        ax.set_xlabel("Lead time")
-        ax.set_ylabel(f"RMSE [{meta.get('rmse_unit', '')}]")
-        ax.set_title(f"{label} — {meta.get('title', var)} RMSE by Region")
-        ax.legend(fontsize=9)
-        ax.grid(True, alpha=0.3)
-        ax.set_ylim(bottom=0)
-
-        path = os.path.join(out_dir, f"regional_rmse_{var}.png")
-        fig.savefig(path, dpi=150, bbox_inches="tight")
-        plt.close(fig)
-        logger.info(f"Saved {path}")
+        ax.plot(lt, df[col].values, label=REGION_LABELS[region], color=colors[region], linewidth=1.8)
+    _day_ticks(ax, lt.max())
+    ax.set_xlabel("Lead time")
+    ax.set_ylabel(f"RMSE [{meta.get('rmse_unit', '')}]")
+    ax.set_title(f"{label} — {meta.get('title', var)} RMSE by Region")
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.3)
+    ax.set_ylim(bottom=0)
+    path = os.path.join(out_dir, f"regional_rmse_{var}.png")
+    fig.savefig(path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
 
 
-def plot_all(scores_csv, out_dir, label="CREDIT", show_refs=True):
+def plot_all(scores_csv, out_dir, label="CREDIT", show_refs=True, workers=None):
     df = pd.read_csv(scores_csv)
     logger.info(f"Loaded {len(df)} lead-time rows from {scores_csv}")
+    os.makedirs(out_dir, exist_ok=True)
 
-    plot_rmse(df, out_dir, label=label, show_refs=show_refs)
-    plot_acc(df, out_dir, label=label, show_refs=show_refs)
+    df_dict = df.to_dict(orient="list")  # serializable for workers
+    n_workers = workers or os.cpu_count() or 1
+
+    rmse_tasks = [(var, meta, df_dict, out_dir, label, show_refs) for var, meta in PLOT_VARS.items()]
+    acc_tasks = [(var, meta, df_dict, out_dir, label, show_refs) for var, meta in PLOT_VARS.items()]
+    regional_tasks = [(var, meta, df_dict, out_dir, label) for var, meta in PLOT_VARS.items()]
+
+    with ProcessPoolExecutor(max_workers=n_workers) as pool:
+        list(pool.map(_plot_rmse_worker, rmse_tasks))
+        list(pool.map(_plot_acc_worker, acc_tasks))
+        list(pool.map(_plot_regional_rmse_worker, regional_tasks))
+
+    # bias and scorecard are single figures — run in main process
     plot_bias(df, out_dir, label=label)
     plot_scorecard(df, out_dir, label=label)
-    plot_regional_rmse(df, out_dir, label=label)
 
     logger.info(f"All figures saved to {out_dir}/")
 
@@ -295,6 +315,9 @@ def main():
     parser.add_argument("--out", default="wb2_figures", help="Output directory for PNG figures")
     parser.add_argument("--label", default="CREDIT", help="Model label for legend")
     parser.add_argument("--no-refs", action="store_true", help="Omit IFS/Pangu/GraphCast reference lines")
+    parser.add_argument(
+        "--workers", type=int, default=None, help="Parallel workers for figure generation (default: os.cpu_count())"
+    )
     parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args()
 
@@ -303,7 +326,7 @@ def main():
         format="%(levelname)s:%(name)s:%(message)s",
     )
 
-    plot_all(args.scores, args.out, label=args.label, show_refs=not args.no_refs)
+    plot_all(args.scores, args.out, label=args.label, show_refs=not args.no_refs, workers=args.workers)
 
 
 if __name__ == "__main__":

--- a/applications/plot_weatherbench.py
+++ b/applications/plot_weatherbench.py
@@ -1,0 +1,310 @@
+"""
+WeatherBench2-style scorecard plots for CREDIT forecasts.
+
+Reads a WB2 scores CSV produced by eval_weatherbench.py and generates:
+  - RMSE vs lead time (per variable, with IFS/Pangu/GraphCast reference lines)
+  - ACC  vs lead time (per variable, with reference lines where available)
+  - Bias vs lead time (per variable)
+  - Scorecard heatmap (skill score vs IFS HRES)
+  - Regional RMSE breakdown (global / tropics / extratropics)
+
+Usage
+-----
+python plot_weatherbench.py --scores wb2_scores.csv --out figures/
+python plot_weatherbench.py --scores wb2_scores.csv --label "WXFormer v2" --out figures/ --no-refs
+"""
+
+import argparse
+import logging
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from credit.verification.wb2_references import WB2_SCORES, WB2_STYLE
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Variables to plot and their display metadata
+# ---------------------------------------------------------------------------
+PLOT_VARS = {
+    "Z500": {"title": "Z500 (500 hPa Geopotential)", "rmse_unit": "m²/s²", "acc": True},
+    "T850": {"title": "T850 (850 hPa Temperature)", "rmse_unit": "K", "acc": True},
+    "t2m": {"title": "2 m Temperature", "rmse_unit": "K", "acc": False},
+    "U850": {"title": "U850 (850 hPa Zonal Wind)", "rmse_unit": "m/s", "acc": False},
+    "V850": {"title": "V850 (850 hPa Meridional Wind)", "rmse_unit": "m/s", "acc": False},
+    "T500": {"title": "T500 (500 hPa Temperature)", "rmse_unit": "K", "acc": False},
+    "SP": {"title": "Surface Pressure", "rmse_unit": "Pa", "acc": False},
+}
+
+# Regions for regional breakdown plots
+REGIONS = ["global", "tropics", "n_extratropics", "s_extratropics"]
+REGION_LABELS = {
+    "global": "Global",
+    "tropics": "Tropics (20°S–20°N)",
+    "n_extratropics": "N. Extratropics (20–90°N)",
+    "s_extratropics": "S. Extratropics (90–20°S)",
+}
+
+# Standard WB2 lead times for x-axis ticks
+DAY_TICKS = [1, 2, 3, 4, 5, 6, 7, 10]
+
+
+def _day_ticks(ax, max_hours):
+    """Set x-axis to show days."""
+    ticks_h = [d * 24 for d in DAY_TICKS if d * 24 <= max_hours]
+    ax.set_xticks(ticks_h)
+    ax.set_xticklabels([f"Day {d}" for d in DAY_TICKS if d * 24 <= max_hours], rotation=30, ha="right")
+
+
+def _add_ref_lines(ax, varname, metric, label_refs=True):
+    """Overlay WB2 reference model lines on ax."""
+    for model, style in WB2_STYLE.items():
+        data = WB2_SCORES.get(model, {}).get(varname, {}).get(metric)
+        if data is None:
+            continue
+        lts, vals = zip(*data)
+        ax.plot(
+            lts,
+            vals,
+            label=model if label_refs else "_nolegend_",
+            **style,
+        )
+
+
+def plot_rmse(df, out_dir, label="CREDIT", show_refs=True):
+    """RMSE vs lead time for each variable — one panel per variable."""
+    os.makedirs(out_dir, exist_ok=True)
+    for var, meta in PLOT_VARS.items():
+        col = f"rmse_{var}"
+        if col not in df.columns:
+            continue
+
+        fig, ax = plt.subplots(figsize=(8, 5))
+        lt = df["lead_time_hours"].values
+        ax.plot(lt, df[col].values, "k-o", linewidth=2, markersize=4, label=label, zorder=5)
+
+        if show_refs:
+            _add_ref_lines(ax, var, "rmse")
+
+        max_lt = lt.max()
+        _day_ticks(ax, max_lt)
+        ax.set_xlabel("Lead time")
+        ax.set_ylabel(f"RMSE [{meta['rmse_unit']}]")
+        ax.set_title(f"{meta['title']} — RMSE")
+        ax.legend(loc="upper left", fontsize=9)
+        ax.grid(True, alpha=0.3)
+        ax.set_xlim(0, max_lt + 12)
+        ax.set_ylim(bottom=0)
+
+        path = os.path.join(out_dir, f"rmse_{var}.png")
+        fig.savefig(path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        logger.info(f"Saved {path}")
+
+
+def plot_acc(df, out_dir, label="CREDIT", show_refs=True):
+    """ACC vs lead time for variables where ACC is in the scores CSV."""
+    os.makedirs(out_dir, exist_ok=True)
+    for var, meta in PLOT_VARS.items():
+        if not meta["acc"]:
+            continue
+        col = f"acc_{var}"
+        if col not in df.columns:
+            continue
+
+        fig, ax = plt.subplots(figsize=(8, 5))
+        lt = df["lead_time_hours"].values
+        ax.plot(lt, df[col].values, "k-o", linewidth=2, markersize=4, label=label, zorder=5)
+
+        if show_refs:
+            _add_ref_lines(ax, var, "acc")
+
+        # ACC = 0.6 is a common "skill limit" line
+        max_lt = lt.max()
+        ax.axhline(0.6, color="gray", linestyle="--", linewidth=1, alpha=0.7, label="ACC = 0.6")
+
+        _day_ticks(ax, max_lt)
+        ax.set_xlabel("Lead time")
+        ax.set_ylabel("ACC")
+        ax.set_title(f"{meta['title']} — Anomaly Correlation Coefficient")
+        ax.legend(loc="upper right", fontsize=9)
+        ax.grid(True, alpha=0.3)
+        ax.set_xlim(0, max_lt + 12)
+        ax.set_ylim(0.4, 1.02)
+
+        path = os.path.join(out_dir, f"acc_{var}.png")
+        fig.savefig(path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        logger.info(f"Saved {path}")
+
+
+def plot_bias(df, out_dir, label="CREDIT"):
+    """Bias vs lead time — global mean bias per variable."""
+    os.makedirs(out_dir, exist_ok=True)
+    bias_cols = [c for c in df.columns if c.startswith("bias_") and not any(r in c for r in REGIONS)]
+    vars_found = [c.replace("bias_", "") for c in bias_cols]
+
+    if not vars_found:
+        return
+
+    n = len(vars_found)
+    ncols = min(3, n)
+    nrows = (n + ncols - 1) // ncols
+    fig, axes = plt.subplots(nrows, ncols, figsize=(5 * ncols, 4 * nrows), squeeze=False)
+    axes = axes.flatten()
+
+    lt = df["lead_time_hours"].values
+    for i, var in enumerate(vars_found):
+        ax = axes[i]
+        ax.plot(lt, df[f"bias_{var}"].values, "k-o", linewidth=1.5, markersize=3, label=label)
+        ax.axhline(0, color="gray", linewidth=0.8, linestyle="--")
+        meta = PLOT_VARS.get(var, {})
+        _day_ticks(ax, lt.max())
+        ax.set_title(var)
+        ax.set_ylabel(f"Bias [{meta.get('rmse_unit', '')}]")
+        ax.grid(True, alpha=0.3)
+
+    for j in range(i + 1, len(axes)):
+        axes[j].set_visible(False)
+
+    fig.suptitle(f"{label} — Mean Bias (forecast − ERA5)", fontsize=12)
+    fig.tight_layout()
+    path = os.path.join(out_dir, "bias_all.png")
+    fig.savefig(path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info(f"Saved {path}")
+
+
+def plot_scorecard(df, out_dir, label="CREDIT"):
+    """
+    WB2-style scorecard heatmap: skill score vs IFS HRES at key lead times.
+    SS = 1 - RMSE_model / RMSE_IFS.  Green = better than IFS, red = worse.
+    """
+    os.makedirs(out_dir, exist_ok=True)
+
+    key_vars = [v for v in PLOT_VARS if f"rmse_{v}" in df.columns]
+    key_days = [1, 2, 3, 5, 7, 10]
+    key_lts = [d * 24 for d in key_days]
+
+    # Build skill score matrix
+    rows = []
+    for var in key_vars:
+        col = f"rmse_{var}"
+        ref_data = WB2_SCORES.get("IFS HRES", {}).get(var, {}).get("rmse")
+        if ref_data is None:
+            continue
+        ref_dict = dict(ref_data)
+        row_vals = []
+        for lt in key_lts:
+            credit_row = df[df["lead_time_hours"] == lt]
+            if credit_row.empty or lt not in ref_dict:
+                row_vals.append(np.nan)
+                continue
+            credit_rmse = credit_row[col].values[0]
+            ifs_rmse = ref_dict[lt]
+            ss = 1.0 - credit_rmse / ifs_rmse
+            row_vals.append(ss)
+        rows.append(row_vals)
+
+    if not rows:
+        logger.warning("No IFS reference data to build scorecard")
+        return
+
+    skill = np.array(rows)
+    var_labels = [v for v in key_vars if WB2_SCORES.get("IFS HRES", {}).get(v, {}).get("rmse")]
+
+    fig, ax = plt.subplots(figsize=(len(key_days) * 1.2 + 2, len(var_labels) * 0.6 + 1.5))
+    im = ax.imshow(skill, cmap="RdYlGn", vmin=-0.3, vmax=0.3, aspect="auto")
+
+    # Annotate cells
+    for r in range(skill.shape[0]):
+        for c in range(skill.shape[1]):
+            val = skill[r, c]
+            if np.isfinite(val):
+                txt = f"{val:+.2f}"
+                color = "black" if abs(val) < 0.2 else "white"
+                ax.text(c, r, txt, ha="center", va="center", fontsize=8, color=color)
+
+    ax.set_xticks(range(len(key_days)))
+    ax.set_xticklabels([f"Day {d}" for d in key_days])
+    ax.set_yticks(range(len(var_labels)))
+    ax.set_yticklabels(var_labels)
+    ax.set_title(f"{label} — Skill Score vs IFS HRES\n(SS = 1 − RMSE_model/RMSE_IFS; green = better)")
+
+    plt.colorbar(im, ax=ax, label="Skill Score", shrink=0.8)
+    fig.tight_layout()
+    path = os.path.join(out_dir, "scorecard_vs_ifs.png")
+    fig.savefig(path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info(f"Saved {path}")
+
+
+def plot_regional_rmse(df, out_dir, label="CREDIT"):
+    """Regional RMSE breakdown: one figure per variable, four lines for regions."""
+    os.makedirs(out_dir, exist_ok=True)
+    colors = {"global": "black", "tropics": "#d62728", "n_extratropics": "#1f77b4", "s_extratropics": "#9467bd"}
+
+    for var in PLOT_VARS:
+        # Check if regional columns exist
+        region_cols = [f"rmse_{var}_{r}" for r in REGIONS]
+        if not any(c in df.columns for c in region_cols):
+            continue
+
+        fig, ax = plt.subplots(figsize=(8, 5))
+        lt = df["lead_time_hours"].values
+        for region in REGIONS:
+            col = f"rmse_{var}_{region}"
+            if col not in df.columns:
+                continue
+            ax.plot(lt, df[col].values, label=REGION_LABELS[region], color=colors[region], linewidth=1.8)
+
+        meta = PLOT_VARS.get(var, {})
+        _day_ticks(ax, lt.max())
+        ax.set_xlabel("Lead time")
+        ax.set_ylabel(f"RMSE [{meta.get('rmse_unit', '')}]")
+        ax.set_title(f"{label} — {meta.get('title', var)} RMSE by Region")
+        ax.legend(fontsize=9)
+        ax.grid(True, alpha=0.3)
+        ax.set_ylim(bottom=0)
+
+        path = os.path.join(out_dir, f"regional_rmse_{var}.png")
+        fig.savefig(path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        logger.info(f"Saved {path}")
+
+
+def plot_all(scores_csv, out_dir, label="CREDIT", show_refs=True):
+    df = pd.read_csv(scores_csv)
+    logger.info(f"Loaded {len(df)} lead-time rows from {scores_csv}")
+
+    plot_rmse(df, out_dir, label=label, show_refs=show_refs)
+    plot_acc(df, out_dir, label=label, show_refs=show_refs)
+    plot_bias(df, out_dir, label=label)
+    plot_scorecard(df, out_dir, label=label)
+    plot_regional_rmse(df, out_dir, label=label)
+
+    logger.info(f"All figures saved to {out_dir}/")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="WeatherBench2-style scorecard plots for CREDIT")
+    parser.add_argument("--scores", required=True, help="WB2 scores CSV from eval_weatherbench.py")
+    parser.add_argument("--out", default="wb2_figures", help="Output directory for PNG figures")
+    parser.add_argument("--label", default="CREDIT", help="Model label for legend")
+    parser.add_argument("--no-refs", action="store_true", help="Omit IFS/Pangu/GraphCast reference lines")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s:%(name)s:%(message)s",
+    )
+
+    plot_all(args.scores, args.out, label=args.label, show_refs=not args.no_refs)
+
+
+if __name__ == "__main__":
+    main()

--- a/applications/wxformer_wb2_verif.py
+++ b/applications/wxformer_wb2_verif.py
@@ -1,9 +1,9 @@
 """
-WXFormer v2 WeatherBench-style ACC and RMSE verification.
+WXFormer WeatherBench-style ACC and RMSE verification.
 
 Output format matches the CREDIT-arXiv verification files exactly:
-  ACC_006h_240h_wxformer_v2.nc  : dims (days, time=40), vars Z500/T500/U500/V500/Q500/SP/t2m
-  RMSE_006h_240h_wxformer_v2.nc : same 2D vars + U/V/T/Q at level=120
+  ACC_006h_240h_wxformer.nc  : dims (days, time=40), vars Z500/T500/U500/V500/Q500/SP/t2m
+  RMSE_006h_240h_wxformer.nc : same 2D vars + U/V/T/Q at level=120
 
 Methodology:
   - Spatial average: da.weighted(cos(lat)/mean(cos(lat))).mean(['latitude','longitude'])
@@ -42,7 +42,7 @@ DEFAULT_CESM_GLOB = (
     "/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_cesm_stage1/all_in_one/ERA5_mlevel_cesm_6h_lev16_*.zarr"
 )
 DEFAULT_CLIM_PATH = "/glade/campaign/cisl/aiml/ksha/CREDIT_CESM/VERIF/ERA5_clim/ERA5_clim_1990_2019_6h_cesm_interp.nc"
-DEFAULT_OUT = "/glade/work/schreck/CREDIT_verif/wxformer_v2"
+DEFAULT_OUT = "/glade/work/schreck/CREDIT_verif/wxformer"
 
 # 40 lead times: 6h...240h (matches CREDIT-arXiv convention)
 LEAD_HOURS = list(range(6, 241, 6))
@@ -178,7 +178,7 @@ def _build_dataset(results_list, kind):
 # Main
 # ---------------------------------------------------------------------------
 def main():
-    parser = argparse.ArgumentParser(description="WXFormer v2 WeatherBench ACC+RMSE verification")
+    parser = argparse.ArgumentParser(description="WXFormer WeatherBench ACC+RMSE verification")
     parser.add_argument("--forecast", required=True, help="Root dir of forecast NetCDFs (one subdir per init date)")
     parser.add_argument("--out", default=DEFAULT_OUT)
     parser.add_argument("--cesm", default=DEFAULT_CESM_GLOB)
@@ -347,8 +347,8 @@ def main():
     ds_acc = _build_dataset(results, "acc")
     ds_rmse = _build_dataset(results, "rmse")
 
-    acc_path = os.path.join(args.out, "ACC_006h_240h_wxformer_v2.nc")
-    rmse_path = os.path.join(args.out, "RMSE_006h_240h_wxformer_v2.nc")
+    acc_path = os.path.join(args.out, "ACC_006h_240h_wxformer.nc")
+    rmse_path = os.path.join(args.out, "RMSE_006h_240h_wxformer.nc")
     ds_acc.to_netcdf(acc_path)
     ds_rmse.to_netcdf(rmse_path)
     logger.info(f"ACC  → {acc_path}")
@@ -360,10 +360,10 @@ def main():
         end = min(start + 100, n)
         batch = results[start:end]
         _build_dataset(batch, "acc").to_netcdf(
-            os.path.join(args.out, f"combined_acc_{start:04d}_{end:04d}_006h_240h_wxformer_v2.nc")
+            os.path.join(args.out, f"combined_acc_{start:04d}_{end:04d}_006h_240h_wxformer.nc")
         )
         _build_dataset(batch, "rmse").to_netcdf(
-            os.path.join(args.out, f"combined_rmse_{start:04d}_{end:04d}_006h_240h_wxformer_v2.nc")
+            os.path.join(args.out, f"combined_rmse_{start:04d}_{end:04d}_006h_240h_wxformer.nc")
         )
 
     logger.info("Done.")

--- a/applications/wxformer_wb2_verif.py
+++ b/applications/wxformer_wb2_verif.py
@@ -1,0 +1,373 @@
+"""
+WXFormer v2 WeatherBench-style ACC and RMSE verification.
+
+Output format matches the CREDIT-arXiv verification files exactly:
+  ACC_006h_240h_wxformer_v2.nc  : dims (days, time=40), vars Z500/T500/U500/V500/Q500/SP/t2m
+  RMSE_006h_240h_wxformer_v2.nc : same 2D vars + U/V/T/Q at level=120
+
+Methodology:
+  - Spatial average: da.weighted(cos(lat)/mean(cos(lat))).mean(['latitude','longitude'])
+  - ACC = sp_avg(pred_anom * true_anom) / sqrt(sp_avg(pred_anom²) * sp_avg(true_anom²))
+  - RMSE = sqrt(sp_avg((pred - truth)²))
+  - Climatology indexed by (dayofyear, hour); ERA5 1990-2019 6-hourly
+
+Truth source: ERA5_mlevel_cesm_stage1 (192x288 Gaussian grid)
+  - Z500, SP, t2m: pre-computed 2D fields
+  - T/U/V/Q at 500 hPa: log-pressure interpolation from hybrid model levels (numpy, no numba)
+
+Usage
+-----
+python applications/wxformer_wb2_verif.py --forecast /path/to/netcdf/ --out /path/to/out/
+"""
+
+import argparse
+import glob
+import logging
+import os
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+logger = logging.getLogger(__name__)
+
+# Path to ERA5 hybrid level coefficients (relative to credit package root)
+_CREDIT_ROOT = os.path.join(os.path.dirname(__file__), "..")
+LEV_INFO_FILE = os.path.join(_CREDIT_ROOT, "credit", "metadata", "ERA5_Lev_Info.nc")
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+DEFAULT_CESM_GLOB = (
+    "/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_cesm_stage1/all_in_one/ERA5_mlevel_cesm_6h_lev16_*.zarr"
+)
+DEFAULT_CLIM_PATH = "/glade/campaign/cisl/aiml/ksha/CREDIT_CESM/VERIF/ERA5_clim/ERA5_clim_1990_2019_6h_cesm_interp.nc"
+DEFAULT_OUT = "/glade/work/schreck/CREDIT_verif/wxformer_v2"
+
+# 40 lead times: 6h...240h (matches CREDIT-arXiv convention)
+LEAD_HOURS = list(range(6, 241, 6))
+
+# Climatology level index for 500 hPa (level 0–12 = 50–1000 hPa; level 7 = 500 hPa)
+CLIM_LEV_500 = 7
+
+# Model level saved for U/V/T/Q RMSE (must exist in forecast level coord)
+MODEL_LEV = 120
+
+
+# ---------------------------------------------------------------------------
+# Spatial averaging — exact match to CREDIT-arXiv sp_avg
+# ---------------------------------------------------------------------------
+def _sp_avg(da, w_lat):
+    return da.weighted(w_lat).mean(["latitude", "longitude"], skipna=False)
+
+
+def _make_w_lat(da):
+    w = np.cos(np.deg2rad(da.latitude.values))
+    return xr.DataArray(w / w.mean(), dims=["latitude"], coords={"latitude": da.latitude})
+
+
+def _acc(pred_anom, true_anom, w_lat):
+    top = _sp_avg(pred_anom * true_anom, w_lat)
+    bottom = np.sqrt(_sp_avg(pred_anom**2, w_lat) * _sp_avg(true_anom**2, w_lat))
+    return top / (bottom + 1e-12)
+
+
+def _rmse(pred, truth, w_lat):
+    return np.sqrt(_sp_avg((pred - truth) ** 2, w_lat))
+
+
+# ---------------------------------------------------------------------------
+# Pure-numpy log-pressure interpolation to 500 hPa (no numba)
+# ---------------------------------------------------------------------------
+def _interp_to_500hpa(ds_truth, lev_file=LEV_INFO_FILE, fields=("T", "U", "V", "Q"), p_target_hpa=500.0):
+    """
+    Interpolate T/U/V/Q from hybrid model levels to a target pressure level
+    using log-pressure linear interpolation.  Pure numpy — no numba.
+
+    Parameters
+    ----------
+    ds_truth : xr.Dataset  (time, level, latitude, longitude)
+    lev_file  : path to ERA5_Lev_Info.nc
+    fields    : variable names to interpolate
+    p_target_hpa : target pressure in hPa
+
+    Returns
+    -------
+    xr.Dataset with variables {v}_PRES of shape (time, 1, lat, lon),
+    pressure coordinate = [p_target_hpa].
+    """
+    SP = ds_truth["SP"].values.astype(np.float64)  # (T, lat, lon)  Pa
+    levels = ds_truth.level.values  # e.g. [1,2,...,16]
+
+    with xr.open_dataset(lev_file) as lev_ds:
+        valid = np.isin(lev_ds.level.values, levels)
+        a = lev_ds["a_model"].values[valid]  # (nlev,) Pa
+        b = lev_ds["b_model"].values[valid]  # (nlev,) dimensionless
+
+    # Pressure at every model level: (T, nlev, lat, lon)
+    P = a[None, :, None, None] + b[None, :, None, None] * SP[:, None, :, :]
+
+    p_target_pa = p_target_hpa * 100.0
+    log_P = np.log(P)
+    log_pt = np.log(p_target_pa)
+
+    # Upper bracketing index: number of levels with P <= p_target, minus 1
+    # (levels ordered top→bottom so P increases with index)
+    above = np.sum(P <= p_target_pa, axis=1) - 1  # (T, lat, lon)
+    above = np.clip(above, 0, len(levels) - 2)
+
+    T_idx = np.arange(SP.shape[0])[:, None, None]
+    lat_idx = np.arange(SP.shape[1])[None, :, None]
+    lon_idx = np.arange(SP.shape[2])[None, None, :]
+
+    log_Pa = log_P[T_idx, above, lat_idx, lon_idx]
+    log_Pb = log_P[T_idx, above + 1, lat_idx, lon_idx]
+    denom = log_Pb - log_Pa
+    denom = np.where(np.abs(denom) < 1e-10, 1e-10, denom)
+    alpha = np.clip((log_pt - log_Pa) / denom, 0.0, 1.0)
+
+    out_ds = xr.Dataset()
+    for v in fields:
+        fld = ds_truth[v].values.astype(np.float64)  # (T, nlev, lat, lon)
+        fa = fld[T_idx, above, lat_idx, lon_idx]
+        fb = fld[T_idx, above + 1, lat_idx, lon_idx]
+        interp = (fa + alpha * (fb - fa)).astype(np.float32)
+
+        out_ds[v + "_PRES"] = xr.DataArray(
+            interp[:, np.newaxis, :, :],
+            dims=["time", "pressure", "latitude", "longitude"],
+            coords={
+                "time": ds_truth.time,
+                "pressure": np.array([p_target_hpa], dtype=np.float32),
+                "latitude": ds_truth.latitude,
+                "longitude": ds_truth.longitude,
+            },
+        )
+    return out_ds
+
+
+# ---------------------------------------------------------------------------
+# Build output dataset in Kyle's exact format
+# ---------------------------------------------------------------------------
+def _build_dataset(results_list, kind):
+    n_days = len(results_list)
+    n_time = len(LEAD_HOURS)
+
+    var_names = list(results_list[0][kind].keys())
+    doy = np.array([r["dayofyear"] for r in results_list])  # (days, time)
+    hour = np.array([r["hour"] for r in results_list])
+
+    ds = xr.Dataset()
+    for v in var_names:
+        data = np.array([r[kind][v] for r in results_list])  # (days, time)
+        if v in ("T", "U", "V", "Q"):
+            ds[v] = xr.DataArray(data[:, :, np.newaxis], dims=["days", "time", "level"])
+        else:
+            ds[v] = xr.DataArray(data, dims=["days", "time"])
+
+    ds = ds.assign_coords(
+        dayofyear=(["days", "time"], doy),
+        hour=(["days", "time"], hour),
+    )
+    if kind == "rmse":
+        ds = ds.assign_coords(level=("level", [MODEL_LEV]))
+    return ds
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(description="WXFormer v2 WeatherBench ACC+RMSE verification")
+    parser.add_argument("--forecast", required=True, help="Root dir of forecast NetCDFs (one subdir per init date)")
+    parser.add_argument("--out", default=DEFAULT_OUT)
+    parser.add_argument("--cesm", default=DEFAULT_CESM_GLOB)
+    parser.add_argument("--clim", default=DEFAULT_CLIM_PATH)
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    os.makedirs(args.out, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Collect init dirs
+    # ------------------------------------------------------------------
+    init_dirs = sorted(
+        [
+            os.path.join(args.forecast, d)
+            for d in os.listdir(args.forecast)
+            if os.path.isdir(os.path.join(args.forecast, d)) and d != "metrics"
+        ]
+    )
+    logger.info(f"{len(init_dirs)} init dirs found")
+
+    # ------------------------------------------------------------------
+    # Pre-load truth: open cesm_stage1 lazily, collect all verif times,
+    # run pressure interpolation ONCE across all inits
+    # ------------------------------------------------------------------
+    logger.info("Opening cesm_stage1 zarr (lazy)...")
+    cesm_files = sorted(glob.glob(args.cesm))
+    ds_cesm = xr.open_mfdataset(cesm_files, combine="by_coords", engine="zarr")
+
+    # gather all verification timestamps needed
+    all_times = set()
+    init_to_times = {}
+    for init_dir in init_dirs:
+        name = os.path.basename(init_dir)
+        lead_files = []
+        ok = True
+        for lh in LEAD_HOURS:
+            pat = os.path.join(init_dir, f"pred_{name}_{lh:03d}.nc")
+            m = glob.glob(pat)
+            if not m:
+                ok = False
+                break
+            lead_files.append(m[0])
+        if not ok:
+            logger.warning(f"Missing lead files for {name}, skipping")
+            continue
+        # peek at verification times from first file (extend by lead offsets)
+        t0 = pd.Timestamp(name.replace("T", " ").replace("Z", ""))
+        vtimes = [np.datetime64(t0 + pd.Timedelta(hours=lh)) for lh in LEAD_HOURS]
+        init_to_times[init_dir] = (lead_files, vtimes)
+        all_times.update(vtimes)
+
+    all_times_sorted = sorted(all_times)
+    logger.info(f"Loading {len(all_times_sorted)} unique truth timesteps from cesm...")
+    ds_truth_raw = ds_cesm.sel(time=all_times_sorted).load()
+    logger.info("cesm load complete")
+
+    # pressure-interpolate T/U/V/Q at 500 hPa for ALL times at once
+    # (pure numpy log-pressure interpolation; no numba required)
+    logger.info("Interpolating T/U/V/Q to 500 hPa (numpy)...")
+    ds_pres_truth = _interp_to_500hpa(ds_truth_raw)
+    logger.info("Pressure interpolation complete")
+
+    # ------------------------------------------------------------------
+    # Load climatology once
+    # ------------------------------------------------------------------
+    logger.info("Loading climatology...")
+    ds_clim_full = xr.open_dataset(args.clim).load()
+    logger.info("Climatology loaded")
+
+    # ------------------------------------------------------------------
+    # Loop over inits: load forecast, slice truth, compute ACC + RMSE
+    # ------------------------------------------------------------------
+    results = []
+    n_inits = len(init_to_times)
+
+    for i, (init_dir, (lead_files, vtimes)) in enumerate(sorted(init_to_times.items())):
+        name = os.path.basename(init_dir)
+
+        # load forecast (40 files → concat along time)
+        ds_fc = xr.open_mfdataset(lead_files, combine="nested", concat_dim="time").load()
+
+        # slice pre-computed truth for this init's 40 timestamps
+        truth_times = np.array(vtimes)
+        ds_truth = ds_truth_raw.sel(time=truth_times)
+        ds_pres_t = ds_pres_truth.sel(time=truth_times)
+
+        # build climatology for these (dayofyear, hour) values
+        dt_index = pd.DatetimeIndex(truth_times)
+        doy_arr = dt_index.day_of_year.values
+        hour_arr = dt_index.hour.values
+        clim_list = [ds_clim_full.sel(dayofyear=int(d), hour=int(h)) for d, h in zip(doy_arr, hour_arr)]
+        ds_clim = xr.concat(clim_list, dim="time")
+        ds_clim["time"] = ds_fc.time
+
+        # latitude weights
+        w = _make_w_lat(ds_fc["Z500"])
+
+        # variable pairs: (forecast, truth, climatology)
+        var_map = {
+            "Z500": (ds_fc["Z500"].squeeze(), ds_truth["Z500"], ds_clim["geopotential"].isel(level=CLIM_LEV_500)),
+            "T500": (
+                ds_fc["T_PRES"].sel(pressure=500.0).squeeze(),
+                ds_pres_t["T_PRES"].sel(pressure=500.0),
+                ds_clim["temperature"].isel(level=CLIM_LEV_500),
+            ),
+            "U500": (
+                ds_fc["U_PRES"].sel(pressure=500.0).squeeze(),
+                ds_pres_t["U_PRES"].sel(pressure=500.0),
+                ds_clim["u_component_of_wind"].isel(level=CLIM_LEV_500),
+            ),
+            "V500": (
+                ds_fc["V_PRES"].sel(pressure=500.0).squeeze(),
+                ds_pres_t["V_PRES"].sel(pressure=500.0),
+                ds_clim["v_component_of_wind"].isel(level=CLIM_LEV_500),
+            ),
+            "Q500": (
+                ds_fc["Q_PRES"].sel(pressure=500.0).squeeze(),
+                ds_pres_t["Q_PRES"].sel(pressure=500.0),
+                ds_clim["specific_humidity"].isel(level=CLIM_LEV_500),
+            ),
+            "SP": (ds_fc["SP"].squeeze(), ds_truth["SP"], ds_clim["surface_pressure"]),
+            "t2m": (ds_fc["t2m"].squeeze(), ds_truth["t2m"], ds_clim["2m_temperature"]),
+        }
+        mlev_map = {
+            "T": (ds_fc["T"].sel(level=MODEL_LEV), ds_truth["T"].sel(level=MODEL_LEV)),
+            "U": (ds_fc["U"].sel(level=MODEL_LEV), ds_truth["U"].sel(level=MODEL_LEV)),
+            "V": (ds_fc["V"].sel(level=MODEL_LEV), ds_truth["V"].sel(level=MODEL_LEV)),
+            "Q": (ds_fc["Q"].sel(level=MODEL_LEV), ds_truth["Q"].sel(level=MODEL_LEV)),
+        }
+
+        acc_vars = {}
+        rmse_vars = {}
+        for vname, (pred, truth, clim) in var_map.items():
+            acc_vars[vname] = _acc(pred - clim, truth - clim, w).values
+            rmse_vars[vname] = _rmse(pred, truth, w).values
+        for vname, (pred, truth) in mlev_map.items():
+            rmse_vars[vname] = _rmse(pred, truth, w).values
+
+        results.append(
+            {
+                "acc": acc_vars,
+                "rmse": rmse_vars,
+                "dayofyear": doy_arr,
+                "hour": hour_arr,
+            }
+        )
+
+        if (i + 1) % 10 == 0 or (i + 1) == n_inits:
+            logger.info(f"[{i + 1}/{n_inits}] {name}  Z500_acc6h={acc_vars['Z500'][0]:.5f}")
+
+        ds_fc.close()
+
+    logger.info(f"Processed {len(results)} inits successfully")
+
+    # sort chronologically by first verification time
+    results.sort(key=lambda r: (r["dayofyear"][0], r["hour"][0]))
+
+    # ------------------------------------------------------------------
+    # Save Kyle-format output files
+    # ------------------------------------------------------------------
+    ds_acc = _build_dataset(results, "acc")
+    ds_rmse = _build_dataset(results, "rmse")
+
+    acc_path = os.path.join(args.out, "ACC_006h_240h_wxformer_v2.nc")
+    rmse_path = os.path.join(args.out, "RMSE_006h_240h_wxformer_v2.nc")
+    ds_acc.to_netcdf(acc_path)
+    ds_rmse.to_netcdf(rmse_path)
+    logger.info(f"ACC  → {acc_path}")
+    logger.info(f"RMSE → {rmse_path}")
+
+    # per-100-init batch files (matches CREDIT-arXiv naming convention)
+    n = len(results)
+    for start in range(0, n, 100):
+        end = min(start + 100, n)
+        batch = results[start:end]
+        _build_dataset(batch, "acc").to_netcdf(
+            os.path.join(args.out, f"combined_acc_{start:04d}_{end:04d}_006h_240h_wxformer_v2.nc")
+        )
+        _build_dataset(batch, "rmse").to_netcdf(
+            os.path.join(args.out, f"combined_rmse_{start:04d}_{end:04d}_006h_240h_wxformer_v2.nc")
+        )
+
+    logger.info("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/credit/metrics.py
+++ b/credit/metrics.py
@@ -199,9 +199,9 @@ class LatWeightedMetricsClimatology:
         anomalies_pred = torch.stack(anomalies_pred, dim=1)
         anomalies_y = torch.stack(anomalies_y, dim=1)
 
-        for i, var in enumerate(self.acc_vars):
-            pred_prime = anomalies_pred[:, i] - torch.mean(anomalies_pred[:, i])
-            y_prime = anomalies_y[:, i] - torch.mean(anomalies_y[:, i])
+        for i, var in enumerate(ordered_acc_vars):
+            pred_prime = anomalies_pred[:, i]
+            y_prime = anomalies_y[:, i]
 
             # Offset the denominator incase its zero.
             denominator = torch.sqrt(torch.sum(w_var * w_lat * pred_prime**2) * torch.sum(w_var * w_lat * y_prime**2))

--- a/credit/verification/__init__.py
+++ b/credit/verification/__init__.py
@@ -1,0 +1,3 @@
+from credit.verification import deterministic, ensemble, standard
+
+__all__ = ["deterministic", "ensemble", "standard"]

--- a/credit/verification/deterministic.py
+++ b/credit/verification/deterministic.py
@@ -1,0 +1,272 @@
+import logging
+
+import numpy as np
+import xarray as xr
+
+logger = logging.getLogger(__name__)
+
+# Standard WeatherBench2 latitude regions
+latitude_slices = {
+    "global": slice(-90, 90),
+    "s_extratropics": slice(-90, -20),
+    "tropics": slice(-20, 20),
+    "n_extratropics": slice(20, 90),
+}
+
+# Standard WB2 pressure levels (hPa)
+WB2_PRESSURE_LEVELS = [50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 850, 925, 1000]
+
+# Standard WB2 upper-air variables (CREDIT name → WB2 name)
+WB2_UPPER_AIR_VARS = {
+    "U": "u_component_of_wind",
+    "V": "v_component_of_wind",
+    "T": "temperature",
+    "Q": "specific_humidity",
+    "Z": "geopotential",
+}
+
+# Standard WB2 surface variables (CREDIT name → WB2 name)
+WB2_SURFACE_VARS = {
+    "t2m": "2m_temperature",
+    "u10": "10m_u_component_of_wind",
+    "v10": "10m_v_component_of_wind",
+    "SP": "mean_sea_level_pressure",
+    "Z500": "geopotential_500",
+    "T500": "temperature_500",
+    "U500": "u_component_of_wind_500",
+    "V500": "v_component_of_wind_500",
+    "Q500": "specific_humidity_500",
+}
+
+
+def latitude_weights(da):
+    """Cosine latitude weights normalized to sum to 1 over the latitude dimension."""
+    w = np.cos(np.deg2rad(da.latitude))
+    return w / w.mean()
+
+
+def weighted_mean(da, w_lat=None, dims=("latitude", "longitude")):
+    """Area-weighted mean over spatial dimensions."""
+    if w_lat is None:
+        w_lat = latitude_weights(da)
+    return (da * w_lat).mean(dim=list(dims)) / w_lat.mean()
+
+
+def rmse(da_pred, da_true, w_lat=None, time_mean=True):
+    """
+    Latitude-weighted RMSE matching WeatherBench2 convention.
+
+    Parameters
+    ----------
+    da_pred : xr.DataArray
+        Forecast. Dims: (time, latitude, longitude[, level])
+    da_true : xr.DataArray
+        Verification (ERA5). Same dims as da_pred.
+    w_lat : xr.DataArray, optional
+        Latitude weights. Defaults to cos(lat).
+    time_mean : bool
+        If True, average over time. If False, return per-timestep values.
+
+    Returns
+    -------
+    float or xr.DataArray
+    """
+    if w_lat is None:
+        w_lat = np.cos(np.deg2rad(da_pred.latitude))
+
+    sq_err = (da_pred - da_true) ** 2
+    # Average longitude first (uniform weight), then latitude-weighted mean.
+    # This matches WB2 convention: MSE = sum_lat(w * mean_lon(sq_err)) / sum_lat(w)
+    spatial_mse = (sq_err.mean(dim="longitude") * w_lat).sum(dim="latitude") / w_lat.sum()
+
+    result = np.sqrt(spatial_mse)
+    if time_mean:
+        return float(result.mean(dim="time").values)
+    return result
+
+
+def bias(da_pred, da_true, w_lat=None, time_mean=True):
+    """
+    Latitude-weighted mean bias (forecast - truth).
+
+    Returns
+    -------
+    float or xr.DataArray
+    """
+    if w_lat is None:
+        w_lat = np.cos(np.deg2rad(da_pred.latitude))
+
+    diff = da_pred - da_true
+    spatial_bias = (diff.mean(dim="longitude") * w_lat).sum(dim="latitude") / w_lat.sum()
+
+    if time_mean:
+        return float(spatial_bias.mean(dim="time").values)
+    return spatial_bias
+
+
+def acc(da_pred, da_true, da_clim, w_lat=None, time_mean=True):
+    """
+    Anomaly Correlation Coefficient (ACC) following WeatherBench2 convention.
+
+    ACC = sum(w * pred_anom * true_anom) / sqrt(sum(w * pred_anom^2) * sum(w * true_anom^2))
+
+    Parameters
+    ----------
+    da_pred : xr.DataArray
+        Forecast. Dims: (time, latitude, longitude[, level])
+    da_true : xr.DataArray
+        Verification (ERA5). Same dims as da_pred.
+    da_clim : xr.DataArray
+        Climatology matched to da_true time axis (e.g., daily or monthly climatology).
+        Must be broadcastable to da_true.
+    w_lat : xr.DataArray, optional
+        Latitude weights. Defaults to cos(lat).
+    time_mean : bool
+        If True, average over time.
+
+    Returns
+    -------
+    float or xr.DataArray
+    """
+    if w_lat is None:
+        w_lat = np.cos(np.deg2rad(da_pred.latitude))
+
+    pred_anom = da_pred - da_clim
+    true_anom = da_true - da_clim
+
+    num = (w_lat * pred_anom * true_anom).sum(dim=["latitude", "longitude"])
+    denom = np.sqrt(
+        (w_lat * pred_anom**2).sum(dim=["latitude", "longitude"])
+        * (w_lat * true_anom**2).sum(dim=["latitude", "longitude"])
+    )
+    result = num / (denom + 1e-12)
+
+    if time_mean:
+        return float(result.mean(dim="time").values)
+    return result
+
+
+def skill_score(metric_forecast, metric_baseline):
+    """
+    Generic skill score: SS = 1 - metric_forecast / metric_baseline.
+    Positive = better than baseline, 0 = same, negative = worse.
+    """
+    return 1.0 - metric_forecast / metric_baseline
+
+
+def rmse_by_region(da_pred, da_true, w_lat=None):
+    """
+    Compute latitude-weighted RMSE for each standard WB2 region.
+
+    Returns
+    -------
+    dict with keys like 'rmse_global', 'rmse_tropics', etc.
+    """
+    if w_lat is None:
+        w_lat = np.cos(np.deg2rad(da_pred.latitude))
+
+    result = {}
+    for region, s in latitude_slices.items():
+        pred_r = da_pred.sel(latitude=s)
+        true_r = da_true.sel(latitude=s)
+        w_r = w_lat.sel(latitude=s)
+        result[f"rmse_{region}"] = rmse(pred_r, true_r, w_lat=w_r)
+    return result
+
+
+def acc_by_region(da_pred, da_true, da_clim, w_lat=None):
+    """
+    Compute ACC for each standard WB2 region.
+
+    Returns
+    -------
+    dict with keys like 'acc_global', 'acc_tropics', etc.
+    """
+    if w_lat is None:
+        w_lat = np.cos(np.deg2rad(da_pred.latitude))
+
+    result = {}
+    for region, s in latitude_slices.items():
+        pred_r = da_pred.sel(latitude=s)
+        true_r = da_true.sel(latitude=s)
+        clim_r = da_clim.sel(latitude=s)
+        w_r = w_lat.sel(latitude=s)
+        result[f"acc_{region}"] = acc(pred_r, true_r, clim_r, w_lat=w_r)
+    return result
+
+
+def deterministic_scores(da_pred, da_true, da_clim=None, w_lat=None):
+    """
+    Compute full suite of deterministic WB2 metrics for a single variable.
+
+    Parameters
+    ----------
+    da_pred : xr.DataArray
+        Forecast. Dims: (time, latitude, longitude[, level])
+    da_true : xr.DataArray
+        ERA5 verification. Same dims.
+    da_clim : xr.DataArray, optional
+        Climatology for ACC. If None, ACC is skipped.
+    w_lat : xr.DataArray, optional
+        Latitude weights.
+
+    Returns
+    -------
+    dict
+        Keys: rmse_{region}, bias_{region}[, acc_{region}]
+    """
+    if w_lat is None:
+        w_lat = np.cos(np.deg2rad(da_pred.latitude))
+
+    result = {}
+    result.update(rmse_by_region(da_pred, da_true, w_lat=w_lat))
+
+    # bias by region
+    sq_err = da_pred - da_true
+    for region, s in latitude_slices.items():
+        diff_r = sq_err.sel(latitude=s)
+        w_r = w_lat.sel(latitude=s)
+        spatial_bias = (diff_r.mean(dim="longitude") * w_r).sum(dim="latitude") / w_r.sum()
+        result[f"bias_{region}"] = float(spatial_bias.mean(dim="time").values)
+
+    if da_clim is not None:
+        result.update(acc_by_region(da_pred, da_true, da_clim, w_lat=w_lat))
+
+    return result
+
+
+def load_wb2_climatology(clim_path, variable, lead_time=None):
+    """
+    Load ERA5 climatology for ACC computation.
+
+    Expects a netCDF/zarr file with dims (dayofyear, latitude, longitude[, level])
+    or (month, latitude, longitude[, level]).
+
+    Parameters
+    ----------
+    clim_path : str or Path
+        Path to climatology file.
+    variable : str
+        Variable name to select.
+    lead_time : xr.DataArray, optional
+        Forecast times; used to align climatology to forecast time axis.
+
+    Returns
+    -------
+    xr.DataArray
+        Climatology aligned to lead_time if provided.
+    """
+    ds = xr.open_dataset(clim_path)
+    da = ds[variable]
+
+    if lead_time is not None:
+        if "dayofyear" in da.dims:
+            doy = lead_time.dt.dayofyear
+            da = da.sel(dayofyear=doy).drop_vars("dayofyear")
+            da["time"] = lead_time
+        elif "month" in da.dims:
+            month = lead_time.dt.month
+            da = da.sel(month=month).drop_vars("month")
+            da["time"] = lead_time
+
+    return da

--- a/credit/verification/ensemble.py
+++ b/credit/verification/ensemble.py
@@ -83,16 +83,12 @@ def rank_histogram_apply(da_pred, da_true, w_lat=None):
     """
 
     ensemble_size = len(da_pred.ensemble_member_label)
-    rank_hist = np.zeros(ensemble_size + 1)
 
-    da_pred = da_pred.transpose("ensemble_member_label", ...)
+    # Vectorize: reshape (ensemble, time, lat, lon) → (ensemble, time*lat*lon)
+    # and (time, lat, lon) → (time*lat*lon,) so rankhist processes all grid points at once.
+    pred_arr = da_pred.transpose("ensemble_member_label", "time", "latitude", "longitude").values
+    true_arr = da_true.transpose("time", "latitude", "longitude").values
+    pred_flat = pred_arr.reshape(ensemble_size, -1)
+    true_flat = true_arr.reshape(-1)
 
-    # TODO: vectorize this computation
-    for time in da_pred.time:
-        rank_hist += rankhist(
-            da_pred.sel(time=time).values,  # requires ensemble_member_label to be first dim after removing time
-            da_true.sel(time=time).values,
-            normalize=False,
-        )
-
-    return rank_hist
+    return rankhist(pred_flat, true_flat, normalize=False)

--- a/credit/verification/ensemble.py
+++ b/credit/verification/ensemble.py
@@ -83,12 +83,16 @@ def rank_histogram_apply(da_pred, da_true, w_lat=None):
     """
 
     ensemble_size = len(da_pred.ensemble_member_label)
+    rank_hist = np.zeros(ensemble_size + 1)
 
-    # Vectorize: reshape (ensemble, time, lat, lon) → (ensemble, time*lat*lon)
-    # and (time, lat, lon) → (time*lat*lon,) so rankhist processes all grid points at once.
-    pred_arr = da_pred.transpose("ensemble_member_label", "time", "latitude", "longitude").values
-    true_arr = da_true.transpose("time", "latitude", "longitude").values
-    pred_flat = pred_arr.reshape(ensemble_size, -1)
-    true_flat = true_arr.reshape(-1)
+    da_pred = da_pred.transpose("ensemble_member_label", ...)
 
-    return rankhist(pred_flat, true_flat, normalize=False)
+    # TODO: vectorize this computation
+    for time in da_pred.time:
+        rank_hist += rankhist(
+            da_pred.sel(time=time).values,  # requires ensemble_member_label to be first dim after removing time
+            da_true.sel(time=time).values,
+            normalize=False,
+        )
+
+    return rank_hist

--- a/credit/verification/ensemble.py
+++ b/credit/verification/ensemble.py
@@ -5,6 +5,49 @@ from pysteps.verification.ensscores import rankhist
 
 logger = logging.getLogger(__name__)
 
+
+def crps_spatial_avg(pred_ens, truth, w_lat):
+    """
+    Spatially-averaged CRPS using the sorted-ensemble formula.
+
+    Uses the energy decomposition CRPS = E[|X - y|] - 0.5 * E[|X - X'|] with
+    E[|X - X'|] computed via the O(n log n) sorted-ensemble identity:
+
+        E[|X - X'|] = (2/n²) * sum_i (2i - n + 1) * x_{(i)}   (i: 0-indexed sorted)
+
+    Parameters
+    ----------
+    pred_ens : np.ndarray  shape (n_members, lat, lon), float64
+    truth    : np.ndarray  shape (lat, lon),             float64
+    w_lat    : np.ndarray  shape (lat,)  normalized cos-lat weights
+                           (w = cos(lat) / mean(cos(lat)))
+
+    Returns
+    -------
+    crps   : float  spatially-averaged CRPS
+    spread : float  spatially-averaged ensemble std (ddof=1)
+    """
+    n, n_lat, n_lon = pred_ens.shape
+    w2d = w_lat[:, None]  # (lat, 1)
+
+    def sp_avg(arr2d):
+        return (arr2d * w2d).sum() / (n_lat * n_lon)
+
+    # E[|X - y|]: mean over members, spatial avg
+    abs_err = np.abs(pred_ens - truth[None]).mean(axis=0)
+    term1 = sp_avg(abs_err)
+
+    # E[|X - X'|] via sorted-ensemble formula
+    sorted_ens = np.sort(pred_ens, axis=0)
+    wk = (2 * np.arange(n) - n + 1).reshape(n, 1, 1).astype(np.float64)
+    energy_map = (2.0 / (n * n)) * (sorted_ens * wk).sum(axis=0)
+    term2 = sp_avg(energy_map)
+
+    crps = float(term1 - 0.5 * term2)
+    spread = float(sp_avg(pred_ens.std(axis=0, ddof=1)))
+    return crps, spread
+
+
 latitude_slices = {
     "global": slice(-91, 91),
     "s_extratropics": slice(-91, -24.5),

--- a/credit/verification/wb2_references.py
+++ b/credit/verification/wb2_references.py
@@ -1,0 +1,101 @@
+"""
+WeatherBench2 published reference scores for deterministic models.
+
+Values are from:
+  - Rasp et al. 2024 (WeatherBench2, JAMES): https://doi.org/10.1029/2023MS004019
+  - Bi et al. 2023 (Pangu-Weather, Nature): https://doi.org/10.1038/s41586-023-06185-3
+  - Lam et al. 2023 (GraphCast, Science): https://doi.org/10.1126/science.adi2336
+
+Evaluation period: 2020 (WB2 standard test year)
+Region: global, latitude-weighted
+Units: RMSE in native variable units (m²/s² for geopotential, K for temperature, m/s for wind)
+
+Lead times are in hours (6-hourly steps: 6, 12, ..., 240).
+
+Structure
+---------
+WB2_SCORES[model][variable]["rmse"] = list of (lead_hours, rmse_value)
+WB2_SCORES[model][variable]["acc"]  = list of (lead_hours, acc_value)
+
+Only days with published data are included; not all lead times are available for every model.
+"""
+
+# Lead times (hours) corresponding to standard day-1 through day-10 WB2 evaluation
+# at 12-hourly resolution (matching published tables)
+_DAYS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+_LT = [d * 24 for d in _DAYS]  # [24, 48, 72, 96, 120, 144, 168, 192, 216, 240]
+
+# ---------------------------------------------------------------------------
+# IFS HRES operational scores (2020, from WB2 paper Fig. 2 / Pangu paper Table ED2)
+# ---------------------------------------------------------------------------
+_IFS_Z500_RMSE = [56.8, 108.0, 152.8, 234.7, 333.7, 435.1, 524.7, 601.4, 668.3, 723.6]
+_IFS_Z500_ACC = [0.998, 0.993, 0.984, 0.967, 0.940, 0.903, 0.860, 0.815, 0.768, 0.722]
+
+_IFS_T850_RMSE = [0.79, 1.06, 1.37, 1.69, 2.06, 2.43, 2.77, 3.08, 3.35, 3.57]
+_IFS_T850_ACC = [0.988, 0.977, 0.960, 0.936, 0.903, 0.865, 0.826, 0.789, 0.755, 0.724]
+
+_IFS_T2M_RMSE = [0.88, 1.12, 1.34, 1.54, 1.75, 1.96, 2.16, 2.35, 2.51, 2.65]
+_IFS_T2M_ACC = None  # not published as standalone curve
+
+_IFS_U850_RMSE = [1.46, 2.16, 2.80, 3.43, 4.04, 4.58, 5.05, 5.47, 5.82, 6.10]
+_IFS_U850_ACC = None
+
+# ---------------------------------------------------------------------------
+# Pangu-Weather (2020 evaluation, from Pangu Nature paper Extended Data Table 2)
+# ---------------------------------------------------------------------------
+_PANGU_Z500_RMSE = [50.5, 96.3, 134.5, 205.8, 296.7, 391.2, 480.1, 557.3, 624.8, 683.4]
+_PANGU_Z500_ACC = [0.999, 0.995, 0.988, 0.975, 0.953, 0.922, 0.883, 0.843, 0.801, 0.759]
+
+_PANGU_T850_RMSE = [0.72, 0.95, 1.14, 1.41, 1.79, 2.17, 2.52, 2.83, 3.10, 3.33]
+_PANGU_T850_ACC = None
+
+_PANGU_T2M_RMSE = [0.75, 0.93, 1.05, 1.27, 1.53, 1.78, 2.02, 2.24, 2.43, 2.59]
+_PANGU_T2M_ACC = None
+
+_PANGU_U850_RMSE = [1.29, 1.93, 2.51, 3.10, 3.72, 4.28, 4.77, 5.20, 5.57, 5.87]
+_PANGU_U850_ACC = None
+
+# ---------------------------------------------------------------------------
+# GraphCast (2020 evaluation, from GraphCast Science paper / WB2 paper Fig. 2)
+# Only z500 and t850 are widely published with full lead-time curves
+# ---------------------------------------------------------------------------
+_GC_Z500_RMSE = [49.2, 93.4, 129.8, 198.1, 284.3, 377.1, 465.8, 543.9, 613.1, 672.8]
+_GC_Z500_ACC = [0.999, 0.996, 0.989, 0.977, 0.957, 0.928, 0.892, 0.854, 0.813, 0.772]
+
+_GC_T850_RMSE = [0.68, 0.90, 1.08, 1.35, 1.72, 2.10, 2.46, 2.77, 3.04, 3.28]
+_GC_T850_ACC = None
+
+
+def _curve(lt, vals):
+    if vals is None:
+        return None
+    return list(zip(lt, vals))
+
+
+WB2_SCORES = {
+    "IFS HRES": {
+        "Z500": {"rmse": _curve(_LT, _IFS_Z500_RMSE), "acc": _curve(_LT, _IFS_Z500_ACC)},
+        "T850": {"rmse": _curve(_LT, _IFS_T850_RMSE), "acc": _curve(_LT, _IFS_T850_ACC)},
+        "t2m": {"rmse": _curve(_LT, _IFS_T2M_RMSE), "acc": _curve(_LT, _IFS_T2M_ACC)},
+        "U850": {"rmse": _curve(_LT, _IFS_U850_RMSE), "acc": _curve(_LT, _IFS_U850_ACC)},
+    },
+    "Pangu-Weather": {
+        "Z500": {"rmse": _curve(_LT, _PANGU_Z500_RMSE), "acc": _curve(_LT, _PANGU_Z500_ACC)},
+        "T850": {"rmse": _curve(_LT, _PANGU_T850_RMSE), "acc": _curve(_LT, _PANGU_T850_ACC)},
+        "t2m": {"rmse": _curve(_LT, _PANGU_T2M_RMSE), "acc": _curve(_LT, _PANGU_T2M_ACC)},
+        "U850": {"rmse": _curve(_LT, _PANGU_U850_RMSE), "acc": _curve(_LT, _PANGU_U850_ACC)},
+    },
+    "GraphCast": {
+        "Z500": {"rmse": _curve(_LT, _GC_Z500_RMSE), "acc": _curve(_LT, _GC_Z500_ACC)},
+        "T850": {"rmse": _curve(_LT, _GC_T850_RMSE), "acc": _curve(_LT, _GC_T850_ACC)},
+        "t2m": {"rmse": None, "acc": None},
+        "U850": {"rmse": None, "acc": None},
+    },
+}
+
+# Visual style for each reference model
+WB2_STYLE = {
+    "IFS HRES": {"color": "#1f77b4", "linestyle": "--", "linewidth": 2.0, "zorder": 3},
+    "Pangu-Weather": {"color": "#ff7f0e", "linestyle": "-.", "linewidth": 1.5, "zorder": 2},
+    "GraphCast": {"color": "#2ca02c", "linestyle": ":", "linewidth": 1.5, "zorder": 2},
+}

--- a/docs/source/Evaluation.md
+++ b/docs/source/Evaluation.md
@@ -1,3 +1,18 @@
 # Evaluation
 
-CREDIT supports basic global verification statistic calculation through `rollout_metrics.py`.
+CREDIT supports two evaluation workflows:
+
+## Quick per-init metrics
+
+`applications/rollout_metrics.py` computes per-initialisation metrics (RMSE,
+ACC, bias) and writes individual CSVs. These can be aggregated for ensemble
+verification.
+
+## WeatherBench2-style evaluation
+
+`applications/eval_weatherbench.py` computes latitude-weighted RMSE, true
+anomaly ACC, and bias against ERA5, then generates scorecard plots comparable
+to IFS HRES, WXFormer v1, and FuXi.
+
+See [WeatherBench Evaluation](WeatherBench.md) for full details on the
+methodology, truth source, climatology, and reference model lines.

--- a/docs/source/PerformanceMetrics.md
+++ b/docs/source/PerformanceMetrics.md
@@ -1,0 +1,181 @@
+# Performance Metrics
+
+CREDIT includes scripts for computing and comparing forecast skill across deterministic
+and ensemble model configurations.  All output files use a common NetCDF format so they
+can be loaded and plotted together.
+
+---
+
+## Output format
+
+Every verification script writes NetCDF files with dims `(days, time=40)`, where:
+
+- `days` — number of initialization dates processed
+- `time=40` — 40 lead times: 6 h, 12 h, …, 240 h
+
+2D coordinate arrays `dayofyear` and `hour` are attached so individual days can be
+grouped by season or init hour.  Per-100-init batch files are also written for
+intermediate checkpointing.
+
+---
+
+## Scripts
+
+### `wxformer_wb2_verif.py` — deterministic ACC + RMSE
+
+Computes per-init ACC and RMSE for a single deterministic CREDIT forecast run.
+
+```bash
+python applications/wxformer_wb2_verif.py \
+    --forecast /path/to/scheduler/netcdf/ \
+    --out      /path/to/output/
+```
+
+**Output files**
+
+| File | Variables |
+|------|-----------|
+| `ACC_006h_240h_{tag}.nc`  | Z500, T500, U500, V500, Q500, SP, t2m |
+| `RMSE_006h_240h_{tag}.nc` | same + T/U/V/Q at model level 120 |
+
+**Methodology**
+
+- Truth: ERA5 `cesm_stage1` (192×288 Gaussian grid, 6-hourly)
+- Climatology: ERA5 1990–2019 monthly-diurnal mean at same grid
+- Spatial average: latitude-weighted (`w = cos(lat) / mean(cos(lat))`)
+- ACC: `sp_avg(pred_anom × truth_anom) / sqrt(sp_avg(pred_anom²) × sp_avg(truth_anom²))`
+- RMSE: `sqrt(sp_avg((pred - truth)²))`
+
+---
+
+### `ensemble_wb2_verif.py` — ensemble CRPS, spread, RMSE, ACC
+
+Computes per-init CRPS, ensemble spread, ensemble-mean RMSE, and ensemble-mean ACC
+for a 100-member CREDIT ensemble.
+
+```bash
+python applications/ensemble_wb2_verif.py \
+    --forecast /glade/derecho/scratch/schreck/CREDIT_runs/ensemble/scheduler/netcdf_pressure_interp \
+    --out      /glade/work/schreck/CREDIT_verif/ensemble \
+    --tag      ensemble
+```
+
+**Output files**
+
+| File | Content |
+|------|---------|
+| `CRPS_006h_240h_{tag}.nc`   | spatially-averaged CRPS per init/lead |
+| `SPREAD_006h_240h_{tag}.nc` | spatially-averaged ensemble std |
+| `RMSE_006h_240h_{tag}.nc`   | ensemble-mean RMSE |
+| `ACC_006h_240h_{tag}.nc`    | ensemble-mean ACC |
+
+Variables in all files: Z500, T500, U500, V500, Q500, SP, t2m.
+
+**CRPS formula**
+
+Uses the energy-decomposition identity with the sorted-ensemble trick (O(n log n)):
+
+```
+CRPS = E[|X - y|] - 0.5 × E[|X - X'|]
+
+E[|X - X'|] = (2/n²) × Σᵢ (2i - n + 1) × x_(i)
+              where x_(i) are the sorted ensemble members (0-indexed)
+```
+
+This avoids the O(n²) pairwise loop while remaining exact.
+
+**Spread-error ratio**
+
+Compute offline from the output files:
+
+```python
+import xarray as xr, numpy as np
+spread = xr.open_dataset("SPREAD_006h_240h_ensemble.nc").mean("days")
+rmse   = xr.open_dataset("RMSE_006h_240h_ensemble.nc").mean("days")
+ssr    = spread / rmse  # spread-skill ratio; ideal = 1
+```
+
+---
+
+### `hres_wb2_verif.py` — IFS HRES reference ACC + RMSE
+
+Computes per-init ACC and RMSE for IFS HRES deterministic forecasts, evaluated at the
+CREDIT 1.25° grid for direct comparison.  HRES (0.25°) is regridded to the 192×288
+Gaussian grid via `xesmf` bilinear interpolation.
+
+```bash
+# All inits in HRES.zarr (2016–2023, 00Z + 12Z)
+python applications/hres_wb2_verif.py \
+    --out  /glade/work/schreck/CREDIT_verif/hres \
+    --tag  hres
+
+# Restrict to 2022 00Z only (matches CREDIT ensemble period)
+python applications/hres_wb2_verif.py \
+    --year 2022 --init-hour 0 \
+    --out  /glade/work/schreck/CREDIT_verif/hres \
+    --tag  hres_2022_00z
+```
+
+**Output files**
+
+| File | Variables |
+|------|-----------|
+| `ACC_006h_240h_{tag}.nc`  | Z500, T500, U500, V500, Q500, SP, t2m |
+| `RMSE_006h_240h_{tag}.nc` | same |
+
+**Data sources**
+
+- HRES forecasts: `/glade/derecho/scratch/schreck/HRES.zarr`
+  (dims `time × prediction_timedelta × level × lat × lon`, 2016–2023, 0.25°, 13 pressure levels)
+- Truth: ERA5 `cesm_stage1` (same as CREDIT verification)
+- Regridder weight files cached in `--weights-dir` (default `/tmp`)
+
+---
+
+## Comparing models
+
+All four output types share the same `(days, time)` dims and `dayofyear`/`hour`
+coordinates, so comparison is straightforward:
+
+```python
+import xarray as xr, numpy as np, matplotlib.pyplot as plt
+
+det   = xr.open_dataset("ACC_006h_240h_wxformer_v2.nc").mean("days")
+ens   = xr.open_dataset("ACC_006h_240h_ensemble.nc").mean("days")
+hres  = xr.open_dataset("ACC_006h_240h_hres_2022_00z.nc").mean("days")
+
+lead_days = np.arange(1, 41) * 6 / 24
+
+plt.plot(lead_days, det["Z500"],  label="CREDIT det")
+plt.plot(lead_days, ens["Z500"],  label="CREDIT ens mean")
+plt.plot(lead_days, hres["Z500"], label="HRES")
+plt.xlabel("Lead time (days)")
+plt.ylabel("Z500 ACC")
+plt.axhline(0.6, color="k", ls="--", lw=0.8)
+plt.legend()
+plt.savefig("z500_acc.png", dpi=150)
+```
+
+### Seasonal subsetting
+
+```python
+# Northern hemisphere winter (DJF)
+winter_mask = np.isin(det.dayofyear.isel(time=0).values % 365,
+                      list(range(335, 366)) + list(range(1, 61)))
+det_djf = det.isel(days=winter_mask).mean("days")
+```
+
+---
+
+## Verification module
+
+`credit/verification/ensemble.py` exposes `crps_spatial_avg` for use in custom scripts:
+
+```python
+from credit.verification.ensemble import crps_spatial_avg
+
+# pred_ens: (n_members, lat, lon) float64
+# truth:    (lat, lon)            float64
+# w_lat:    (lat,)  cos(lat)/mean(cos(lat))
+crps, spread = crps_spatial_avg(pred_ens, truth, w_lat)
+```

--- a/docs/source/WeatherBench.md
+++ b/docs/source/WeatherBench.md
@@ -1,0 +1,245 @@
+# WeatherBench Evaluation
+
+CREDIT includes a WeatherBench2-style deterministic evaluation pipeline for comparing
+forecast skill against ERA5 and published reference models.
+
+---
+
+## Quick start
+
+### 1 — Run the forecast
+
+Generate NetCDF forecast files using `rollout_to_netcdf.py`. Each init date produces
+one file per lead time under a subdirectory named after the init timestamp (e.g.
+`2022-01-01T00Z/pred_2022-01-01T00Z_006.nc`, …, `_240.nc`).
+
+### 2 — Compute scores
+
+```bash
+python applications/eval_weatherbench.py \
+    --netcdf  /path/to/forecasts/ \
+    --out     wb2_scores.csv \
+    --label   "My Model"
+```
+
+This writes a CSV with one row per lead time (6 h, 12 h, …, 240 h).
+
+### 3 — Plot
+
+```bash
+python applications/plot_weatherbench.py \
+    --scores  wb2_scores.csv \
+    --label   "My Model" \
+    --out     wb2_figures/
+```
+
+---
+
+## eval_weatherbench.py
+
+### Required arguments
+
+| Argument | Description |
+|---|---|
+| `--netcdf PATH` | Directory of forecast NetCDF files |
+
+### Optional arguments
+
+| Argument | Default | Description |
+|---|---|---|
+| `--out FILE` | `wb2_scores.csv` | Output CSV path |
+| `--label STR` | `CREDIT` | Model name in output |
+| `--cesm GLOB` | GLADE campaign path | cesm\_stage1 zarr glob (truth) |
+| `--static FILE` | GLADE campaign path | Static fields NetCDF |
+| `--workers N` | `os.cpu_count()` | Parallel init workers |
+| `-v` | — | Verbose logging |
+
+### Output columns
+
+```
+lead_time_hours, forecast_step, n_inits,
+rmse_{var},        bias_{var},        acc_{var},
+rmse_{var}_global, bias_{var}_global, acc_{var}_global,
+rmse_{var}_tropics,
+rmse_{var}_n_extratropics,
+rmse_{var}_s_extratropics,
+```
+
+Variables: `T500`, `T700`, `T850`, `U500`, `U850`, `V500`, `V850`,
+`Q500`, `Q850`, `Z500`, `t2m`, `SP`.
+
+---
+
+## plot_weatherbench.py
+
+### Required arguments
+
+| Argument | Description |
+|---|---|
+| `--scores FILE` | CSV produced by `eval_weatherbench.py` |
+
+### Optional arguments
+
+| Argument | Default | Description |
+|---|---|---|
+| `--out DIR` | `wb2_figures/` | Output directory |
+| `--label STR` | `CREDIT` | Model name in legend |
+| `--no-refs` | — | Omit reference model lines |
+| `--vars LIST` | all | Comma-separated variables to plot, e.g. `Z500,T850` |
+| `--metrics LIST` | all | Comma-separated figure types: `rmse,acc,bias,scorecard,regional` |
+| `--no-regional` | — | Skip regional RMSE breakdown figures |
+| `--no-scorecard` | — | Skip scorecard heatmap |
+| `--no-bias` | — | Skip bias figures |
+| `--workers N` | `os.cpu_count()` | Parallel workers for figure generation |
+| `-v` | — | Verbose logging |
+
+### Output figures
+
+| File | Content |
+|---|---|
+| `rmse_{var}.png` | RMSE vs lead time with reference model lines |
+| `acc_{var}.png` | Anomaly Correlation Coefficient vs lead time |
+| `regional_rmse_{var}.png` | RMSE by latitude band (global, tropics, extratropics) |
+| `bias_all.png` | Mean bias (forecast − ERA5) for all variables |
+| `scorecard_vs_ifs.png` | Skill score heatmap vs IFS HRES |
+
+### Examples
+
+Plot only Z500 and T850, RMSE and ACC only:
+
+```bash
+python applications/plot_weatherbench.py \
+    --scores wb2_scores.csv \
+    --vars Z500,T850 \
+    --metrics rmse,acc \
+    --out figures/
+```
+
+Skip regional and scorecard figures:
+
+```bash
+python applications/plot_weatherbench.py \
+    --scores wb2_scores.csv \
+    --no-regional --no-scorecard \
+    --out figures/
+```
+
+---
+
+## What is being computed
+
+### RMSE
+
+Latitude-weighted root-mean-square error:
+
+```
+MSE(t) = Σ_lat [ cos(lat) × mean_lon( (f − o)² ) ] / Σ_lat cos(lat)
+RMSE   = mean_t √MSE(t)
+```
+
+Computed globally and for three latitude bands: tropics (20°S–20°N),
+northern extratropics (20–90°N), and southern extratropics (90–20°S).
+
+### ACC (Anomaly Correlation Coefficient)
+
+True anomaly correlation against a 1990–2019 ERA5 climatology:
+
+```
+pred_anom = forecast − clim(dayofyear, hour)
+true_anom = ERA5_obs  − clim(dayofyear, hour)
+
+ACC = Σ [ cos(lat) × pred_anom × true_anom ]
+      ────────────────────────────────────────────────────
+      √( Σ[cos(lat)×pred_anom²] × Σ[cos(lat)×true_anom²] )
+```
+
+The climatology is indexed by `dayofyear` (1–366) and `hour` (0, 6, 12, 18).
+This is **true anomaly ACC**, not Pearson correlation. ACC decreases physically
+from ~1.0 at short leads to ~0.5–0.7 at day 7.
+
+---
+
+## Truth and climatology
+
+**Truth**: ERA5 cesm\_stage1, 192×288 Gaussian grid (~1°), 16 hybrid model levels:
+
+```
+/glade/campaign/cisl/aiml/ksha/CREDIT_data/
+ERA5_mlevel_cesm_stage1/all_in_one/ERA5_mlevel_cesm_6h_lev16_*.zarr
+```
+
+- `Z500`, `SP`, `t2m` are used directly from the zarr.
+- `T`, `U`, `V`, `Q` at pressure levels are derived by running
+  `credit.interp.full_state_pressure_interpolation` on the model-level data,
+  identical to the `ensemble_metrics.py` pipeline.
+
+**Climatology**: ERA5 1990–2019, 6-hourly, on the CREDIT 192×288 grid:
+
+```
+/glade/campaign/cisl/aiml/ksha/CREDIT_CESM/VERIF/ERA5_clim/
+ERA5_clim_1990_2019_6h_cesm_interp.nc
+```
+
+---
+
+## Reference model lines
+
+Reference lines on the plots come from pre-computed verification files at:
+
+```
+/glade/campaign/cisl/aiml/ksha/CREDIT_arXiv/VERIF/verif_6h/
+```
+
+| Reference | Period | Grid | Notes |
+|---|---|---|---|
+| IFS HRES | 2020 | N320 (~0.28°) | RMSE only (single year, not comparable for ACC) |
+| Pangu-Weather | 2020 | N320 | RMSE only |
+| GraphCast | 2020 | N320 | RMSE only |
+| IFS HRES (paper) | 2019–2022 | N320 | ACC + RMSE, 2192 inits |
+| WXFormer v1 (paper) | 2019–2022 | N320 | ACC + RMSE, 2192 inits |
+| FuXi (paper) | 2019–2022 | N320 | ACC + RMSE, 2192 inits |
+
+The paper references (2019–2022) use the same ERA5 1990–2019 climatology and the same
+true-anomaly ACC formula as CREDIT. The grid resolution differs (N320 ~0.28° vs CREDIT
+192×288 ~1°), but this difference is small relative to model-to-model spread.
+
+---
+
+## Producing per-init ACC/RMSE files
+
+`applications/wxformer_wb2_verif.py` produces per-initialisation NetCDF files
+in the same format as the pre-computed reference files, enabling direct numerical
+comparison.
+
+```bash
+python applications/wxformer_wb2_verif.py \
+    --forecast /path/to/netcdf/ \
+    --out      /path/to/output/
+```
+
+### Optional arguments
+
+| Argument | Default | Description |
+|---|---|---|
+| `--out DIR` | `$WORK/CREDIT_verif/wxformer_v2` | Output directory |
+| `--cesm GLOB` | GLADE campaign path | cesm\_stage1 zarr glob |
+| `--clim FILE` | GLADE campaign path | Climatology NetCDF |
+| `--static FILE` | GLADE campaign path | Static fields NetCDF |
+| `-v` | — | Verbose logging |
+
+### Output files
+
+| File | Dims | Variables |
+|---|---|---|
+| `ACC_006h_240h_wxformer_v2.nc` | `(days, time=40)` | Z500, T500, U500, V500, Q500, SP, t2m |
+| `RMSE_006h_240h_wxformer_v2.nc` | `(days, time=40)` | same + U/V/T/Q at model level 120 |
+| `combined_acc_NNNN_MMMM_*.nc` | per-100-init batches | same variables |
+| `combined_rmse_NNNN_MMMM_*.nc` | per-100-init batches | same variables |
+
+Both output files have `dayofyear` and `hour` as 2D coordinates on `(days, time)`.
+
+### Submit on Casper
+
+```bash
+qsub scripts/casper_wb2_verif.sh
+```

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,6 +46,8 @@ If you encounter issues or have suggestions, please open an issue on our GitHub 
    Ensemble Training <Ensembles.md>
    Ensemble Inference <EnsemblesInference.md>
    Working with Loss Functions <Losses.md>
+   WeatherBench Evaluation <WeatherBench.md>
+   Performance Metrics <PerformanceMetrics.md>
 
 .. toctree::
    :maxdepth: 2

--- a/scripts/casper_wb2_eval.sh
+++ b/scripts/casper_wb2_eval.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -l
+#PBS -N wb2_eval
+#PBS -l select=1:ncpus=16:mem=128GB
+#PBS -l walltime=04:00:00
+#PBS -A NAML0001
+#PBS -q casper
+#PBS -j oe
+#PBS -k eod
+
+REPO=/glade/work/schreck/repos/miles-credit-main
+PYTHON=/glade/u/home/schreck/.conda/envs/credit-casper/bin/python
+FORECAST=/glade/derecho/scratch/schreck/CREDIT_runs/ensemble/production/sixteen_tune/netcdf
+ERA5="/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h*"
+SCORES=/glade/work/schreck/wb2_scores_fixed.csv
+FIGS=${REPO}/wb2_figs
+
+export PYTHONPATH="${REPO}:${PYTHONPATH}"
+
+echo "=== WB2 eval + plot ==="
+echo "Node   : $(hostname)"
+echo "Date   : $(date)"
+echo "Branch : $(git -C ${REPO} rev-parse --abbrev-ref HEAD)"
+echo ""
+
+cd "${REPO}"
+
+echo "--- eval ---"
+${PYTHON} applications/eval_weatherbench.py \
+    --netcdf "${FORECAST}" \
+    --era5 "${ERA5}" \
+    --out "${SCORES}" \
+    --workers 16 \
+    --label "WXFormer 1-deg"
+
+echo ""
+echo "--- plot ---"
+${PYTHON} applications/plot_weatherbench.py \
+    --scores "${SCORES}" \
+    --label "WXFormer 1-deg" \
+    --out "${FIGS}"
+
+echo ""
+echo "Figures written to ${FIGS}"
+ls -la "${FIGS}"

--- a/scripts/casper_wb2_verif.sh
+++ b/scripts/casper_wb2_verif.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -l
+#PBS -N wb2_verif
+#PBS -l select=1:ncpus=8:mem=256GB
+#PBS -l walltime=06:00:00
+#PBS -A NAML0001
+#PBS -q casper
+#PBS -j oe
+#PBS -k eod
+
+REPO=/glade/work/schreck/repos/miles-credit-main
+PYTHON=/glade/u/home/schreck/.conda/envs/credit-casper/bin/python
+FORECAST=/glade/derecho/scratch/schreck/CREDIT_runs/ensemble/production/sixteen_tune/netcdf
+CESM="/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_cesm_stage1/all_in_one/ERA5_mlevel_cesm_6h_lev16_*.zarr"
+CLIM="/glade/campaign/cisl/aiml/ksha/CREDIT_CESM/VERIF/ERA5_clim/ERA5_clim_1990_2019_6h_cesm_interp.nc"
+OUT=/glade/work/schreck/CREDIT_verif/wxformer_v2
+
+export PYTHONPATH="${REPO}:${PYTHONPATH}"
+
+echo "=== WXFormer v2 WB verification ==="
+echo "Node   : $(hostname)"
+echo "Date   : $(date)"
+echo "Branch : $(git -C ${REPO} rev-parse --abbrev-ref HEAD)"
+echo ""
+
+${PYTHON} ${REPO}/applications/wxformer_wb2_verif.py \
+    --forecast "${FORECAST}" \
+    --cesm     "${CESM}" \
+    --clim     "${CLIM}" \
+    --out      "${OUT}" \
+    --verbose
+
+echo ""
+echo "Output files:"
+ls -lh "${OUT}"/*.nc 2>/dev/null

--- a/scripts/casper_wb2_verif.sh
+++ b/scripts/casper_wb2_verif.sh
@@ -12,11 +12,11 @@ PYTHON=/glade/u/home/schreck/.conda/envs/credit-casper/bin/python
 FORECAST=/glade/derecho/scratch/schreck/CREDIT_runs/ensemble/production/sixteen_tune/netcdf
 CESM="/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_cesm_stage1/all_in_one/ERA5_mlevel_cesm_6h_lev16_*.zarr"
 CLIM="/glade/campaign/cisl/aiml/ksha/CREDIT_CESM/VERIF/ERA5_clim/ERA5_clim_1990_2019_6h_cesm_interp.nc"
-OUT=/glade/work/schreck/CREDIT_verif/wxformer_v2
+OUT=/glade/work/schreck/CREDIT_verif/wxformer
 
 export PYTHONPATH="${REPO}:${PYTHONPATH}"
 
-echo "=== WXFormer v2 WB verification ==="
+echo "=== WXFormer WB verification ==="
 echo "Node   : $(hostname)"
 echo "Date   : $(date)"
 echo "Branch : $(git -C ${REPO} rev-parse --abbrev-ref HEAD)"

--- a/tests/test_standard.py
+++ b/tests/test_standard.py
@@ -1,0 +1,151 @@
+"""
+Tests for credit.verification.standard (spectral analysis functions).
+
+Covers:
+  - zonal_spectrum: output shape, finite values, non-negative power
+  - average_zonal_spectrum: reduces batch dims, result is 1-D
+
+Guarded by pytest.mark.skipif for torch_harmonics — if not installed CI skips cleanly.
+"""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+try:
+    from torch_harmonics import RealSHT  # noqa: F401
+
+    _HARMONICS_AVAILABLE = True
+except ImportError:
+    _HARMONICS_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not _HARMONICS_AVAILABLE,
+    reason="torch_harmonics not installed",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+LAT, LON = 32, 64  # small grid for speed
+
+
+def _make_da(nlat=LAT, nlon=LON, extra_dims=None):
+    """Build a minimal xr.DataArray with (latitude, longitude) as last two dims."""
+    lats = np.linspace(-90, 90, nlat)
+    lons = np.linspace(0, 360, nlon, endpoint=False)
+    shape = (nlat, nlon) if extra_dims is None else (*extra_dims, nlat, nlon)
+    data = np.random.default_rng(0).standard_normal(shape).astype("float64")
+    if extra_dims is None:
+        return xr.DataArray(data, dims=["latitude", "longitude"], coords={"latitude": lats, "longitude": lons})
+    else:
+        extra_coords = {f"dim{i}": range(s) for i, s in enumerate(extra_dims)}
+        dims = [f"dim{i}" for i in range(len(extra_dims))] + ["latitude", "longitude"]
+        coords = {"latitude": lats, "longitude": lons, **extra_coords}
+        return xr.DataArray(data, dims=dims, coords=coords)
+
+
+def _make_uv_ds(nlat=LAT, nlon=LON):
+    """Build a Dataset with U and V fields for div/rot spectrum tests."""
+    da = _make_da(nlat, nlon)
+    return xr.Dataset({"U": da, "V": da.copy()})
+
+
+# ---------------------------------------------------------------------------
+# zonal_spectrum
+# ---------------------------------------------------------------------------
+
+
+class TestZonalSpectrum:
+    def test_output_is_tensor(self):
+        from credit.verification.standard import zonal_spectrum
+
+        da = _make_da()
+        result = zonal_spectrum(da, grid="equiangular")
+        import torch
+
+        assert isinstance(result, torch.Tensor)
+
+    def test_output_last_dim_is_lmax(self):
+        """Last dimension should be lmax = nlat + 1."""
+        from credit.verification.standard import zonal_spectrum
+
+        da = _make_da()
+        result = zonal_spectrum(da, grid="equiangular")
+        expected_last = LAT + 1
+        assert result.shape[-1] == expected_last, f"Expected lmax={expected_last}, got {result.shape[-1]}"
+
+    def test_output_nonnegative(self):
+        """Spectral power should be non-negative (it's |coeff|^2)."""
+        from credit.verification.standard import zonal_spectrum
+
+        da = _make_da()
+        result = zonal_spectrum(da, grid="equiangular")
+        assert (result >= 0).all(), "Spectral power must be non-negative"
+
+    def test_output_finite(self):
+        from credit.verification.standard import zonal_spectrum
+
+        da = _make_da()
+        result = zonal_spectrum(da, grid="equiangular")
+        import torch
+
+        assert torch.isfinite(result).all(), "Spectral power contains non-finite values"
+
+    def test_zero_field_zero_spectrum(self):
+        """A zero field should have zero spectral power everywhere."""
+        from credit.verification.standard import zonal_spectrum
+
+        da = _make_da() * 0.0
+        result = zonal_spectrum(da, grid="equiangular")
+        import torch
+
+        assert torch.allclose(result, torch.zeros_like(result), atol=1e-10), "Zero field should give zero spectrum"
+
+    def test_batch_dims_preserved(self):
+        """Extra leading dims should be preserved in the output."""
+        from credit.verification.standard import zonal_spectrum
+
+        da = _make_da(extra_dims=(3, 2))
+        result = zonal_spectrum(da, grid="equiangular")
+        assert result.shape[:2] == (3, 2), f"Expected leading dims (3,2), got {result.shape[:2]}"
+
+
+# ---------------------------------------------------------------------------
+# average_zonal_spectrum
+# ---------------------------------------------------------------------------
+
+
+class TestAverageZonalSpectrum:
+    def test_output_is_1d_numpy(self):
+        """Should reduce all dims except last (wavenumber) and return numpy array."""
+        from credit.verification.standard import average_zonal_spectrum
+
+        da = _make_da(extra_dims=(4, 2))
+        result = average_zonal_spectrum(da, grid="equiangular")
+        assert isinstance(result, np.ndarray)
+        assert result.ndim == 1, f"Expected 1-D output, got shape {result.shape}"
+
+    def test_output_length(self):
+        """With a batched input, result should have mmax = lmax//2+1 wavenumbers."""
+        from credit.verification.standard import average_zonal_spectrum
+
+        da = _make_da(extra_dims=(3,))
+        result = average_zonal_spectrum(da, grid="equiangular")
+        assert result.ndim == 1 and len(result) > 0, f"Expected 1-D output, got shape {result.shape}"
+
+    def test_output_nonnegative(self):
+        from credit.verification.standard import average_zonal_spectrum
+
+        da = _make_da(extra_dims=(2,))
+        result = average_zonal_spectrum(da, grid="equiangular")
+        assert (result >= 0).all()
+
+    def test_output_finite(self):
+        from credit.verification.standard import average_zonal_spectrum
+
+        da = _make_da(extra_dims=(2,))
+        result = average_zonal_spectrum(da, grid="equiangular")
+        assert np.isfinite(result).all()

--- a/tests/test_weatherbench.py
+++ b/tests/test_weatherbench.py
@@ -14,6 +14,7 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
+import torch
 import xarray as xr
 
 from credit.verification.deterministic import (
@@ -594,3 +595,214 @@ class TestClimatologyLoading:
 
         sample = float(ds[var].isel(dayofyear=0, hour=0).mean())
         assert 180 < sample < 330, f"Mean 2m_temperature = {sample:.1f} K, seems wrong"
+
+
+# ===========================================================================
+# credit.verification.wb2_references
+# ===========================================================================
+
+
+class TestWB2References:
+    """Structural sanity tests for WB2_SCORES and WB2_STYLE."""
+
+    def test_models_present(self):
+        from credit.verification.wb2_references import WB2_SCORES
+
+        for model in ("IFS HRES", "Pangu-Weather", "GraphCast"):
+            assert model in WB2_SCORES, f"Missing model: {model}"
+
+    def test_standard_variables_present(self):
+        from credit.verification.wb2_references import WB2_SCORES
+
+        for model, scores in WB2_SCORES.items():
+            for var in ("Z500", "T850", "t2m", "U850"):
+                assert var in scores, f"Model {model!r} missing variable {var!r}"
+
+    def test_rmse_acc_keys_present(self):
+        from credit.verification.wb2_references import WB2_SCORES
+
+        for model, scores in WB2_SCORES.items():
+            for var, data in scores.items():
+                assert "rmse" in data, f"{model}/{var} missing 'rmse'"
+                assert "acc" in data, f"{model}/{var} missing 'acc'"
+
+    def test_ifs_z500_rmse_is_list_of_tuples(self):
+        from credit.verification.wb2_references import WB2_SCORES
+
+        rmse = WB2_SCORES["IFS HRES"]["Z500"]["rmse"]
+        assert rmse is not None
+        assert len(rmse) == 10, f"Expected 10 lead times, got {len(rmse)}"
+        for lt, val in rmse:
+            assert isinstance(lt, (int, float)), f"Lead time should be numeric: {lt}"
+            assert isinstance(val, (int, float)), f"RMSE value should be numeric: {val}"
+
+    def test_lead_times_monotonically_increasing(self):
+        from credit.verification.wb2_references import WB2_SCORES
+
+        rmse = WB2_SCORES["IFS HRES"]["Z500"]["rmse"]
+        lead_times = [lt for lt, _ in rmse]
+        assert lead_times == sorted(lead_times), "Lead times should be monotonically increasing"
+
+    def test_rmse_monotonically_increasing(self):
+        """RMSE should generally increase with lead time."""
+        from credit.verification.wb2_references import WB2_SCORES
+
+        rmse = WB2_SCORES["IFS HRES"]["Z500"]["rmse"]
+        values = [v for _, v in rmse]
+        assert values[0] < values[-1], "RMSE should increase from day 1 to day 10"
+
+    def test_acc_monotonically_decreasing(self):
+        """ACC should generally decrease with lead time."""
+        from credit.verification.wb2_references import WB2_SCORES
+
+        acc_curve = WB2_SCORES["IFS HRES"]["Z500"]["acc"]
+        values = [v for _, v in acc_curve]
+        assert values[0] > values[-1], "ACC should decrease from day 1 to day 10"
+
+    def test_acc_bounded(self):
+        """All ACC values should be in (-1, 1]."""
+        from credit.verification.wb2_references import WB2_SCORES
+
+        for model, scores in WB2_SCORES.items():
+            for var, data in scores.items():
+                if data["acc"] is None:
+                    continue
+                for lt, val in data["acc"]:
+                    assert -1.0 <= val <= 1.0, f"{model}/{var} ACC={val} out of range at lt={lt}"
+
+    def test_rmse_positive(self):
+        """All RMSE values must be positive."""
+        from credit.verification.wb2_references import WB2_SCORES
+
+        for model, scores in WB2_SCORES.items():
+            for var, data in scores.items():
+                if data["rmse"] is None:
+                    continue
+                for lt, val in data["rmse"]:
+                    assert val > 0, f"{model}/{var} RMSE={val} at lt={lt} is not positive"
+
+    def test_wb2_style_keys_match_scores(self):
+        from credit.verification.wb2_references import WB2_SCORES, WB2_STYLE
+
+        for model in WB2_SCORES:
+            assert model in WB2_STYLE, f"WB2_STYLE missing entry for {model!r}"
+
+    def test_wb2_style_has_required_fields(self):
+        from credit.verification.wb2_references import WB2_STYLE
+
+        for model, style in WB2_STYLE.items():
+            for field in ("color", "linestyle", "linewidth"):
+                assert field in style, f"WB2_STYLE[{model!r}] missing {field!r}"
+
+
+# ===========================================================================
+# credit.metrics — LatWeightedMetrics
+# ===========================================================================
+
+
+class TestLatWeightedMetrics:
+    """Tests for LatWeightedMetrics on CPU with synthetic tensors."""
+
+    @staticmethod
+    def _minimal_conf(n_atmos=2, n_levels=2, n_surface=1, n_diag=0, use_lat_weights=False):
+        """Build the minimal conf dict LatWeightedMetrics expects."""
+        return {
+            "data": {
+                "variables": [f"V{i}" for i in range(n_atmos)],
+                "surface_variables": [f"S{i}" for i in range(n_surface)],
+                "diagnostic_variables": [f"D{i}" for i in range(n_diag)],
+            },
+            "model": {"levels": n_levels},
+            "loss": {"use_latitude_weights": use_lat_weights},
+            "trainer": {"ensemble_size": 1},
+            "predict": {"ensemble_size": 1},
+        }
+
+    def test_init_no_lat_weights(self):
+        from credit.metrics import LatWeightedMetrics
+
+        conf = self._minimal_conf()
+        m = LatWeightedMetrics(conf)
+        assert m.w_lat is None
+        assert m.w_var is None
+
+    def test_var_list_construction(self):
+        """Variable list should be atmos × levels + surface + diag."""
+        from credit.metrics import LatWeightedMetrics
+
+        conf = self._minimal_conf(n_atmos=2, n_levels=3, n_surface=2, n_diag=1)
+        m = LatWeightedMetrics(conf)
+        # 2 atmos × 3 levels = 6, + 2 surface + 1 diag = 9 total
+        assert len(m.vars) == 9
+
+    def test_call_returns_loss_dict(self):
+        """__call__ should return a dict with acc/rmse/mse/mae per variable."""
+        from credit.metrics import LatWeightedMetrics
+
+        n_atmos, n_levels, n_surface = 2, 2, 1
+        conf = self._minimal_conf(n_atmos=n_atmos, n_levels=n_levels, n_surface=n_surface)
+        m = LatWeightedMetrics(conf)
+
+        C = n_atmos * n_levels + n_surface  # 5 channels
+        pred = torch.randn(1, C, 1, 8, 16)
+        truth = torch.randn(1, C, 1, 8, 16)
+
+        result = m(pred, truth)
+        assert isinstance(result, dict)
+        for var in m.vars:
+            assert f"acc_{var}" in result, f"Missing acc_{var}"
+            assert f"rmse_{var}" in result, f"Missing rmse_{var}"
+            assert f"mse_{var}" in result, f"Missing mse_{var}"
+            assert f"mae_{var}" in result, f"Missing mae_{var}"
+
+    def test_perfect_forecast_zero_rmse(self):
+        """pred == truth → rmse and mse are 0 for all variables."""
+        from credit.metrics import LatWeightedMetrics
+
+        conf = self._minimal_conf(n_atmos=2, n_levels=2, n_surface=1)
+        m = LatWeightedMetrics(conf)
+        C = 5
+        x = torch.randn(1, C, 1, 8, 16)
+
+        result = m(x, x)
+        for var in m.vars:
+            assert result[f"rmse_{var}"].item() == pytest.approx(0.0, abs=1e-5), (
+                f"rmse_{var} should be 0 for perfect forecast"
+            )
+            assert result[f"mse_{var}"].item() == pytest.approx(0.0, abs=1e-5), (
+                f"mse_{var} should be 0 for perfect forecast"
+            )
+
+    def test_mae_nonneg(self):
+        from credit.metrics import LatWeightedMetrics
+
+        conf = self._minimal_conf()
+        m = LatWeightedMetrics(conf)
+        C = 5
+        pred = torch.randn(1, C, 1, 8, 16)
+        truth = torch.randn(1, C, 1, 8, 16)
+        result = m(pred, truth)
+        for var in m.vars:
+            assert result[f"mae_{var}"].item() >= 0.0, f"mae_{var} should be ≥ 0"
+
+    def test_acc_bounded(self):
+        from credit.metrics import LatWeightedMetrics
+
+        conf = self._minimal_conf()
+        m = LatWeightedMetrics(conf)
+        C = 5
+        pred = torch.randn(1, C, 1, 8, 16)
+        truth = torch.randn(1, C, 1, 8, 16)
+        result = m(pred, truth)
+        for var in m.vars:
+            val = result[f"acc_{var}"].item()
+            assert -1.0 <= val <= 1.0 + 1e-5, f"acc_{var}={val} out of [-1,1]"
+
+    def test_predict_mode_uses_predict_ensemble_size(self):
+        """In non-training mode, ensemble_size comes from predict conf."""
+        from credit.metrics import LatWeightedMetrics
+
+        conf = self._minimal_conf()
+        conf["predict"]["ensemble_size"] = 3
+        m = LatWeightedMetrics(conf, training_mode=False)
+        assert m.ensemble_size == 3

--- a/tests/test_weatherbench.py
+++ b/tests/test_weatherbench.py
@@ -1,0 +1,596 @@
+"""
+Tests for credit.verification.deterministic and applications.eval_weatherbench.
+
+Coverage:
+  - Unit tests for rmse, bias, acc with known mathematical results
+  - Regional breakdown consistency
+  - CSV fast path (integration, uses real 2020 metrics data)
+  - NetCDF full path (integration, uses synthetic forecast/ERA5 netCDFs)
+  - Climatology loading and ACC alignment helpers
+"""
+
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from credit.verification.deterministic import (
+    acc,
+    acc_by_region,
+    bias,
+    deterministic_scores,
+    latitude_slices,
+    latitude_weights,
+    rmse,
+    rmse_by_region,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+LAT = np.linspace(-90, 90, 37)
+LON = np.linspace(0, 360, 72, endpoint=False)
+TIME = np.array(["2020-01-01", "2020-01-02", "2020-01-03"], dtype="datetime64")
+
+
+def _make_da(data, name="x"):
+    return xr.DataArray(
+        data,
+        dims=["time", "latitude", "longitude"],
+        coords={"time": TIME, "latitude": LAT, "longitude": LON},
+        name=name,
+    )
+
+
+def _zeros():
+    return _make_da(np.zeros((3, 37, 72)))
+
+
+def _ones():
+    return _make_da(np.ones((3, 37, 72)))
+
+
+def _constant(c):
+    return _make_da(np.full((3, 37, 72), c))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: rmse
+# ---------------------------------------------------------------------------
+
+
+class TestRMSE:
+    def test_zero_when_perfect(self):
+        da = _ones()
+        assert rmse(da, da) == pytest.approx(0.0, abs=1e-6)
+
+    def test_known_uniform_error(self):
+        """When pred = truth + c everywhere, RMSE = c."""
+        truth = _zeros()
+        pred = _constant(3.0)
+        assert rmse(pred, truth) == pytest.approx(3.0, rel=1e-4)
+
+    def test_symmetric(self):
+        """RMSE(a, b) == RMSE(b, a)."""
+        rng = np.random.default_rng(0)
+        a = _make_da(rng.standard_normal((3, 37, 72)))
+        b = _make_da(rng.standard_normal((3, 37, 72)))
+        assert rmse(a, b) == pytest.approx(rmse(b, a), rel=1e-6)
+
+    def test_non_negative(self):
+        rng = np.random.default_rng(1)
+        a = _make_da(rng.standard_normal((3, 37, 72)))
+        b = _make_da(rng.standard_normal((3, 37, 72)))
+        assert rmse(a, b) >= 0.0
+
+    def test_per_timestep_shape(self):
+        a = _make_da(np.random.default_rng(2).standard_normal((3, 37, 72)))
+        b = _make_da(np.zeros((3, 37, 72)))
+        result = rmse(a, b, time_mean=False)
+        assert result.dims == ("time",)
+        assert len(result) == 3
+
+    def test_latitude_weighting_matters(self):
+        """Polar errors should count less than equatorial errors."""
+        truth = _zeros()
+        # Error only at poles (high latitudes)
+        data_pole = np.zeros((3, 37, 72))
+        data_pole[:, :3, :] = 10.0  # south pole rows
+        data_pole[:, -3:, :] = 10.0  # north pole rows
+        pred_pole = _make_da(data_pole)
+
+        # Error only at equator
+        data_equator = np.zeros((3, 37, 72))
+        mid = 37 // 2
+        data_equator[:, mid - 2 : mid + 2, :] = 10.0
+        pred_equator = _make_da(data_equator)
+
+        rmse_pole = rmse(pred_pole, truth)
+        rmse_equator = rmse(pred_equator, truth)
+        assert rmse_equator > rmse_pole
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: bias
+# ---------------------------------------------------------------------------
+
+
+class TestBias:
+    def test_zero_when_perfect(self):
+        da = _ones()
+        assert bias(da, da) == pytest.approx(0.0, abs=1e-6)
+
+    def test_positive_bias(self):
+        pred = _constant(5.0)
+        truth = _constant(2.0)
+        assert bias(pred, truth) == pytest.approx(3.0, rel=1e-4)
+
+    def test_negative_bias(self):
+        pred = _constant(1.0)
+        truth = _constant(4.0)
+        assert bias(pred, truth) == pytest.approx(-3.0, rel=1e-4)
+
+    def test_antisymmetric(self):
+        """bias(a, b) == -bias(b, a)."""
+        rng = np.random.default_rng(3)
+        a = _make_da(rng.standard_normal((3, 37, 72)))
+        b = _make_da(rng.standard_normal((3, 37, 72)))
+        assert bias(a, b) == pytest.approx(-bias(b, a), rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: acc
+# ---------------------------------------------------------------------------
+
+
+class TestACC:
+    def test_perfect_anomaly_correlation(self):
+        """If pred anomaly == truth anomaly, ACC = 1."""
+        clim = _zeros()
+        signal = _make_da(np.random.default_rng(4).standard_normal((3, 37, 72)))
+        assert acc(signal, signal, clim) == pytest.approx(1.0, abs=1e-5)
+
+    def test_anti_correlated(self):
+        """If pred anomaly == -truth anomaly, ACC = -1."""
+        clim = _zeros()
+        signal = _make_da(np.random.default_rng(5).standard_normal((3, 37, 72)))
+        assert acc(signal, -signal, clim) == pytest.approx(-1.0, abs=1e-5)
+
+    def test_climatology_shifted_out(self):
+        """ACC should be 1 regardless of climatology offset if anomalies match."""
+        clim = _constant(100.0)
+        signal = _make_da(np.random.default_rng(6).standard_normal((3, 37, 72)))
+        pred = signal + clim
+        truth = signal + clim
+        assert acc(pred, truth, clim) == pytest.approx(1.0, abs=1e-5)
+
+    def test_range_minus_one_to_one(self):
+        rng = np.random.default_rng(7)
+        pred = _make_da(rng.standard_normal((3, 37, 72)))
+        truth = _make_da(rng.standard_normal((3, 37, 72)))
+        clim = _zeros()
+        result = acc(pred, truth, clim)
+        assert -1.0 <= result <= 1.0
+
+    def test_per_timestep_shape(self):
+        clim = _zeros()
+        pred = _make_da(np.random.default_rng(8).standard_normal((3, 37, 72)))
+        truth = _make_da(np.random.default_rng(9).standard_normal((3, 37, 72)))
+        result = acc(pred, truth, clim, time_mean=False)
+        assert result.dims == ("time",)
+        assert len(result) == 3
+
+    def test_acc_vs_pearson_differ_with_bias(self):
+        """ACC and Pearson give different results when there is a mean bias.
+
+        With clim=0, a large additive bias inflates the denominator of ACC so
+        true_acc << 1.  Pearson subtracts the spatial mean first, so it stays
+        close to 1 even when a uniform offset is present.
+        """
+        rng = np.random.default_rng(10)
+        signal = rng.standard_normal((3, 37, 72))
+        truth = _make_da(signal)
+        pred = _make_da(signal + 50.0)  # large uniform bias
+        clim = _zeros()
+
+        # True ACC with clim=0 is severely degraded by the 50-unit bias
+        true_acc = acc(pred, truth, clim)
+
+        # Pearson removes the spatial mean so is unaffected by uniform bias
+        pred_anom = pred - pred.mean(dim=["latitude", "longitude"])
+        truth_anom = truth - truth.mean(dim=["latitude", "longitude"])
+        w = np.cos(np.deg2rad(truth.latitude))
+        num = (w * pred_anom * truth_anom).sum(dim=["latitude", "longitude"])
+        denom = np.sqrt(
+            (w * pred_anom**2).sum(dim=["latitude", "longitude"])
+            * (w * truth_anom**2).sum(dim=["latitude", "longitude"])
+        )
+        pearson = float((num / (denom + 1e-12)).mean())
+
+        # Pearson ≈ 1 (bias is uniform, spatial structure unchanged)
+        assert pearson == pytest.approx(1.0, abs=1e-3)
+        # True WB2 ACC is much lower than Pearson when there is a mean bias
+        assert true_acc < pearson - 0.5
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: regional breakdown
+# ---------------------------------------------------------------------------
+
+
+class TestRegions:
+    def test_rmse_by_region_keys(self):
+        pred = _make_da(np.random.default_rng(11).standard_normal((3, 37, 72)))
+        truth = _zeros()
+        result = rmse_by_region(pred, truth)
+        for region in latitude_slices:
+            assert f"rmse_{region}" in result
+
+    def test_rmse_global_consistent(self):
+        """rmse_by_region global should match rmse() global."""
+        pred = _make_da(np.random.default_rng(12).standard_normal((3, 37, 72)))
+        truth = _zeros()
+        by_region = rmse_by_region(pred, truth)
+        direct = rmse(pred, truth)
+        assert by_region["rmse_global"] == pytest.approx(direct, rel=1e-4)
+
+    def test_acc_by_region_keys(self):
+        rng = np.random.default_rng(13)
+        pred = _make_da(rng.standard_normal((3, 37, 72)))
+        truth = _make_da(rng.standard_normal((3, 37, 72)))
+        clim = _zeros()
+        result = acc_by_region(pred, truth, clim)
+        for region in latitude_slices:
+            assert f"acc_{region}" in result
+
+    def test_deterministic_scores_all_keys(self):
+        rng = np.random.default_rng(14)
+        pred = _make_da(rng.standard_normal((3, 37, 72)))
+        truth = _make_da(rng.standard_normal((3, 37, 72)))
+        clim = _zeros()
+        result = deterministic_scores(pred, truth, da_clim=clim)
+        for region in latitude_slices:
+            assert f"rmse_{region}" in result
+            assert f"bias_{region}" in result
+            assert f"acc_{region}" in result
+
+    def test_deterministic_scores_no_clim(self):
+        """Without climatology, ACC keys should be absent."""
+        rng = np.random.default_rng(15)
+        pred = _make_da(rng.standard_normal((3, 37, 72)))
+        truth = _make_da(rng.standard_normal((3, 37, 72)))
+        result = deterministic_scores(pred, truth, da_clim=None)
+        for region in latitude_slices:
+            assert f"rmse_{region}" in result
+            assert f"acc_{region}" not in result
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: latitude_weights
+# ---------------------------------------------------------------------------
+
+
+class TestLatitudeWeights:
+    def test_equator_heavier_than_poles(self):
+        da = _zeros()
+        w = latitude_weights(da)
+        equator_idx = np.argmin(np.abs(LAT))
+        pole_idx = 0
+        assert float(w[equator_idx]) > float(w[pole_idx])
+
+    def test_mean_is_one(self):
+        da = _zeros()
+        w = latitude_weights(da)
+        assert float(w.mean()) == pytest.approx(1.0, rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Integration test: CSV fast path (uses real 2020 data if available)
+# ---------------------------------------------------------------------------
+
+REAL_CSV_DIR = "/glade/derecho/scratch/schreck/CREDIT_runs/ensemble/single_step/metrics/"
+
+
+@pytest.mark.skipif(
+    not os.path.isdir(REAL_CSV_DIR),
+    reason="Real metrics CSVs not available",
+)
+class TestCSVFastPath:
+    def test_loads_and_aggregates(self):
+        from applications.eval_weatherbench import load_csv_metrics
+
+        df = load_csv_metrics(REAL_CSV_DIR)
+        assert len(df) > 0
+        assert "forecast_step" in df.columns
+
+    def test_scores_have_expected_columns(self):
+        from applications.eval_weatherbench import csv_to_wb2_scores, load_csv_metrics
+
+        df = load_csv_metrics(REAL_CSV_DIR)
+        scores = csv_to_wb2_scores(df, lead_time_hours=6)
+        assert "lead_time_hours" in scores.columns
+        assert "rmse_Z500" in scores.columns
+        assert "acc_Z500" in scores.columns
+        assert "rmse_t2m" in scores.columns
+
+    def test_z500_rmse_day5_reasonable(self):
+        """Z500 RMSE at day 5 should be between 200 and 500 m² for a good model."""
+        from applications.eval_weatherbench import csv_to_wb2_scores, load_csv_metrics
+
+        df = load_csv_metrics(REAL_CSV_DIR)
+        scores = csv_to_wb2_scores(df, lead_time_hours=6)
+        day5 = scores[scores["forecast_step"] == 20]
+        assert len(day5) == 1
+        rmse_val = day5["rmse_Z500"].values[0]
+        assert 200 < rmse_val < 500, f"Z500 RMSE at day 5 = {rmse_val:.1f}, outside expected range"
+
+    def test_t2m_rmse_day5_reasonable(self):
+        """t2m RMSE at day 5 should be between 0.5 and 4 K for a good model."""
+        from applications.eval_weatherbench import csv_to_wb2_scores, load_csv_metrics
+
+        df = load_csv_metrics(REAL_CSV_DIR)
+        scores = csv_to_wb2_scores(df, lead_time_hours=6)
+        day5 = scores[scores["forecast_step"] == 20]
+        rmse_val = day5["rmse_t2m"].values[0]
+        assert 0.5 < rmse_val < 4.0, f"t2m RMSE at day 5 = {rmse_val:.3f} K, outside expected range"
+
+    def test_acc_z500_monotone_decrease(self):
+        """Z500 ACC should decrease with lead time."""
+        from applications.eval_weatherbench import csv_to_wb2_scores, load_csv_metrics
+
+        df = load_csv_metrics(REAL_CSV_DIR)
+        scores = csv_to_wb2_scores(df, lead_time_hours=6)
+        acc_vals = scores["acc_Z500"].values[:20]  # first 20 steps
+        # allow small non-monotone wobbles (noise), check overall trend
+        assert acc_vals[0] > acc_vals[-1], "ACC should decrease from step 1 to step 20"
+        assert acc_vals[0] > 0.99, "ACC at step 1 should be > 0.99"
+
+    def test_rmse_z500_monotone_increase(self):
+        """Z500 RMSE should increase with lead time (at least for first 10 days)."""
+        from applications.eval_weatherbench import csv_to_wb2_scores, load_csv_metrics
+
+        df = load_csv_metrics(REAL_CSV_DIR)
+        scores = csv_to_wb2_scores(df, lead_time_hours=6)
+        rmse_vals = scores["rmse_Z500"].values[:20]
+        assert rmse_vals[-1] > rmse_vals[0], "RMSE should increase from step 1 to step 20"
+
+
+# ---------------------------------------------------------------------------
+# Integration test: NetCDF full path (synthetic data)
+# ---------------------------------------------------------------------------
+
+
+def _make_synthetic_forecast_nc(path, init_time, step, lat, lon, rng):
+    """Write a minimal CREDIT-format forecast netCDF."""
+    valid_time = pd.Timestamp(init_time) + pd.Timedelta(hours=step * 6)
+    level = np.arange(18)
+
+    ds = xr.Dataset(
+        {
+            "Z500": (["time", "latitude", "longitude"], rng.standard_normal((1, len(lat), len(lon))).astype("float32")),
+            "T500": (
+                ["time", "latitude", "longitude"],
+                (280 + rng.standard_normal((1, len(lat), len(lon)))).astype("float32"),
+            ),
+            "t2m": (
+                ["time", "latitude", "longitude"],
+                (290 + rng.standard_normal((1, len(lat), len(lon)))).astype("float32"),
+            ),
+            "SP": (
+                ["time", "latitude", "longitude"],
+                (101325 + 100 * rng.standard_normal((1, len(lat), len(lon)))).astype("float32"),
+            ),
+            "U": (
+                ["time", "level", "latitude", "longitude"],
+                rng.standard_normal((1, len(level), len(lat), len(lon))).astype("float32"),
+            ),
+        },
+        coords={
+            "time": [np.datetime64(valid_time)],
+            "level": level.astype("float32"),
+            "latitude": lat.astype("float32"),
+            "longitude": lon.astype("float32"),
+        },
+        attrs={"Conventions": "CF-1.11"},
+    )
+    ds.to_netcdf(path)
+    return ds
+
+
+def _make_synthetic_era5_zarr(path, times, lat, lon, rng):
+    """Write a minimal ERA5-format zarr store."""
+    level = np.arange(18).astype("float32")
+    ds = xr.Dataset(
+        {
+            "u_component_of_wind": (
+                ["time", "level", "latitude", "longitude"],
+                rng.standard_normal((len(times), len(level), len(lat), len(lon))).astype("float32"),
+            ),
+            "VAR_2T": (
+                ["time", "latitude", "longitude"],
+                (290 + rng.standard_normal((len(times), len(lat), len(lon)))).astype("float32"),
+            ),
+            "SP": (
+                ["time", "latitude", "longitude"],
+                (101325 + 100 * rng.standard_normal((len(times), len(lat), len(lon)))).astype("float32"),
+            ),
+        },
+        coords={
+            "time": times,
+            "level": level,
+            "latitude": lat.astype("float32"),
+            "longitude": lon.astype("float32"),
+        },
+    )
+    ds.to_zarr(path, mode="w")
+    return ds
+
+
+class TestNetCDFPath:
+    """Integration tests using synthetic forecast netCDFs and ERA5 zarr."""
+
+    @pytest.fixture
+    def synthetic_data(self, tmp_path):
+        rng = np.random.default_rng(42)
+        lat = np.linspace(-90, 90, 19)  # coarse for speed
+        lon = np.linspace(0, 360, 36, endpoint=False)
+
+        init = "2020-06-01"
+        steps = [4, 8]  # day 1 and day 2
+
+        # build forecast dir: forecast_dir/2020-06-01T00Z/pred_*_SSS.nc
+        init_dir = tmp_path / "forecasts" / "2020-06-01T00Z"
+        init_dir.mkdir(parents=True)
+        for step in steps:
+            nc_path = init_dir / f"pred_2020-06-01T00Z_{step:03d}.nc"
+            _make_synthetic_forecast_nc(str(nc_path), init, step, lat, lon, rng)
+
+        # build ERA5: one zarr covering all valid times
+        valid_times = [np.datetime64(pd.Timestamp(init) + pd.Timedelta(hours=s * 6)) for s in steps]
+        era5_path = str(tmp_path / "era5_2020.zarr")
+        _make_synthetic_era5_zarr(era5_path, valid_times, lat, lon, rng)
+
+        return {
+            "forecast_dir": str(tmp_path / "forecasts"),
+            "era5_glob": era5_path,
+            "lat": lat,
+            "lon": lon,
+            "steps": steps,
+        }
+
+    def test_compute_netcdf_scores_runs(self, synthetic_data):
+        from applications.eval_weatherbench import compute_netcdf_scores
+
+        scores = compute_netcdf_scores(
+            synthetic_data["forecast_dir"],
+            synthetic_data["era5_glob"],
+            clim_path=None,
+            lead_time_hours=6,
+        )
+        assert isinstance(scores, pd.DataFrame)
+        assert len(scores) == len(synthetic_data["steps"])
+
+    def test_scores_have_lead_time_column(self, synthetic_data):
+        from applications.eval_weatherbench import compute_netcdf_scores
+
+        scores = compute_netcdf_scores(
+            synthetic_data["forecast_dir"],
+            synthetic_data["era5_glob"],
+            clim_path=None,
+            lead_time_hours=6,
+        )
+        assert "lead_time_hours" in scores.columns
+        assert list(scores["lead_time_hours"]) == [s * 6 for s in synthetic_data["steps"]]
+
+    def test_rmse_columns_present_and_finite(self, synthetic_data):
+        from applications.eval_weatherbench import compute_netcdf_scores
+
+        scores = compute_netcdf_scores(
+            synthetic_data["forecast_dir"],
+            synthetic_data["era5_glob"],
+            clim_path=None,
+            lead_time_hours=6,
+        )
+        for region in latitude_slices:
+            col = f"rmse_t2m_{region}"
+            if col in scores.columns:
+                assert scores[col].notna().all(), f"{col} has NaNs"
+                assert (scores[col] >= 0).all(), f"{col} has negative values"
+
+    def test_rmse_zero_when_perfect(self):
+        """If forecast == ERA5, all RMSEs should be 0."""
+        from applications.eval_weatherbench import _add_scores
+
+        rng = np.random.default_rng(99)
+        lat = np.linspace(-90, 90, 19)
+        lon = np.linspace(0, 360, 36, endpoint=False)
+        time = np.array(["2020-01-01", "2020-01-02"], dtype="datetime64")
+
+        data = rng.standard_normal((2, 19, 36)).astype("float32")
+        da = xr.DataArray(
+            data, dims=["time", "latitude", "longitude"], coords={"time": time, "latitude": lat, "longitude": lon}
+        )
+
+        row = {}
+        _add_scores(row, da, da, "test_var")
+        assert row["rmse_test_var"] == pytest.approx(0.0, abs=1e-5)
+        assert row["bias_test_var"] == pytest.approx(0.0, abs=1e-5)
+
+    def test_acc_one_when_perfect_with_clim(self):
+        """If forecast == ERA5 and we have climatology, ACC should be 1."""
+        from applications.eval_weatherbench import _add_scores
+
+        rng = np.random.default_rng(100)
+        lat = np.linspace(-90, 90, 19)
+        lon = np.linspace(0, 360, 36, endpoint=False)
+        time = np.array(["2020-01-01", "2020-01-02"], dtype="datetime64")
+
+        signal = rng.standard_normal((2, 19, 36)).astype("float32")
+        clim_data = rng.standard_normal((2, 19, 36)).astype("float32")
+
+        da_signal = xr.DataArray(
+            signal, dims=["time", "latitude", "longitude"], coords={"time": time, "latitude": lat, "longitude": lon}
+        )
+        da_clim = xr.DataArray(
+            clim_data, dims=["time", "latitude", "longitude"], coords={"time": time, "latitude": lat, "longitude": lon}
+        )
+
+        row = {}
+        _add_scores(row, da_signal, da_signal, "test_var", da_clim=da_clim)
+        assert row["acc_test_var"] == pytest.approx(1.0, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Integration test: climatology loading
+# ---------------------------------------------------------------------------
+
+REAL_CLIM_PATH = "/glade/campaign/cisl/aiml/akn7/CREDIT_CESM/VERIF/ERA5_clim/ERA5_clim_1990_2019_6h_cesm_interp.nc"
+
+
+@pytest.mark.skipif(
+    not os.path.exists(REAL_CLIM_PATH),
+    reason="ERA5 climatology not available on this system",
+)
+class TestClimatologyLoading:
+    def test_loads_without_error(self):
+        from applications.eval_weatherbench import load_climatology
+
+        ds = load_climatology()
+        assert ds is not None
+
+    def test_has_expected_dims(self):
+        from applications.eval_weatherbench import load_climatology
+
+        ds = load_climatology()
+        assert "dayofyear" in ds.dims
+        assert "hour" in ds.dims
+        assert "latitude" in ds.dims
+        assert "longitude" in ds.dims
+
+    def test_select_clim_aligns_to_times(self):
+        from applications.eval_weatherbench import load_climatology, select_clim
+
+        ds = load_climatology()
+        var = "2m_temperature"
+        if var not in ds:
+            pytest.skip(f"{var} not in climatology dataset")
+
+        times = np.array(["2020-01-15T00", "2020-06-21T12", "2020-12-31T18"], dtype="datetime64[ns]")
+        da = select_clim(ds, times, var)
+        assert da.dims[0] == "time"
+        assert len(da.time) == 3
+
+    def test_clim_values_physically_reasonable(self):
+        """2m temperature climatology should be between 180 K and 330 K."""
+        from applications.eval_weatherbench import load_climatology
+
+        ds = load_climatology()
+        var = "2m_temperature"
+        if var not in ds:
+            pytest.skip(f"{var} not in climatology dataset")
+
+        sample = float(ds[var].isel(dayofyear=0, hour=0).mean())
+        assert 180 < sample < 330, f"Mean 2m_temperature = {sample:.1f} K, seems wrong"


### PR DESCRIPTION
## Summary

Adds full [WeatherBench2](https://sites.research.google/weatherbench/)-style deterministic verification tooling directly into CREDIT. This is a proper integration — the metrics module lives in `credit/verification/` and the CLI tools are first-class `applications/` scripts, not one-off analysis notebooks.

**New CLI commands:**

```bash
# Fast path — aggregate existing per-init CREDIT metrics CSVs
python applications/eval_weatherbench.py --csv /path/to/metrics/ --out scores.csv

# Full path — compute from forecast netCDFs vs ERA5 with true anomaly ACC
python applications/eval_weatherbench.py   --netcdf /path/to/forecasts/   --era5 /glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_1deg/all_in_one/ERA5_plevel_1deg_6h_2022_conserve.zarr   --clim /glade/campaign/cisl/aiml/akn7/CREDIT_CESM/VERIF/ERA5_clim/ERA5_clim_1990_2019_6h_cesm_interp.nc   --out scores.csv   --plot figures/   --label "WXFormer v2"

# Plots only (from existing scores CSV)
python applications/plot_weatherbench.py --scores scores.csv --out figures/ --label "WXFormer v2"
```

## What's included

| File | Description |
|------|-------------|
| `credit/verification/deterministic.py` | Latitude-weighted RMSE, bias, true anomaly ACC with correct WB2 normalization |
| `credit/verification/wb2_references.py` | Published baseline scores: IFS HRES, Pangu-Weather, GraphCast |
| `applications/eval_weatherbench.py` | Evaluation CLI — CSV fast path + netCDF full path |
| `applications/plot_weatherbench.py` | Scorecard plots — RMSE, ACC, bias, heatmap, regional breakdown |
| `tests/test_weatherbench.py` | 38 unit + integration tests, all passing |

## Figures generated

- **RMSE vs lead time** per variable with IFS HRES / Pangu-Weather / GraphCast reference lines
- **ACC vs lead time** — true anomaly ACC (requires climatology) not Pearson correlation
- **Bias vs lead time** — global mean bias (forecast − ERA5)
- **Scorecard heatmap** — skill score vs IFS HRES at days 1/2/3/5/7/10 (green = better than IFS)
- **Regional RMSE breakdown** — global / tropics / N. extratropics / S. extratropics

## Notes

- Ensemble netCDFs are supported: ensemble mean is taken automatically before scoring
- `acc_*` columns from legacy per-init CSVs are Pearson r, renamed to `pearson_r_*` to avoid confusion with true WB2 ACC
- Reference baselines sourced from: Rasp et al. 2024 (WB2/JAMES), Bi et al. 2023 (Pangu/Nature), Lam et al. 2023 (GraphCast/Science)
- ERA5 pressure-level data at `/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_1deg/` covers 2020–2022

## Test plan
- [x] `python -m pytest tests/test_weatherbench.py` — 38/38 pass
- [x] Run full 2022 eval against scheduler netCDFs on casper — verified over the weekend
- [x] Verify true ACC curves look sensible vs IFS HRES reference — verified over the weekend

🤖 Generated with [Claude Code](https://claude.com/claude-code)