### PR TITLE
Configuration File Docs Text Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ climate/Look_at_Tens.ipynb
 
 # local dev / HPC-specific test scripts
 test_energy_fixer_updown.py
+
+# MAC DS_Store files
+.DS_Store

--- a/docs/source/config.md
+++ b/docs/source/config.md
@@ -667,11 +667,6 @@ surface_channels: 7
 
 Here's an **expanded and structured section** detailing the **model configuration**, including explanations of **architecture choices, spatial resolution, patch embeddings, attention mechanisms, and normalization techniques**.  
 
----
-## Model Configuration  
-
-The `model` section defines the **architecture and input structure** for CREDIT.  
-
 ### Selecting a Model Architecture  
 
 ```yaml

--- a/docs/source/config.md
+++ b/docs/source/config.md
@@ -74,7 +74,7 @@ save_loc_diagnostic: '/path/to/diagnostic_data/'
 
 - **Diagnostic variables** are used for evaluation but **not directly predicted** by the model.  
 
-#### Periodic & Static Forcing  
+### Periodic & Static Forcing  
 
 ```yaml
 forcing_variables: ['TSI', 'SST']
@@ -87,8 +87,6 @@ save_loc_static: '/path/to/static_data.nc'
 - **Periodic forcing**: Should cover an entire leap year (e.g., 366 days for an hourly model).  
 - **Static variables**: Must be normalized **by the user** before use.  
 
-
-You're right again—these options are **critical for data standardization and conservation enforcement**, so they should be fully documented. Below is an **expanded section** that provides detailed explanations.  
 
 ---
 

--- a/docs/source/config.md
+++ b/docs/source/config.md
@@ -10,8 +10,10 @@ This document provides detailed instructions on configuring `configuration.yml` 
 
 **Key Topics Covered:**  
 - Understanding and modifying `configuration.yml`  
-- Default values and expected parameter ranges  
-- Common pitfalls and troubleshooting  
+- Standard Configuration Values and Recommendations
+- Best Practices and troubleshooting  
+
+Summary tables are included at the end of each subsection.
 
 ---
 
@@ -87,7 +89,6 @@ save_loc_static: '/path/to/static_data.nc'
 - **Periodic forcing**: Should cover an entire leap year (e.g., 366 days for an hourly model).  
 - **Static variables**: Must be normalized **by the user** before use.  
 
-
 ---
 
 ## Physics and Normalization Files  
@@ -140,7 +141,7 @@ Both `mean_path` and `std_path` should store **1D variables indexed by level**:
 
 ---
 
-## Summary of Key Recommendations  
+### Summary of Key Physics & Normalization Recommendations  
 
 | Parameter | Required For | Notes |
 |-----------|-------------|-------|
@@ -300,7 +301,7 @@ dataset_type: ERA5_MultiStep_Batcher
 
 ---
 
-## Summary of Key Recommendations  
+### Summary of Key Data Processing Recommendations  
 
 | Parameter | Recommended Setting | Notes |
 |-----------|---------------------|-------|
@@ -435,7 +436,7 @@ update_learning_rate: False
 
 ---
 
-## Summary of Key Recommendations  
+### Summary of Key Hardware Utilization Recommendations  
 
 | Parameter | Recommended Setting | Notes |
 |-----------|---------------------|-------|
@@ -625,7 +626,7 @@ prefetch_factor: 4
 
 ---
 
-## Summary of Key Recommendations  
+### Summary of Key Training Strategy Recommendations  
 
 | Parameter | Recommended Setting | Notes |
 |-----------|---------------------|-------|
@@ -816,7 +817,7 @@ interp: True
 
 ---
 
-## Summary of Key Recommendations  
+### Summary of Key Model Recommendations  
 
 | Parameter | Recommended Setting | Notes |
 |-----------|---------------------|-------|
@@ -853,7 +854,7 @@ padding_conf:
 💡 *Padding ensures continuity at boundaries, preventing artifacts in global simulations.*  
 
 ---
-## Summary of Key Recommendations  
+### Summary of Key Padding Recommendations  
 
 | Parameter | Recommended Setting | Notes |
 |-----------|---------------------|-------|
@@ -1111,7 +1112,7 @@ global_energy_fixer:
 
 ---
 
-## Summary of Key Conservation Fixers  
+### Summary of Key Conservation Fixers 
 
 | Fixer | Purpose | Key Variables |
 |--------|---------|--------------|
@@ -1227,7 +1228,7 @@ variable_weights:
 
 ---
 
-## Summary of Key Recommendations  
+### Summary of Key Loss Recommendations  
 
 | Parameter | Recommended Setting | Notes |
 |-----------|---------------------|-------|
@@ -1361,7 +1362,7 @@ climatology: '/path/to/climatology.nc'
 
 ---
 
-## Summary of Key Recommendations  
+### Summary of Key Prediction Recommendations  
 
 | Parameter | Recommended Setting | Notes |
 |-----------|---------------------|-------|


### PR DESCRIPTION
<!-- Note: The pull request (PR) title will be included in the release notes. -->

### Description
<!-- Provide a standalone description of changes in this PR. -->

There were a few places in the "What's in the Configuration File?" docs that seemed to include outdated text. Correspondingly, the following have been changed:
1. Outdated conversational text after variable types (i.e., Periodic & Static Forcing section)
2. Many tables were listed as "Summary of Key Recommendations" and are now more direct (e.g., "Summary of Key Training Strategy Recommendations")
3. There were two "Model Configuration" sections, with one seemingly having been a placeholder.

Note: It may be worth considering the Markdown header number. Right now, we have `# What's in the Configuration FIle` and `# CREDIT Configuration Guide`. I wonder if we need the latter at all. We can also consider multiple top level `#` to better split the sections in the table of contents.

### Related Issues and PRs
<!-- Reference any related issues using the appropriate keyword and issue number as
described in the GitHub documentation: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword. -->
<!-- For example, "Closes #315" -->
<!-- You may also reference any related PRs or discussions using the syntax shown here:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests. -->

This does not close any current issues. Larger structural changes are still retained in issue #185.

### Checklist
- [X] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date.
