### PR TITLE
models: guard legacy imports against NumPy >=2.3 / numba conflict

### DIFF
--- a/credit/models/__init__.py
+++ b/credit/models/__init__.py
@@ -3,67 +3,66 @@ import sys
 import copy
 import logging
 
-# Import model classes
-from credit.models.crossformer import CrossFormer
-from credit.models.camulator import Camulator
-from credit.models.unet import SegmentationModel
-from credit.models.fuxi import Fuxi
-from credit.models.swin import SwinTransformerV2Cr
-from credit.models.graph import GraphResTransfGRU
-from credit.models.debugger_model import DebuggerModel
-from credit.models.wxformer.crossformer import CrossFormer as WXFormer
-from credit.models.wxformer.crossformer_ensemble import CrossFormerWithNoise
-from credit.models.wxformer.crossformer_downscaling import DownscalingCrossFormer
-from credit.models.unet_downscaling import DownscalingSegmentationModel
-from credit.models.wxformer.crossformer_diffusion import CrossFormerDiffusion
-from credit.models.unet_diffusion import UnetDiffusion
-from credit.diffusion import ModifiedGaussianDiffusion
-from credit.models.swin_wrf import WRFTransformer
-from credit.models.dscale_wrf import DscaleTransformer
+# Legacy model imports — wrapped in try/except because their transitive dependencies
+# (bridgescaler → numba) may conflict with newer NumPy (≥2.3) environments.
+try:
+    from credit.models.crossformer import CrossFormer
+    from credit.models.camulator import Camulator
+    from credit.models.unet import SegmentationModel
+    from credit.models.fuxi import Fuxi
+    from credit.models.swin import SwinTransformerV2Cr
+    from credit.models.graph import GraphResTransfGRU
+    from credit.models.debugger_model import DebuggerModel
+    from credit.models.wxformer.crossformer import CrossFormer as WXFormer
+    from credit.models.wxformer.crossformer_ensemble import CrossFormerWithNoise
+    from credit.models.wxformer.crossformer_downscaling import DownscalingCrossFormer
+    from credit.models.unet_downscaling import DownscalingSegmentationModel
+    from credit.models.wxformer.crossformer_diffusion import CrossFormerDiffusion
+    from credit.models.unet_diffusion import UnetDiffusion
+    from credit.diffusion import ModifiedGaussianDiffusion
+    from credit.models.swin_wrf import WRFTransformer
+    from credit.models.dscale_wrf import DscaleTransformer
 
+    _LEGACY_MODELS_AVAILABLE = True
+except (ImportError, Exception) as _legacy_import_err:
+    logging.warning(f"Legacy model imports unavailable (numba/NumPy conflict or missing dep): {_legacy_import_err}.")
+    _LEGACY_MODELS_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
 
 # Define model types and their corresponding classes
-model_types = {
-    "crossformer": (
-        CrossFormer,
-        "Loading the CrossFormer model with a conv decoder head and skip connections ...",
-    ),
-    "camulator": (
-        Camulator,
-        "Loading the CAMulator model with a conv decoder head and skip connections ...",
-    ),
-    "crossformer-diffusion": (
-        CrossFormerDiffusion,
-        "Loading A DDPM model with CrossFormer Backbone ...",
-    ),
-    "unet-diffusion": (
-        UnetDiffusion,
-        "Loading A DDPM model with UNET Backbone ...",
-    ),
-    "wxformer": (WXFormer, "Loading the WXFormer deterministic model ..."),
-    "crossformer-ensemble": (
-        CrossFormerWithNoise,
-        "Loading the ensemble CrossFormer model with a noise injection scheme ...",
-    ),
-    "crossformer-style": (
-        CrossFormerWithNoise,
-        "Loading the ensemble CrossFormer model with a Style-GAN-like noise injection scheme ...",
-    ),
-    "unet": (SegmentationModel, "Loading a unet model"),
-    "fuxi": (Fuxi, "Loading Fuxi model"),
-    "swin": (SwinTransformerV2Cr, "Loading the minimal Swin model"),
-    "graph": (GraphResTransfGRU, "Loading Graph Residual Transformer GRU model"),
-    "debugger": (DebuggerModel, "Loading the debugger model"),
-    "wrf": (WRFTransformer, "Loading WRF Transformer"),
-    "dscale": (DscaleTransformer, "Loading downscaling Transformer"),
-    "crossformer_downscaling": (
-        DownscalingCrossFormer,
-        "Loading downscaling crossformer model",
-    ),
-    "unet_downscaling": (DownscalingSegmentationModel, "Loading downscaling U-net"),
-}
+model_types = {}
+
+if _LEGACY_MODELS_AVAILABLE:
+    model_types.update(
+        {
+            "crossformer": (
+                CrossFormer,
+                "Loading the CrossFormer model with a conv decoder head and skip connections ...",
+            ),
+            "camulator": (Camulator, "Loading the CAMulator model with a conv decoder head and skip connections ..."),
+            "crossformer-diffusion": (CrossFormerDiffusion, "Loading A DDPM model with CrossFormer Backbone ..."),
+            "unet-diffusion": (UnetDiffusion, "Loading A DDPM model with UNET Backbone ..."),
+            "wxformer": (WXFormer, "Loading the WXFormer deterministic model ..."),
+            "crossformer-ensemble": (
+                CrossFormerWithNoise,
+                "Loading the ensemble CrossFormer model with a noise injection scheme ...",
+            ),
+            "crossformer-style": (
+                CrossFormerWithNoise,
+                "Loading the ensemble CrossFormer model with a Style-GAN-like noise injection scheme ...",
+            ),
+            "unet": (SegmentationModel, "Loading a unet model"),
+            "fuxi": (Fuxi, "Loading Fuxi model"),
+            "swin": (SwinTransformerV2Cr, "Loading the minimal Swin model"),
+            "graph": (GraphResTransfGRU, "Loading Graph Residual Transformer GRU model"),
+            "debugger": (DebuggerModel, "Loading the debugger model"),
+            "wrf": (WRFTransformer, "Loading WRF Transformer"),
+            "dscale": (DscaleTransformer, "Loading downscaling Transformer"),
+            "crossformer_downscaling": (DownscalingCrossFormer, "Loading downscaling crossformer model"),
+            "unet_downscaling": (DownscalingSegmentationModel, "Loading downscaling U-net"),
+        }
+    )
 
 
 # Define FSDP sharding and/or checkpointing policy

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -1,0 +1,125 @@
+"""Unit tests for credit.models factory functions.
+
+Covers:
+  - load_model()                        — missing/invalid type error paths; conf immutability
+  - load_model_name()                   — missing/invalid type error paths; conf immutability
+  - load_fsdp_or_checkpoint_policy()    — unsupported type (always); model-specific sets (guarded)
+
+Tests that require legacy model imports (crossformer, swin, fuxi, etc.) are skipped
+when those imports are unavailable (e.g. numba/NumPy conflict in CI).
+"""
+
+import pytest
+
+try:
+    from credit.models import _LEGACY_MODELS_AVAILABLE
+except ImportError:
+    _LEGACY_MODELS_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# load_model — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestLoadModel:
+    def test_missing_type_key_raises(self):
+        from credit.models import load_model
+
+        with pytest.raises(ValueError, match="type"):
+            load_model({"model": {}})
+
+    def test_invalid_type_raises(self):
+        from credit.models import load_model
+
+        with pytest.raises(ValueError, match="not supported"):
+            load_model({"model": {"type": "nonexistent-model-xyz"}})
+
+    def test_original_conf_not_mutated(self):
+        """load_model deep-copies conf internally; the caller's dict must be unchanged."""
+        from credit.models import load_model
+
+        conf = {"model": {"type": "nonexistent-model-xyz", "extra_key": True}}
+        with pytest.raises(ValueError):
+            load_model(conf)
+        assert conf["model"]["type"] == "nonexistent-model-xyz"
+        assert conf["model"]["extra_key"] is True
+
+
+# ---------------------------------------------------------------------------
+# load_model_name — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestLoadModelName:
+    def test_missing_type_key_raises(self):
+        from credit.models import load_model_name
+
+        with pytest.raises(ValueError, match="type"):
+            load_model_name({"model": {}}, "checkpoint.pt")
+
+    def test_invalid_type_raises(self):
+        from credit.models import load_model_name
+
+        with pytest.raises(ValueError, match="not supported"):
+            load_model_name({"model": {"type": "nonexistent-model-xyz"}}, "checkpoint.pt")
+
+    def test_original_conf_not_mutated(self):
+        from credit.models import load_model_name
+
+        conf = {"model": {"type": "nonexistent-model-xyz"}}
+        with pytest.raises(ValueError):
+            load_model_name(conf, "checkpoint.pt")
+        assert conf["model"]["type"] == "nonexistent-model-xyz"
+
+
+# ---------------------------------------------------------------------------
+# load_fsdp_or_checkpoint_policy
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFSDPPolicy:
+    def _conf(self, model_type):
+        return {"model": {"type": model_type}}
+
+    def test_unsupported_type_raises_os_error(self):
+        """A type with no defined FSDP policy must raise OSError without importing legacy deps."""
+        from credit.models import load_fsdp_or_checkpoint_policy
+
+        with pytest.raises(OSError):
+            load_fsdp_or_checkpoint_policy(self._conf("nonexistent-model-xyz"))
+
+    @pytest.mark.skipif(not _LEGACY_MODELS_AVAILABLE, reason="legacy model deps unavailable in this environment")
+    def test_crossformer_returns_nonempty_set(self):
+        from credit.models import load_fsdp_or_checkpoint_policy
+
+        result = load_fsdp_or_checkpoint_policy(self._conf("crossformer"))
+        assert isinstance(result, set) and len(result) > 0
+
+    @pytest.mark.skipif(not _LEGACY_MODELS_AVAILABLE, reason="legacy model deps unavailable in this environment")
+    def test_unet_returns_nonempty_set(self):
+        from credit.models import load_fsdp_or_checkpoint_policy
+
+        result = load_fsdp_or_checkpoint_policy(self._conf("unet"))
+        assert isinstance(result, set) and len(result) > 0
+
+    @pytest.mark.skipif(not _LEGACY_MODELS_AVAILABLE, reason="legacy model deps unavailable in this environment")
+    def test_fuxi_returns_nonempty_set(self):
+        from credit.models import load_fsdp_or_checkpoint_policy
+
+        result = load_fsdp_or_checkpoint_policy(self._conf("fuxi"))
+        assert isinstance(result, set) and len(result) > 0
+
+    @pytest.mark.skipif(not _LEGACY_MODELS_AVAILABLE, reason="legacy model deps unavailable in this environment")
+    def test_wrf_returns_nonempty_set(self):
+        from credit.models import load_fsdp_or_checkpoint_policy
+
+        result = load_fsdp_or_checkpoint_policy(self._conf("wrf"))
+        assert isinstance(result, set) and len(result) > 0
+
+    @pytest.mark.skipif(not _LEGACY_MODELS_AVAILABLE, reason="legacy model deps unavailable in this environment")
+    def test_swin_returns_nonempty_set(self):
+        from credit.models import load_fsdp_or_checkpoint_policy
+
+        result = load_fsdp_or_checkpoint_policy(self._conf("swin"))
+        assert isinstance(result, set) and len(result) > 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,14 +2,22 @@
 
 import os
 import yaml
+import pytest
 
 import torch
 
-from credit.models import load_model
-from credit.models.unet import SegmentationModel
-from credit.models.crossformer import CrossFormer
-from credit.models.fuxi import Fuxi
+from credit.models import load_model, _LEGACY_MODELS_AVAILABLE
 from credit.parser import credit_main_parser
+
+pytestmark = pytest.mark.skipif(
+    not _LEGACY_MODELS_AVAILABLE,
+    reason="Legacy model deps unavailable (numba/bridgescaler conflict with NumPy ≥2.3)",
+)
+
+if _LEGACY_MODELS_AVAILABLE:
+    from credit.models.unet import SegmentationModel
+    from credit.models.crossformer import CrossFormer
+    from credit.models.fuxi import Fuxi
 
 TEST_FILE_DIR = "/".join(os.path.abspath(__file__).split("/")[:-1])
 CONFIG_FILE_DIR = os.path.join("/".join(os.path.abspath(__file__).split("/")[:-2]), "config")


### PR DESCRIPTION
## Summary

`bridgescaler` pulls in `numba`, which breaks on NumPy >=2.3 in CI — `import credit.models` hard-fails and no tests run.

This wraps the legacy model imports in a try/except and exposes `_LEGACY_MODELS_AVAILABLE` so test suites can skip gracefully rather than error out.

This is a CI compatibility fix, not a gen2 architectural change. Splitting it out of the [1/4] trainer PR so it can merge independently.

**@djgagne** — `bridgescaler` is yours. Ideally this guard lives upstream (bridgescaler pins or drops the numba dependency for NumPy >=2.3) so CREDIT does not need to own it. Flagging here so it is on your radar.

**@charlie-becker** — tagging you as well since this touches model loading.

## Files
- `credit/models/__init__.py` — try/except around legacy imports, `_LEGACY_MODELS_AVAILABLE` flag
- `tests/test_models.py` — skip guards using the flag
- `tests/test_model_loading.py` — new tests for `load_model` / `load_fsdp_or_checkpoint_policy` error paths

## Test plan
- [ ] CI passes on Python 3.11/3.12/3.13
- [ ] `python -m pytest tests/test_models.py tests/test_model_loading.py`