### PR TITLE
Fix units in mean_sea_level_pressure_simple lapse-rate branch test

### DIFF
--- a/credit/interp.py
+++ b/credit/interp.py
@@ -814,7 +814,7 @@ def mean_sea_level_pressure_simple(surface_pressure_pa, temperature_k, surface_g
             mslp[i, j] = surface_pressure_pa[i, j]
         else:
             temp = temperature_k[i, j]
-            tto = temp + LAPSE_RATE * sgp
+            tto = temp + LAPSE_RATE * sgp / GRAVITY
             alpha_local = ALPHA
             if (temp <= 290.5) and (tto > 290.5):
                 alpha_local = RDGAS * (290.5 - temp) / sgp


### PR DESCRIPTION
## Summary

- `mean_sea_level_pressure_simple` computes `tto = temp + LAPSE_RATE * sgp` to decide which lapse-rate correction branch to take (Trenberth et al. 1993). `LAPSE_RATE` is K/m but `sgp` is surface geopotential (m² s⁻²), so the product has units K·m/s² rather than K. Dividing by `GRAVITY` (9.81 m/s²) converts to height in meters and restores dimensional consistency.
- One-character fix, no logic change beyond the corrected threshold comparison.

## Test plan

- [x] Existing `test_physics.py` passes
- [x] Spot-check: `mean_sea_level_pressure_simple` called directly with a mid-elevation point (z ≈ 3000 m, T = 270 K) returns a value consistent with the full `mean_sea_level_pressure` implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)