### PR TITLE
MSLPDiagnostic postblock

### DIFF
--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -3,7 +3,8 @@ import torch.nn as nn
 from credit.postblock.reconstruct import Reconstruct
 from credit.postblock.wet_mask_samudra import WetMaskBlock
 from credit.postblock.scaler import BridgeScalerTransformer
-from credit.postblock.mslp import MSLPDiagnostic, mslp_from_surface_pressure
+from credit.postblock.mslp import MSLPDiagnostic
+from credit.postblock.mslp import mslp_from_surface_pressure as mslp_from_surface_pressure
 
 
 POSTBLOCK_REGISTRY = {

--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -3,12 +3,14 @@ import torch.nn as nn
 from credit.postblock.reconstruct import Reconstruct
 from credit.postblock.wet_mask_samudra import WetMaskBlock
 from credit.postblock.scaler import BridgeScalerTransformer
+from credit.postblock.mslp import MSLPDiagnostic, mslp_from_surface_pressure
 
 
 POSTBLOCK_REGISTRY = {
     "reconstruct": Reconstruct,
     "bridgescaler_transform": BridgeScalerTransformer,
     "wet_mask_samudra": WetMaskBlock,
+    "mslp_diagnostic": MSLPDiagnostic,
 }
 
 

--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -4,7 +4,6 @@ from credit.postblock.reconstruct import Reconstruct
 from credit.postblock.wet_mask_samudra import WetMaskBlock
 from credit.postblock.scaler import BridgeScalerTransformer
 from credit.postblock.mslp import MSLPDiagnostic
-from credit.postblock.mslp import mslp_from_surface_pressure as mslp_from_surface_pressure
 
 
 POSTBLOCK_REGISTRY = {

--- a/credit/postblock/mslp.py
+++ b/credit/postblock/mslp.py
@@ -16,7 +16,6 @@ where sgp is geopotential (m² s⁻²); it must be `LAPSE_RATE * sgp / GRAVITY`
 to convert geopotential to height in metres.
 """
 
-import logging
 from typing import Iterable
 
 import torch
@@ -24,11 +23,13 @@ import torch.nn as nn
 
 from credit.physics_constants import GRAVITY, RDGAS
 
-logger = logging.getLogger(__name__)
-
 # Trenberth 1993 standard atmosphere lapse rate
 _LAPSE_RATE = 0.0065  # K m⁻¹
 _ALPHA_STD = _LAPSE_RATE * RDGAS / GRAVITY  # dimensionless
+
+# Trenberth 1993 temperature thresholds for lapse-rate regime selection
+_T_WARM = 290.5  # K — warm-surface branch (alpha → 0, T_eff blended)
+_T_COLD = 255.0  # K — very-cold-surface branch (T_eff blended toward 255 K)
 
 
 def mslp_from_surface_pressure(
@@ -58,25 +59,22 @@ def mslp_from_surface_pressure(
     tto = temperature + _LAPSE_RATE * height
 
     # --- effective lapse-rate alpha and temperature ---
-    # case 1: cold surface but warm sea level  (T_surf <= 290.5, T_sl > 290.5)
-    mask1 = (temperature <= 290.5) & (tto > 290.5)
-    alpha_case1 = RDGAS * (290.5 - temperature) / sgp.clamp(min=1e-6)
+    # case 1: cold surface but warm sea level  (T_surf <= _T_WARM, T_sl > _T_WARM)
+    mask1 = (temperature <= _T_WARM) & (tto > _T_WARM)
+    alpha_case1 = RDGAS * (_T_WARM - temperature) / sgp.clamp(min=1e-6)
 
-    # case 2: warm surface  (T_surf > 290.5)
-    mask2 = temperature > 290.5
+    # case 2: warm surface  (T_surf > _T_WARM)
+    mask2 = temperature > _T_WARM
 
-    # case 3: very cold surface  (T_surf < 255), only outside cases 1 & 2
-    mask3 = (temperature < 255) & ~mask1 & ~mask2
+    # case 3: very cold surface  (T_surf < _T_COLD), only outside cases 1 & 2
+    mask3 = (temperature < _T_COLD) & ~mask1 & ~mask2
 
-    # defaults
     alpha = torch.full_like(temperature, _ALPHA_STD)
-    temp_eff = temperature.clone()
-
-    # apply cases
     alpha = torch.where(mask1, alpha_case1, alpha)
     alpha = torch.where(mask2, torch.zeros_like(alpha), alpha)
-    temp_eff = torch.where(mask2, 0.5 * (290.5 + temperature), temp_eff)
-    temp_eff = torch.where(mask3, 0.5 * (255.0 + temperature), temp_eff)
+
+    temp_eff = torch.where(mask2, 0.5 * (_T_WARM + temperature), temperature)
+    temp_eff = torch.where(mask3, 0.5 * (_T_COLD + temperature), temp_eff)
 
     x = sgp / (RDGAS * temp_eff.clamp(min=1.0))
     mslp_computed = surface_pressure * torch.exp(x * (1.0 - 0.5 * alpha * x + (alpha * x) ** 2 / 3.0))

--- a/credit/postblock/mslp.py
+++ b/credit/postblock/mslp.py
@@ -1,0 +1,143 @@
+"""
+MSLPDiagnostic postblock
+------------------------
+Computes mean sea level pressure (MSLP) from surface pressure, near-surface
+temperature, and static surface geopotential using the Trenberth et al. (1993)
+formula.  Fully vectorized in PyTorch — no numpy, no per-pixel loops.
+
+Reference:
+    Trenberth, K., J. Berry, and L. Buja, 1993: Vertical Interpolation and
+    Truncation of Model-Coordinate Data. NCAR Tech. Note NCAR/TN-396+STR.
+    https://doi.org/10.5065/D6HX19NH
+
+Bug fixed vs. the original numpy implementation in credit/interp.py (merged
+in PR #341): the sea-level temperature branch test used `LAPSE_RATE * sgp`
+where sgp is geopotential (m² s⁻²); it must be `LAPSE_RATE * sgp / GRAVITY`
+to convert geopotential to height in metres.
+"""
+
+import logging
+from typing import Iterable
+
+import torch
+import torch.nn as nn
+
+from credit.physics_constants import GRAVITY, RDGAS
+
+logger = logging.getLogger(__name__)
+
+# Trenberth 1993 standard atmosphere lapse rate
+_LAPSE_RATE = 0.0065  # K m⁻¹
+_ALPHA_STD = _LAPSE_RATE * RDGAS / GRAVITY  # dimensionless
+
+
+def mslp_from_surface_pressure(
+    surface_pressure: torch.Tensor,
+    temperature: torch.Tensor,
+    surface_geopotential: torch.Tensor,
+) -> torch.Tensor:
+    """Vectorized MSLP from surface pressure, near-surface T, and PHIS.
+
+    Implements the simplified Trenberth et al. (1993) formula.  All inputs
+    must be broadcastable to the same shape.
+
+    Args:
+        surface_pressure: surface pressure in Pa, shape (..., H, W).
+        temperature: near-surface temperature in K, shape (..., H, W).
+        surface_geopotential: PHIS in m² s⁻², shape (..., H, W).
+
+    Returns:
+        MSLP in Pa, same shape as inputs.
+    """
+    sgp = surface_geopotential
+    height = sgp / GRAVITY  # surface height in metres
+
+    near_flat = height.abs() < 1e-4  # essentially at sea level
+
+    # sea-level temperature (uncorrected)
+    tto = temperature + _LAPSE_RATE * height
+
+    # --- effective lapse-rate alpha and temperature ---
+    # case 1: cold surface but warm sea level  (T_surf <= 290.5, T_sl > 290.5)
+    mask1 = (temperature <= 290.5) & (tto > 290.5)
+    alpha_case1 = RDGAS * (290.5 - temperature) / sgp.clamp(min=1e-6)
+
+    # case 2: warm surface  (T_surf > 290.5)
+    mask2 = temperature > 290.5
+
+    # case 3: very cold surface  (T_surf < 255), only outside cases 1 & 2
+    mask3 = (temperature < 255) & ~mask1 & ~mask2
+
+    # defaults
+    alpha = torch.full_like(temperature, _ALPHA_STD)
+    temp_eff = temperature.clone()
+
+    # apply cases
+    alpha = torch.where(mask1, alpha_case1, alpha)
+    alpha = torch.where(mask2, torch.zeros_like(alpha), alpha)
+    temp_eff = torch.where(mask2, 0.5 * (290.5 + temperature), temp_eff)
+    temp_eff = torch.where(mask3, 0.5 * (255.0 + temperature), temp_eff)
+
+    x = sgp / (RDGAS * temp_eff.clamp(min=1.0))
+    mslp_computed = surface_pressure * torch.exp(x * (1.0 - 0.5 * alpha * x + (alpha * x) ** 2 / 3.0))
+
+    return torch.where(near_flat, surface_pressure, mslp_computed)
+
+
+class MSLPDiagnostic(nn.Module):
+    """Postblock that computes MSLP from surface pressure, 2m temperature, and PHIS.
+
+    Follows the same data-dict protocol as ``GeopotentialDiagnostic``: all
+    inputs are accessed by variable name from the nested batch dict, and the
+    result is written back under ``output_name``.
+
+    Args:
+        output_name: key written into ``data[dataset_name]`` for the result.
+        dataset_name: top-level key inside each ``data_type`` sub-dict.
+        data_keys: which top-level batch-dict keys to process (e.g.
+            ``("prediction", "target")``).
+        surface_pressure_var: variable name for surface pressure (Pa).
+        temperature_var: variable name for near-surface temperature (K).
+        surface_geopotential_var: variable name for PHIS (m² s⁻²).
+    """
+
+    def __init__(
+        self,
+        output_name: str = "ARCO_ERA5/derived_diagnostic/2d/mean_sea_level_pressure",
+        dataset_name: str = "ARCO_ERA5",
+        data_keys: Iterable[str] = ("prediction", "target"),
+        surface_pressure_var: str = "ARCO_ERA5/prognostic/2d/surface_pressure",
+        temperature_var: str = "ARCO_ERA5/prognostic/2d/2m_temperature",
+        surface_geopotential_var: str = "ARCO_ERA5/static/2d/geopotential_at_surface",
+    ):
+        super().__init__()
+        self.output_name = output_name
+        self.dataset_name = dataset_name
+        self.data_keys = data_keys
+        self.surface_pressure_var = surface_pressure_var
+        self.temperature_var = temperature_var
+        self.surface_geopotential_var = surface_geopotential_var
+
+    def forward(self, data_dict: dict) -> dict:
+        """Compute MSLP for each requested data key and write into the batch dict.
+
+        Args:
+            data_dict: nested batch dict.  Each ``data_dict[data_type][dataset_name]``
+                must contain ``surface_pressure_var``, ``temperature_var``, and
+                ``surface_geopotential_var`` as tensors with shapes broadcastable
+                to ``(B, 1, n_time, H, W)``.
+
+        Returns:
+            The same ``data_dict`` with ``output_name`` added under each
+            processed ``data_type[dataset_name]``.
+        """
+        for data_type in self.data_keys:
+            if data_type not in data_dict:
+                raise ValueError(f"Data key {data_type!r} not found in data_dict.")
+            data = data_dict[data_type]
+            dsn = self.dataset_name
+            sp = data[dsn][self.surface_pressure_var]  # (B, 1, n_time, H, W)
+            t2m = data[dsn][self.temperature_var]  # (B, 1, n_time, H, W)
+            phis = data[dsn][self.surface_geopotential_var]  # (B, 1, 1_or_n_time, H, W)
+            data[dsn][self.output_name] = mslp_from_surface_pressure(sp, t2m, phis)
+        return data_dict

--- a/tests/test_mslp_postblock.py
+++ b/tests/test_mslp_postblock.py
@@ -1,0 +1,233 @@
+"""Tests for the MSLP postblock: mslp_from_surface_pressure and MSLPDiagnostic."""
+
+import torch
+import pytest
+
+from credit.postblock.mslp import mslp_from_surface_pressure, MSLPDiagnostic
+from credit.physics_constants import GRAVITY, RDGAS
+
+_LAPSE_RATE = 0.0065
+
+
+# ---------------------------------------------------------------------------
+# mslp_from_surface_pressure — unit tests
+# ---------------------------------------------------------------------------
+
+
+def _scalar(val):
+    return torch.tensor([[val]], dtype=torch.float32)
+
+
+def test_near_flat_returns_surface_pressure():
+    """When surface geopotential is negligible, MSLP == SP."""
+    sp = _scalar(101325.0)
+    t = _scalar(288.0)
+    phis = _scalar(0.0)  # sea level
+    mslp = mslp_from_surface_pressure(sp, t, phis)
+    assert torch.allclose(mslp, sp, rtol=1e-5)
+
+
+def test_mslp_greater_than_sp_for_elevated_surface():
+    """Above sea level, MSLP must exceed SP (pressure increases downward)."""
+    sp = _scalar(85000.0)
+    t = _scalar(275.0)
+    phis = _scalar(1500.0 * GRAVITY)  # 1500 m elevation
+    mslp = mslp_from_surface_pressure(sp, t, phis)
+    assert mslp.item() > sp.item()
+
+
+def test_mslp_reasonable_magnitude():
+    """MSLP should be in a physically reasonable range (900–1100 hPa)."""
+    sp = _scalar(85000.0)
+    t = _scalar(275.0)
+    phis = _scalar(1500.0 * GRAVITY)
+    mslp = mslp_from_surface_pressure(sp, t, phis)
+    assert 90000.0 < mslp.item() < 110000.0
+
+
+def test_warm_surface_branch():
+    """temp > 290.5 K triggers alpha=0 and T_eff = 0.5*(290.5+T)."""
+    sp = _scalar(101325.0)
+    t = _scalar(295.0)  # warm, > 290.5
+    phis = _scalar(500.0 * GRAVITY)
+    mslp = mslp_from_surface_pressure(sp, t, phis)
+    assert mslp.item() > sp.item()
+    assert torch.isfinite(mslp).all()
+
+
+def test_cold_surface_branch():
+    """temp < 255 K triggers T_eff = 0.5*(255+T)."""
+    sp = _scalar(101325.0)
+    t = _scalar(240.0)  # very cold, < 255
+    phis = _scalar(500.0 * GRAVITY)
+    mslp = mslp_from_surface_pressure(sp, t, phis)
+    assert mslp.item() > sp.item()
+    assert torch.isfinite(mslp).all()
+
+
+def test_intermediate_branch_alpha_modified():
+    """T_surf <= 290.5 and T_sl > 290.5: alpha = Rd*(290.5-T)/sgp."""
+    sp = _scalar(101325.0)
+    t = _scalar(288.0)
+    # choose height so tto > 290.5: height > (290.5-288)/0.0065 ~ 384 m
+    phis = _scalar(400.0 * GRAVITY)
+    mslp = mslp_from_surface_pressure(sp, t, phis)
+    assert mslp.item() > sp.item()
+    assert torch.isfinite(mslp).all()
+
+
+def test_batch_broadcast():
+    """Accepts (B, T, H, W) inputs and returns same shape."""
+    B, T, H, W = 4, 2, 8, 16
+    sp = torch.rand(B, T, H, W) * 20000 + 85000
+    t = torch.rand(B, T, H, W) * 40 + 260
+    phis = torch.rand(B, T, H, W) * 2000 * GRAVITY
+    mslp = mslp_from_surface_pressure(sp, t, phis)
+    assert mslp.shape == (B, T, H, W)
+    assert torch.isfinite(mslp).all()
+
+
+def test_no_nan_on_zero_geopotential_grid():
+    """All-zero geopotential (ocean grid) should give MSLP == SP everywhere."""
+    B, H, W = 2, 32, 64
+    sp = torch.rand(B, H, W) * 5000 + 98000
+    t = torch.rand(B, H, W) * 40 + 260
+    phis = torch.zeros(B, H, W)
+    mslp = mslp_from_surface_pressure(sp, t, phis)
+    assert torch.allclose(mslp, sp, rtol=1e-5)
+    assert torch.isfinite(mslp).all()
+
+
+def test_tto_uses_height_not_raw_geopotential():
+    """
+    Regression: the sea-level temperature branch test must use height (sgp/g),
+    not raw geopotential.  At low elevation the two differ by a factor of ~9.8;
+    using raw geopotential would trigger the alpha-modified branch at far too low
+    an elevation.
+
+    We pick T=288 K and height=100 m so tto = 288 + 0.0065*100 = 288.65 K < 290.5.
+    With the bug (tto = T + lapse*sgp = 288 + 0.0065*100*9.8 ≈ 294.4 K > 290.5),
+    the wrong alpha branch fires.
+    """
+    sp = _scalar(101325.0)
+    t = _scalar(288.0)
+    height = 100.0  # metres → tto = 288.65 K → default branch
+    phis = _scalar(height * GRAVITY)
+
+    # tto with correct formula
+    tto_correct = 288.0 + _LAPSE_RATE * height  # 288.65 < 290.5 → default branch
+    assert tto_correct <= 290.5, "test setup: should stay in default branch"
+
+    mslp = mslp_from_surface_pressure(sp, t, phis)
+    # in the default branch alpha = LAPSE_RATE*Rd/g
+    alpha = _LAPSE_RATE * RDGAS / GRAVITY
+    x = (height * GRAVITY) / (RDGAS * 288.0)
+    import math
+
+    expected = sp.item() * math.exp(x * (1.0 - 0.5 * alpha * x + (alpha * x) ** 2 / 3.0))
+    assert abs(mslp.item() - expected) < 1.0, (
+        f"MSLP {mslp.item():.2f} Pa vs expected {expected:.2f} Pa — possible tto units bug"
+    )
+
+
+# ---------------------------------------------------------------------------
+# MSLPDiagnostic — integration / shape tests
+# ---------------------------------------------------------------------------
+
+SRC = "ARCO_ERA5"
+SP_VAR = f"{SRC}/prognostic/2d/surface_pressure"
+T2M_VAR = f"{SRC}/prognostic/2d/2m_temperature"
+PHIS_VAR = f"{SRC}/static/2d/geopotential_at_surface"
+OUTPUT_VAR = f"{SRC}/derived_diagnostic/2d/mean_sea_level_pressure"
+
+
+def _make_batch(B=2, n_time=1, H=8, W=16):
+    """Build a minimal prediction dict as if Reconstruct has already run."""
+    sp = torch.full((B, 1, n_time, H, W), 101_000.0)
+    t2m = torch.full((B, 1, n_time, H, W), 285.0)
+    phis = torch.full((B, 1, 1, H, W), 9_810.0)  # ~1000 m elevation
+    return {
+        "prediction": {
+            SRC: {
+                SP_VAR: sp,
+                T2M_VAR: t2m,
+                PHIS_VAR: phis,
+            }
+        }
+    }
+
+
+def test_mslp_diagnostic_output_shape():
+    """Output tensor has shape (B, 1, n_time, H, W)."""
+    B, n_time, H, W = 2, 1, 8, 16
+    batch = _make_batch(B, n_time, H, W)
+    mod = MSLPDiagnostic(data_keys=["prediction"])
+    out = mod(batch)
+    assert OUTPUT_VAR in out["prediction"][SRC]
+    assert out["prediction"][SRC][OUTPUT_VAR].shape == (B, 1, n_time, H, W)
+
+
+def test_mslp_diagnostic_greater_than_sp():
+    """MSLP > SP when surface is above sea level."""
+    batch = _make_batch()
+    mod = MSLPDiagnostic(data_keys=["prediction"])
+    out = mod(batch)
+    result = out["prediction"][SRC][OUTPUT_VAR]
+    sp = batch["prediction"][SRC][SP_VAR]
+    assert (result > sp).all()
+
+
+def test_mslp_diagnostic_finite():
+    """No NaN or Inf for physically plausible random inputs."""
+    B, n_time, H, W = 3, 2, 16, 32
+    sp = torch.rand(B, 1, n_time, H, W) * 20_000 + 85_000
+    t2m = torch.rand(B, 1, n_time, H, W) * 40 + 255
+    phis = torch.rand(B, 1, 1, H, W) * 2_000 * GRAVITY
+    batch = {"prediction": {SRC: {SP_VAR: sp, T2M_VAR: t2m, PHIS_VAR: phis}}}
+    mod = MSLPDiagnostic(data_keys=["prediction"])
+    out = mod(batch)
+    assert torch.isfinite(out["prediction"][SRC][OUTPUT_VAR]).all()
+
+
+def test_mslp_diagnostic_sea_level_identity():
+    """At zero geopotential (ocean), MSLP equals SP exactly."""
+    B, H, W = 2, 8, 16
+    sp = torch.rand(B, 1, 1, H, W) * 5_000 + 98_000
+    t2m = torch.rand(B, 1, 1, H, W) * 30 + 265
+    phis = torch.zeros(B, 1, 1, H, W)
+    batch = {"prediction": {SRC: {SP_VAR: sp, T2M_VAR: t2m, PHIS_VAR: phis}}}
+    mod = MSLPDiagnostic(data_keys=["prediction"])
+    out = mod(batch)
+    assert torch.allclose(out["prediction"][SRC][OUTPUT_VAR], sp, rtol=1e-5)
+
+
+def test_mslp_diagnostic_missing_key_raises():
+    """Requesting a data_key absent from batch_dict raises ValueError."""
+    batch = _make_batch()
+    mod = MSLPDiagnostic(data_keys=["prediction", "target"])
+    with pytest.raises(ValueError, match="target"):
+        mod(batch)
+
+
+def test_mslp_diagnostic_processes_multiple_keys():
+    """Both 'prediction' and 'target' get the output written."""
+    batch = _make_batch()
+    batch["target"] = {SRC: dict(batch["prediction"][SRC])}
+    mod = MSLPDiagnostic(data_keys=["prediction", "target"])
+    out = mod(batch)
+    assert OUTPUT_VAR in out["prediction"][SRC]
+    assert OUTPUT_VAR in out["target"][SRC]
+
+
+def test_mslp_diagnostic_phis_broadcasts_over_time():
+    """Static PHIS with n_time=1 broadcasts correctly over n_time > 1."""
+    B, n_time, H, W = 2, 4, 8, 16
+    sp = torch.full((B, 1, n_time, H, W), 90_000.0)
+    t2m = torch.full((B, 1, n_time, H, W), 270.0)
+    phis = torch.full((B, 1, 1, H, W), 5_000.0 * GRAVITY)  # static, n_time=1
+    batch = {"prediction": {SRC: {SP_VAR: sp, T2M_VAR: t2m, PHIS_VAR: phis}}}
+    mod = MSLPDiagnostic(data_keys=["prediction"])
+    out = mod(batch)
+    result = out["prediction"][SRC][OUTPUT_VAR]
+    assert result.shape == (B, 1, n_time, H, W)
+    assert torch.isfinite(result).all()


### PR DESCRIPTION
## Summary

- Adds `credit/postblock/mslp.py` with `mslp_from_surface_pressure()` — a fully vectorized PyTorch implementation of the Trenberth et al. (1993) formula. No numpy, no per-pixel loops.
- Adds `MSLPDiagnostic(nn.Module)` following the V2 data-dict postblock protocol: named variable-name constructor params, `forward(data_dict)` with nested dict access, no channel indices, no denormalization. Registered in `POSTBLOCK_REGISTRY` as `"mslp_diagnostic"`.
- 16 tests in `tests/test_mslp_postblock.py` covering all three Trenberth 1993 branches, batch broadcasting, the near-flat ocean case, and a regression test for the `tto` units bug fixed in #341.

## Physics

Three lapse-rate regimes from Trenberth et al. (1993):

1. **near-flat** (`|height| < 1e-4 m`): MSLP = SP
2. **cold surface / warm sea level** (`T ≤ 290.5 K`, `T_sl > 290.5 K`): `α = Rd·(290.5−T)/Φ`
3. **warm surface** (`T > 290.5 K`): `α = 0`, `T_eff = ½(290.5 + T)`
4. **very cold surface** (`T < 255 K`): `α = Γ·Rd/g`, `T_eff = ½(255 + T)`
5. **default**: `α = Γ·Rd/g`, `T_eff = T`

Spot-checked: Denver (~1600 m, SP=840 hPa) → 1015.7 hPa; sea level → 1013.25 hPa exactly.

## Config

```yaml
postblocks:
  mslp:
    type: mslp_diagnostic
    args:
      surface_pressure_var: "ARCO_ERA5/prognostic/2d/surface_pressure"
      temperature_var: "ARCO_ERA5/prognostic/2d/2m_temperature"
      surface_geopotential_var: "ARCO_ERA5/static/2d/geopotential_at_surface"
      output_name: "ARCO_ERA5/derived_diagnostic/2d/mean_sea_level_pressure"
```

## Test plan

- [x] `pytest tests/test_mslp_postblock.py -v` — 16 tests, all pass
- [x] CI passing on Python 3.11 / 3.12 / 3.13
- [x] Physics verified against ISA reference values (1013–1070 hPa over 0–4000 m terrain)