### PR TITLE
Added registry and ability to add custom models from outside of CREDIT.

### DIFF
--- a/config/example-v2026.2.yml
+++ b/config/example-v2026.2.yml
@@ -15,6 +15,14 @@
 save_loc: '/glade/derecho/scratch/$USER/CREDIT_runs/starter_gen2'
 seed: 1000
 
+# ---- Optional: register custom model classes ---- #
+# List Python files that define @register_model-decorated classes.
+# Each file is imported before load_model runs, making its model types
+# available as any built-in type.  $USER / $WORK env vars are expanded.
+#
+# custom_models:
+#   - '/path/to/my_experiment/models.py'
+
 
 # ---- USER SETTINGS: training data ---- #
 # Dates follow ISO 8601: "YYYY-MM-DD". The default below uses 1979–2018 for training.

--- a/credit/models/__init__.py
+++ b/credit/models/__init__.py
@@ -2,74 +2,145 @@ import os
 import sys
 import copy
 import logging
-
-# Import model classes
-from credit.models.crossformer import CrossFormer
-from credit.models.camulator import Camulator
-from credit.models.unet import SegmentationModel
-from credit.models.fuxi import Fuxi
-from credit.models.swin import SwinTransformerV2Cr
-
-try:
-    from credit.models.graph import GraphResTransfGRU
-except ImportError:
-    GraphResTransfGRU = None
-from credit.models.debugger_model import DebuggerModel
-from credit.models.wxformer.crossformer import CrossFormer as WXFormer
-from credit.models.wxformer.crossformer_ensemble import CrossFormerWithNoise
-from credit.models.wxformer.crossformer_downscaling import DownscalingCrossFormer
-from credit.models.unet_downscaling import DownscalingSegmentationModel
-from credit.models.wxformer.crossformer_diffusion import CrossFormerDiffusion
-from credit.models.unet_diffusion import UnetDiffusion
-from credit.diffusion import ModifiedGaussianDiffusion
-from credit.models.swin_wrf import WRFTransformer
-from credit.models.dscale_wrf import DscaleTransformer
-
+import importlib
 
 logger = logging.getLogger(__name__)
 
-# Define model types and their corresponding classes
-model_types = {
+# Registry entries are either:
+#   (module_path: str, class_name: str, log_message: str)  — internal lazy entries
+#   (cls: type,        log_message: str)                   — externally registered classes
+_MODEL_REGISTRY = {
     "crossformer": (
-        CrossFormer,
+        "credit.models.crossformer",
+        "CrossFormer",
         "Loading the CrossFormer model with a conv decoder head and skip connections ...",
     ),
     "camulator": (
-        Camulator,
+        "credit.models.camulator",
+        "Camulator",
         "Loading the CAMulator model with a conv decoder head and skip connections ...",
     ),
     "crossformer-diffusion": (
-        CrossFormerDiffusion,
+        "credit.models.wxformer.crossformer_diffusion",
+        "CrossFormerDiffusion",
         "Loading A DDPM model with CrossFormer Backbone ...",
     ),
     "unet-diffusion": (
-        UnetDiffusion,
+        "credit.models.unet_diffusion",
+        "UnetDiffusion",
         "Loading A DDPM model with UNET Backbone ...",
     ),
-    "wxformer": (WXFormer, "Loading the WXFormer deterministic model ..."),
+    "wxformer": (
+        "credit.models.wxformer.crossformer",
+        "CrossFormer",
+        "Loading the WXFormer deterministic model ...",
+    ),
     "crossformer-ensemble": (
-        CrossFormerWithNoise,
+        "credit.models.wxformer.crossformer_ensemble",
+        "CrossFormerWithNoise",
         "Loading the ensemble CrossFormer model with a noise injection scheme ...",
     ),
     "crossformer-style": (
-        CrossFormerWithNoise,
+        "credit.models.wxformer.crossformer_ensemble",
+        "CrossFormerWithNoise",
         "Loading the ensemble CrossFormer model with a Style-GAN-like noise injection scheme ...",
     ),
-    "unet": (SegmentationModel, "Loading a unet model"),
-    "fuxi": (Fuxi, "Loading Fuxi model"),
-    "swin": (SwinTransformerV2Cr, "Loading the minimal Swin model"),
-    "graph": (GraphResTransfGRU, "Loading Graph Residual Transformer GRU model")
-    if GraphResTransfGRU is not None
-    else None,
-    "debugger": (DebuggerModel, "Loading the debugger model"),
-    "wrf": (WRFTransformer, "Loading WRF Transformer"),
-    "dscale": (DscaleTransformer, "Loading downscaling Transformer"),
+    "unet": ("credit.models.unet", "SegmentationModel", "Loading a unet model"),
+    "fuxi": ("credit.models.fuxi", "Fuxi", "Loading Fuxi model"),
+    "swin": ("credit.models.swin", "SwinTransformerV2Cr", "Loading the minimal Swin model"),
+    "graph": (
+        "credit.models.graph",
+        "GraphResTransfGRU",
+        "Loading Graph Residual Transformer GRU model",
+    ),
+    "debugger": ("credit.models.debugger_model", "DebuggerModel", "Loading the debugger model"),
+    "wrf": ("credit.models.swin_wrf", "WRFTransformer", "Loading WRF Transformer"),
+    "dscale": ("credit.models.dscale_wrf", "DscaleTransformer", "Loading downscaling Transformer"),
     "crossformer_downscaling": (
-        DownscalingCrossFormer,
+        "credit.models.wxformer.crossformer_downscaling",
+        "DownscalingCrossFormer",
         "Loading downscaling crossformer model",
     ),
-    "unet_downscaling": (DownscalingSegmentationModel, "Loading downscaling U-net"),
+    "unet_downscaling": (
+        "credit.models.unet_downscaling",
+        "DownscalingSegmentationModel",
+        "Loading downscaling U-net",
+    ),
 }
+
+# Backward-compatible name -> (module_path, class_name) for direct attribute access
+_CLASS_SOURCES = {
+    "CrossFormer": ("credit.models.crossformer", "CrossFormer"),
+    "Camulator": ("credit.models.camulator", "Camulator"),
+    "SegmentationModel": ("credit.models.unet", "SegmentationModel"),
+    "Fuxi": ("credit.models.fuxi", "Fuxi"),
+    "SwinTransformerV2Cr": ("credit.models.swin", "SwinTransformerV2Cr"),
+    "GraphResTransfGRU": ("credit.models.graph", "GraphResTransfGRU"),
+    "DebuggerModel": ("credit.models.debugger_model", "DebuggerModel"),
+    "WXFormer": ("credit.models.wxformer.crossformer", "CrossFormer"),
+    "CrossFormerWithNoise": ("credit.models.wxformer.crossformer_ensemble", "CrossFormerWithNoise"),
+    "DownscalingCrossFormer": ("credit.models.wxformer.crossformer_downscaling", "DownscalingCrossFormer"),
+    "DownscalingSegmentationModel": ("credit.models.unet_downscaling", "DownscalingSegmentationModel"),
+    "CrossFormerDiffusion": ("credit.models.wxformer.crossformer_diffusion", "CrossFormerDiffusion"),
+    "UnetDiffusion": ("credit.models.unet_diffusion", "UnetDiffusion"),
+    "ModifiedGaussianDiffusion": ("credit.diffusion", "ModifiedGaussianDiffusion"),
+    "WRFTransformer": ("credit.models.swin_wrf", "WRFTransformer"),
+    "DscaleTransformer": ("credit.models.dscale_wrf", "DscaleTransformer"),
+}
+
+
+def __getattr__(name):
+    if name in _CLASS_SOURCES:
+        module_path, class_name = _CLASS_SOURCES[name]
+        try:
+            module = importlib.import_module(module_path)
+            return getattr(module, class_name)
+        except ImportError as exc:
+            raise AttributeError(f"Cannot import {name!r}: optional dependencies missing.") from exc
+    raise AttributeError(f"module 'credit.models' has no attribute {name!r}")
+
+
+def register_model(model_type, message=None):
+    """Decorator that adds an external PyTorch model class to the model registry.
+
+    Args:
+        model_type: Key used in the config ``model.type`` field.
+        message: Optional log message shown when the model is loaded.
+
+    Example::
+
+        @register_model("my_model", "Loading my custom model ...")
+        class MyModel(torch.nn.Module):
+            ...
+    """
+
+    def decorator(cls):
+        if model_type in _MODEL_REGISTRY:
+            logger.warning(f"register_model: overwriting existing registry entry for '{model_type}'")
+        _MODEL_REGISTRY[model_type] = (cls, message or f"Loading {model_type} model ...")
+        return cls
+
+    return decorator
+
+
+def _load_model_entry(model_type):
+    """Lazily import and return (model_class, log_message) for a registered model type."""
+    if model_type not in _MODEL_REGISTRY:
+        return None
+    entry = _MODEL_REGISTRY[model_type]
+    # External registration stores the class directly as the first element.
+    if not isinstance(entry[0], str):
+        cls, message = entry
+        return cls, message
+    module_path, class_name, message = entry
+    try:
+        module = importlib.import_module(module_path)
+        cls = getattr(module, class_name)
+        return cls, message
+    except ImportError as exc:
+        raise ImportError(
+            f"Model type '{model_type}' requires optional dependencies that are not installed. Original error: {exc}"
+        ) from exc
 
 
 # Define FSDP sharding and/or checkpointing policy
@@ -164,7 +235,7 @@ def load_model(conf, load_weights=False, model_name=False):
     if model_type in ("unet", "unet404"):
         import torch
 
-        model, message = model_types[model_type]
+        model, message = _load_model_entry(model_type)
         logger.info(message)
         if load_weights:
             model = model(**model_conf)
@@ -192,8 +263,10 @@ def load_model(conf, load_weights=False, model_name=False):
 
         return model(**model_conf)
 
-    elif model_type == "crossformer-diffusion":
-        model, message = model_types[model_type]
+    elif model_type in ("crossformer-diffusion", "unet-diffusion"):
+        from credit.diffusion import ModifiedGaussianDiffusion
+
+        model, message = _load_model_entry(model_type)
         logger.info(message)
         diffusion_config = conf.get("model", {}).get("diffusion")
         if diffusion_config is not None:
@@ -215,36 +288,8 @@ def load_model(conf, load_weights=False, model_name=False):
             **diffusion_config,
         )
 
-    elif model_type == "unet-diffusion":
-        model, message = model_types[model_type]
-        logger.info(message)
-        diffusion_config = conf.get("model", {}).get("diffusion")
-        if diffusion_config is not None:
-            diffusion_config = diffusion_config.copy()
-            self_condition = diffusion_config.pop("self_condition", False)
-            condition = diffusion_config.pop("condition", True)
-        else:
-            logger.warning("The diffusion details were not specified as model:diffusion, exiting")
-            sys.exit(0)
-
-        if load_weights:
-            if model_name:
-                return model.load_model_name(conf, model_name=model_name)
-            else:
-                return model.load_model(conf)
-
-        return ModifiedGaussianDiffusion(
-            model(**model_conf, self_condition=self_condition, condition=condition),
-            **diffusion_config,
-        )
-    elif model_type in model_types:
-        entry = model_types[model_type]
-        if entry is None:
-            raise ImportError(
-                f"Model type '{model_type}' requires optional dependencies that are not installed. "
-                f"Install torch_geometric and fsspec to use this model."
-            )
-        model, message = entry
+    elif model_type in _MODEL_REGISTRY:
+        model, message = _load_model_entry(model_type)
         logger.info(message)
         if load_weights:
             if model_name:
@@ -252,6 +297,7 @@ def load_model(conf, load_weights=False, model_name=False):
             else:
                 return model.load_model(conf)
         return model(**model_conf)
+
     else:
         msg = f"Model type {model_type} not supported. Exiting."
         logger.warning(msg)
@@ -272,7 +318,7 @@ def load_model_name(conf, model_name, load_weights=False):
     if model_type in ("unet", "unet404"):
         import torch
 
-        model, message = model_types[model_type]
+        model, message = _load_model_entry(model_type)
         logger.info(message)
         if load_weights:
             model = model(**model_conf)
@@ -290,8 +336,8 @@ def load_model_name(conf, model_name, load_weights=False):
 
         return model(**model_conf)
 
-    if model_type in model_types:
-        model, message = model_types[model_type]
+    if model_type in _MODEL_REGISTRY:
+        model, message = _load_model_entry(model_type)
         logger.info(message)
         if load_weights:
             return model.load_model_name(conf, model_name)

--- a/credit/models/__init__.py
+++ b/credit/models/__init__.py
@@ -220,9 +220,32 @@ def load_fsdp_or_checkpoint_policy(conf):
     return transformer_layers_cls
 
 
+def load_custom_model_modules(conf):
+    """Import every file listed under ``custom_models`` in the config.
+
+    Each file is executed as a standalone module.  The expected use-case is
+    that each file contains one or more classes decorated with
+    ``@register_model``, so the import triggers registration as a side-effect.
+
+    Args:
+        conf (dict): Top-level config dict.  If ``custom_models`` is absent or
+            empty this function is a no-op.
+
+    Raises:
+        FileNotFoundError: If a listed path does not exist on disk.
+    """
+    for raw_path in conf.get("custom_models", []):
+        path = os.path.expandvars(raw_path)
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"custom_models: file not found: {path!r}")
+        spec = importlib.util.spec_from_file_location("_credit_custom_model", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+
 def load_model(conf, load_weights=False, model_name=False):
     conf = copy.deepcopy(conf)
-
+    load_custom_model_modules(conf)
     model_conf = conf["model"]
 
     if "type" not in model_conf:

--- a/credit/parser.py
+++ b/credit/parser.py
@@ -11,7 +11,6 @@ Content:
 import os
 import copy
 import inspect
-import importlib.util
 import warnings
 from glob import glob
 from collections import Counter
@@ -21,30 +20,9 @@ from credit.datasets.downscaling_dataset import DownscalingDataset
 
 # from credit.datasets.datamap import DataMap
 from credit.datasets.count_channels import count_channels
+
 # from credit.transforms_downscaling import DataTransforms
-
-
-def load_custom_model_modules(conf):
-    """Import every file listed under ``custom_models`` in the config.
-
-    Each file is executed as a standalone module.  The expected use-case is
-    that each file contains one or more classes decorated with
-    ``@register_model``, so the import triggers registration as a side-effect.
-
-    Args:
-        conf (dict): Top-level config dict.  If ``custom_models`` is absent or
-            empty this function is a no-op.
-
-    Raises:
-        FileNotFoundError: If a listed path does not exist on disk.
-    """
-    for raw_path in conf.get("custom_models", []):
-        path = os.path.expandvars(raw_path)
-        if not os.path.isfile(path):
-            raise FileNotFoundError(f"custom_models: file not found: {path!r}")
-        spec = importlib.util.spec_from_file_location("_credit_custom_model", path)
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
+from credit.models import load_custom_model_modules
 
 
 def validate_args(function, argdict, context, ignore=[]):

--- a/credit/parser.py
+++ b/credit/parser.py
@@ -11,6 +11,7 @@ Content:
 import os
 import copy
 import inspect
+import importlib.util
 import warnings
 from glob import glob
 from collections import Counter
@@ -21,6 +22,29 @@ from credit.datasets.downscaling_dataset import DownscalingDataset
 # from credit.datasets.datamap import DataMap
 from credit.datasets.count_channels import count_channels
 # from credit.transforms_downscaling import DataTransforms
+
+
+def load_custom_model_modules(conf):
+    """Import every file listed under ``custom_models`` in the config.
+
+    Each file is executed as a standalone module.  The expected use-case is
+    that each file contains one or more classes decorated with
+    ``@register_model``, so the import triggers registration as a side-effect.
+
+    Args:
+        conf (dict): Top-level config dict.  If ``custom_models`` is absent or
+            empty this function is a no-op.
+
+    Raises:
+        FileNotFoundError: If a listed path does not exist on disk.
+    """
+    for raw_path in conf.get("custom_models", []):
+        path = os.path.expandvars(raw_path)
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"custom_models: file not found: {path!r}")
+        spec = importlib.util.spec_from_file_location("_credit_custom_model", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
 
 
 def validate_args(function, argdict, context, ignore=[]):
@@ -103,6 +127,8 @@ def credit_main_parser(conf, parse_training=True, parse_predict=True, print_summ
         - applications/rollout_to_netcdf.py
 
     """
+
+    load_custom_model_modules(conf)
 
     # many config options don't apply when downscaling to regional
     is_downscaling = "datasets" in conf["data"]

--- a/docs/source/Model_Architectures.md
+++ b/docs/source/Model_Architectures.md
@@ -14,11 +14,15 @@ In your configuration file, you can select from multiple supported models. Below
 
 **WxFormer** is the flagship model developed by the MILES group at NCAR.
 
-It is a hybrid architecture that combines a CrossFormer-based encoder with a hierarchical decoder using transpose convolutional layers. Its structure includes U-Net-like skip connections and a pyramid layout to facilitate multi-scale feature representation.
+It is a hybrid architecture that combines a CrossFormer-based encoder with a hierarchical decoder using transpose 
+convolutional layers. Its structure includes U-Net-like skip connections and a pyramid layout to facilitate multi-scale 
+feature representation.
 
-CrossFormer, the foundation of WxFormer, enables long-range dependency modeling and multi-scale spatial reasoning. This approach has demonstrated comparable performance to other vision transformers like Swin, which forms the backbone of models such as FuXi.
+CrossFormer, the foundation of WxFormer, enables long-range dependency modeling and multi-scale spatial reasoning. 
+This approach has demonstrated comparable performance to other vision transformers like Swin, which forms the backbone of models such as FuXi.
 
-WxFormer is trained to predict the atmospheric state at time step *i+1*, given the state at time *i*, typically with a one-hour time increment.
+WxFormer is trained to predict the atmospheric state at time step *i+1*, given the state at time *i*, typically 
+with a one-hour time increment.
 
 For further architectural details and design motivations, see **Schreck et al., 2024**.
 
@@ -121,14 +125,89 @@ padding_conf:
     pad_lon: 48
 ```
 
-## Graph Transformer 
+---
 
-Arnold to add discussion. 
+## Add Your Own Model to CREDIT
 
-## Unet 
+CREDIT's `register_model` decorator lets you plug any PyTorch model into the factory system without modifying the library. Once registered, your model is indistinguishable from a built-in type: `load_model` will instantiate it, and all trainer, loss, and transform machinery works as normal.
 
-Add Discussion 
+### Basic usage
 
-## WxFormer Diffusion 
+Define your model class and apply `@register_model` with the type key you want to use in config files:
 
-Will to add discussion. 
+```python
+import torch.nn as nn
+from credit.models import register_model
+
+@register_model("my_model", "Loading my custom model ...")
+class MyModel(nn.Module):
+    def __init__(self, in_channels: int, hidden_dim: int = 256):
+        super().__init__()
+        self.net = nn.Linear(in_channels, hidden_dim)
+
+    def forward(self, x):
+        return self.net(x)
+```
+
+The first argument to `register_model` becomes the value you set for `model.type` in your YAML config. The second argument is an optional log message shown when the model is loaded. If omitted, a default message is generated from the type key.
+
+### Matching the config signature
+
+Constructor keyword arguments are taken directly from the `model:` block in your config, so your `__init__` signature should match the keys you put there:
+
+```yaml
+model:
+  type: "my_model"
+  in_channels: 128
+  hidden_dim: 512
+```
+
+### Registering via the config file
+
+The recommended way to use a custom model with the CREDIT CLI is to add a `custom_models` list at the top level of your config file. Each entry is a path to a Python file containing `@register_model`-decorated classes. CREDIT imports these files before `load_model` runs, so the type becomes available just like any built-in.
+
+```yaml
+# ---- Optional: register custom model classes ---- #
+custom_models:
+  - '/path/to/my_experiment/models.py'
+
+save_loc: '/glade/derecho/scratch/$USER/CREDIT_runs/my_run'
+
+model:
+  type: "my_model"
+  in_channels: 128
+  hidden_dim: 512
+  ...
+```
+
+Environment variables (e.g. `$WORK`, `$USER`) in the paths are expanded automatically. You can list multiple files if your experiment registers more than one custom type:
+
+```yaml
+custom_models:
+  - '/path/to/my_experiment/backbone.py'
+  - '/path/to/my_experiment/head.py'
+```
+
+### Registering via a Python import (alternative)
+
+If you are calling `load_model` directly from your own script rather than using the CLI, you can register the model by importing the module that defines it before calling `load_model`:
+
+```python
+# my_experiment/train.py
+import yaml
+import my_experiment.models  # registers MyModel as a side-effect
+from credit.models import load_model
+
+with open("config.yml") as f:
+    conf = yaml.safe_load(f)
+
+model = load_model(conf)  # dispatches to MyModel
+```
+
+### Overwriting a built-in type
+
+If you pass a `model_type` key that already exists in the registry (e.g. `"fuxi"`), a warning is logged and your class replaces the built-in. This is useful for swapping in a modified version of an existing architecture during experimentation without changing library code.
+
+### Exposing `load_model` and `load_model_name` on your class
+
+Built-in models support `load_weights=True` in `load_model` via class-level `load_model` / `load_model_name` methods. If you need checkpoint loading through the same factory call, add those methods to your class following the same convention used in `credit/models/fuxi.py`.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,10 +2,12 @@
 
 import os
 import yaml
+import pytest
 
 import torch
 
-from credit.models import load_model
+from credit.models import load_model, register_model
+from credit.parser import load_custom_model_modules
 from credit.models.unet import SegmentationModel
 from credit.models.wxformer.crossformer import CrossFormer
 from credit.models.fuxi import Fuxi
@@ -136,6 +138,73 @@ def test_fuxi():
     y_pred = model(input_tensor)
     assert y_pred.shape == torch.Size([1, out_channels, 1, image_height, image_width])
     assert not torch.isnan(y_pred).any()
+
+
+def test_register_model():
+    """Test that register_model decorator adds a custom model to the registry."""
+
+    @register_model("test_custom_model", "Loading test custom model ...")
+    class CustomModel(torch.nn.Module):
+        def __init__(self, hidden_dim=32):
+            super().__init__()
+            self.fc = torch.nn.Linear(hidden_dim, hidden_dim)
+
+        def forward(self, x):
+            return self.fc(x)
+
+    conf = {"model": {"type": "test_custom_model", "hidden_dim": 16}, "save_loc": "/tmp"}
+    model = load_model(conf)
+
+    assert isinstance(model, CustomModel)
+    assert model.fc.in_features == 16
+
+
+def test_load_custom_model_modules(tmp_path):
+    """Test that load_custom_model_modules imports a file and registers its model."""
+    module_file = tmp_path / "custom_models.py"
+    module_file.write_text(
+        "import torch.nn as nn\n"
+        "from credit.models import register_model\n"
+        "\n"
+        "@register_model('file_registered_model')\n"
+        "class FileRegisteredModel(nn.Module):\n"
+        "    def __init__(self, size=8):\n"
+        "        super().__init__()\n"
+        "        self.fc = nn.Linear(size, size)\n"
+    )
+
+    load_custom_model_modules({"custom_models": [str(module_file)]})
+
+    conf = {"model": {"type": "file_registered_model", "size": 4}, "save_loc": "/tmp"}
+    model = load_model(conf)
+    assert model.fc.in_features == 4
+
+
+def test_load_custom_model_modules_missing_file():
+    """Test that a missing path raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError, match="custom_models"):
+        load_custom_model_modules({"custom_models": ["/nonexistent/path/models.py"]})
+
+
+def test_register_model_overwrite(caplog):
+    """Test that registering a duplicate key logs a warning and overwrites."""
+    import logging
+
+    @register_model("test_overwrite_model")
+    class ModelV1(torch.nn.Module):
+        pass
+
+    with caplog.at_level(logging.WARNING, logger="credit.models"):
+
+        @register_model("test_overwrite_model")
+        class ModelV2(torch.nn.Module):
+            pass
+
+    assert any("test_overwrite_model" in msg for msg in caplog.messages)
+
+    conf = {"model": {"type": "test_overwrite_model"}, "save_loc": "/tmp"}
+    model = load_model(conf)
+    assert isinstance(model, ModelV2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Note: The pull request (PR) title will be included in the release notes. -->

### Description
<!-- Provide a standalone description of changes in this PR. -->
I have refactored the credit.models init to create a model registry dictionary that lazily imports models when they are needed rather than importing all models any time credit.models is imported. This will significantly speed up the initialization of all credit applications and make it easier to add more models in the future.

I have also added a register_model function that will allow users to either decorate pytorch model classes  to add them to the registry or they can add the path to the module in their credit config file under a new `custom_models` section. This change will allow us to move toward users using credit more as an importable library rather than editing code themselves.

### Related Issues and PRs
<!-- Reference any related issues using the appropriate keyword and issue number as
described in the GitHub documentation: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword. -->
<!-- For example, "Closes #315" -->
<!-- You may also reference any related PRs or discussions using the syntax shown here:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests. -->

None.

### Checklist
- [x] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date.
