### PR TITLE
Change preblock output structure

### DIFF
--- a/applications/rollout_realtime_gen2.py
+++ b/applications/rollout_realtime_gen2.py
@@ -337,8 +337,7 @@ def run_forecast(conf, init_time: pd.Timestamp, n_steps: int, save_dir: str, poo
     # ---- Load full initial state ----
     sample_full = dataset[(init_time, 0)]
     batch_full = _sample_to_batch(sample_full)
-    x, _ = apply_preblocks(preblocks, batch_full)
-    x = x.to(device).float()  # (1, C_in, 1, H, W)
+    x = apply_preblocks(preblocks, batch_full)["input"].to(device).float()  # (1, C_in, 1, H, W)
 
     results = []
     x_init = None
@@ -374,8 +373,7 @@ def run_forecast(conf, init_time: pd.Timestamp, n_steps: int, save_dir: str, poo
                 t_next = init_time + step * dt
                 sample_frc = dataset[(t_next, 1)]  # only dynamic_forcing
                 batch_frc = _sample_to_batch(sample_frc)
-                x_frc, _ = apply_preblocks(preblocks, batch_frc)
-                x_frc = x_frc.to(device).float()
+                x_frc = apply_preblocks(preblocks, batch_frc)["input"].to(device).float()
 
                 # ERA5Dataset insertion order: [dynfrc | static | prog]
                 x[:, :n_dyn, ...] = x_frc

--- a/applications/rollout_realtime_gen2.py
+++ b/applications/rollout_realtime_gen2.py
@@ -337,7 +337,7 @@ def run_forecast(conf, init_time: pd.Timestamp, n_steps: int, save_dir: str, poo
     # ---- Load full initial state ----
     sample_full = dataset[(init_time, 0)]
     batch_full = _sample_to_batch(sample_full)
-    x = apply_preblocks(preblocks, batch_full)["input"].to(device).float()  # (1, C_in, 1, H, W)
+    x = apply_preblocks(preblocks, batch_full, device=device)["input"].float()  # (1, C_in, 1, H, W)
 
     results = []
     x_init = None
@@ -373,7 +373,7 @@ def run_forecast(conf, init_time: pd.Timestamp, n_steps: int, save_dir: str, poo
                 t_next = init_time + step * dt
                 sample_frc = dataset[(t_next, 1)]  # only dynamic_forcing
                 batch_frc = _sample_to_batch(sample_frc)
-                x_frc = apply_preblocks(preblocks, batch_frc)["input"].to(device).float()
+                x_frc = apply_preblocks(preblocks, batch_frc, device=device)["input"].float()
 
                 # ERA5Dataset insertion order: [dynfrc | static | prog]
                 x[:, :n_dyn, ...] = x_frc

--- a/applications/rollout_to_netcdf_gen2.py
+++ b/applications/rollout_to_netcdf_gen2.py
@@ -280,7 +280,7 @@ def predict(rank, world_size, conf, p):
             # Step 0: load full initial state
             sample_full = dataset[(t0, 0)]
             batch_full = _sample_to_batch(sample_full)
-            x = apply_preblocks(preblocks, batch_full)["input"].to(device).float()  # (1, C_in, 1, H, W)
+            x = apply_preblocks(preblocks, batch_full, device=device)["input"].float()  # (1, C_in, 1, H, W)
 
             x_init = None
             results = []
@@ -320,7 +320,7 @@ def predict(rank, world_size, conf, p):
                     t_next = t0 + step * dt
                     sample_frc = dataset[(t_next, 1)]  # loads only dynamic_forcing
                     batch_frc = _sample_to_batch(sample_frc)
-                    x_frc = apply_preblocks(preblocks, batch_frc)["input"].to(device).float()  # (1, n_dyn, 1, H, W)
+                    x_frc = apply_preblocks(preblocks, batch_frc, device=device)["input"].float()  # (1, n_dyn, 1, H, W)
 
                     # ERA5Dataset insertion order: [dynfrc | static | prog]
                     x[:, :n_dyn, ...] = x_frc  # update dynamic forcing

--- a/applications/rollout_to_netcdf_gen2.py
+++ b/applications/rollout_to_netcdf_gen2.py
@@ -280,8 +280,7 @@ def predict(rank, world_size, conf, p):
             # Step 0: load full initial state
             sample_full = dataset[(t0, 0)]
             batch_full = _sample_to_batch(sample_full)
-            x, _ = apply_preblocks(preblocks, batch_full)
-            x = x.to(device).float()  # (1, C_in, 1, H, W)
+            x = apply_preblocks(preblocks, batch_full)["input"].to(device).float()  # (1, C_in, 1, H, W)
 
             x_init = None
             results = []
@@ -321,8 +320,7 @@ def predict(rank, world_size, conf, p):
                     t_next = t0 + step * dt
                     sample_frc = dataset[(t_next, 1)]  # loads only dynamic_forcing
                     batch_frc = _sample_to_batch(sample_frc)
-                    x_frc, _ = apply_preblocks(preblocks, batch_frc)
-                    x_frc = x_frc.to(device).float()  # (1, n_dyn, 1, H, W)
+                    x_frc = apply_preblocks(preblocks, batch_frc)["input"].to(device).float()  # (1, n_dyn, 1, H, W)
 
                     # ERA5Dataset insertion order: [dynfrc | static | prog]
                     x[:, :n_dyn, ...] = x_frc  # update dynamic forcing

--- a/credit/cli/_plot.py
+++ b/credit/cli/_plot.py
@@ -150,8 +150,8 @@ def _plot(args) -> None:
     sample = dataset[(ts, 0)]
     batch = default_collate([sample])
     preblocks = build_preblocks(conf.get("preblocks", {}))
-    _batch = apply_preblocks(preblocks, batch)
-    x, y, meta = _batch["input"].to(device), _batch["target"].to(device), _batch["meta"]
+    _batch = apply_preblocks(preblocks, batch, device=device)
+    x, y, meta = _batch["input"], _batch["target"], _batch["meta"]
     with torch.no_grad():
         y_pred = model(x)
 

--- a/credit/cli/_plot.py
+++ b/credit/cli/_plot.py
@@ -150,9 +150,8 @@ def _plot(args) -> None:
     sample = dataset[(ts, 0)]
     batch = default_collate([sample])
     preblocks = build_preblocks(conf.get("preblocks", {}))
-    x, y, _ = apply_preblocks(preblocks, batch)
-    x = x.to(device)
-
+    _batch = apply_preblocks(preblocks, batch)
+    x, y, meta = _batch["input"].to(device), _batch["target"].to(device), _batch["meta"]
     with torch.no_grad():
         y_pred = model(x)
 

--- a/credit/cli/_plot.py
+++ b/credit/cli/_plot.py
@@ -151,7 +151,11 @@ def _plot(args) -> None:
     batch = default_collate([sample])
     preblocks = build_preblocks(conf.get("preblocks", {}))
     _batch = apply_preblocks(preblocks, batch, device=device)
-    x, y, meta = _batch["input"], _batch["target"], _batch["meta"]
+    x = _batch["input"]
+    if "target" in _batch:
+        y = _batch["target"]
+    if "meta" in _batch:
+        meta = _batch["meta"]
     with torch.no_grad():
         y_pred = model(x)
 

--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -65,10 +65,18 @@ def apply_postblocks(postblocks: nn.ModuleDict, y_pred: torch.Tensor, metadata: 
         transformed by registered postblocks.
     """
 
-    for postblock in postblocks.values():
-        if isinstance(postblock, Reconstruct):
-            y_pred = postblock(y_pred, metadata)
-        else:
-            y_pred = postblock(y_pred)
-
+    blocks = list(postblocks.values())
+    if not blocks:
+        raise RuntimeError(
+            'No postblocks configured. "postblocks" must be present in the config, '
+            'with "reconstruct" as the first postblock.'
+        )
+    if not isinstance(blocks[0], Reconstruct):
+        raise RuntimeError(
+            '"reconstruct" must be present as the first postblock '
+            "to reconstruct the output tensor into a named variable dict."
+        )
+    y_pred = blocks[0](y_pred, metadata)
+    for postblock in blocks[1:]:
+        y_pred = postblock(y_pred)
     return y_pred

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+import torch
 import torch.nn as nn
 
 from credit.preblock.log import LogTransform
@@ -52,18 +53,22 @@ def build_preblocks(preblock_cfg: dict | None = None) -> nn.ModuleDict:
     )
 
 
-def apply_preblocks(preblocks: nn.ModuleDict, batch: dict):
+def apply_preblocks(preblocks: nn.ModuleDict, batch: dict, device=None):
     """Sequentially applies transform preblocks (dict→dict).
 
-    Returns:
-        (x, target, meta) where target is None if no "target" data_type was present in the batch.
+    Returns a dict with keys:
+        "input"  — concatenated tensor (if concat preblock present) or nested batch dict
+        "meta"   — metadata dict (only present if concat preblock ran)
+        "target" — target tensor (only present if target data was in the batch)
+
+    Tensors in the output are moved to ``device`` unless the concat preblock was
+    configured with ``to_device: false``.
     """
     if not preblocks:
-        raise RuntimeError(
-            'No preblocks configured. "preblocks" must be present in the config, with "concat" as the final preblock.'
-        )
+        raise RuntimeError('No preblocks configured. "preblocks" must be present in the config.')
     meta = None
     target = None
+    to_device = True
     for preblock in preblocks.values():
         result = preblock(batch)
         if isinstance(result, tuple):
@@ -73,11 +78,16 @@ def apply_preblocks(preblocks: nn.ModuleDict, batch: dict):
                 batch, meta = result
         else:
             batch = result
-    if meta is None:
-        raise RuntimeError(
-            'Metadata missing. "concat" must be present as the final preblock to concatenate data and prepare metadata.'
-        )
-    out = {"input": batch, "meta": meta}
+        if hasattr(preblock, "to_device"):
+            to_device = preblock.to_device
+
+    out = {"input": batch}
+    if meta is not None:
+        out["meta"] = meta
     if target is not None:
         out["target"] = target
+
+    if device is not None and to_device:
+        out = {k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in out.items()}
+
     return out

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -53,20 +53,28 @@ def build_preblocks(preblock_cfg: dict | None = None) -> nn.ModuleDict:
 
 
 def apply_preblocks(preblocks: nn.ModuleDict, batch: dict):
-    """Sequentially applies transform preblocks (dict→dict)."""
+    """Sequentially applies transform preblocks (dict→dict).
+
+    Returns:
+        (x, target, meta) where target is None if no "target" data_type was present in the batch.
+    """
     if not preblocks:
         raise RuntimeError(
             'No preblocks configured. "preblocks" must be present in the config, with "concat" as the final preblock.'
         )
     meta = None
+    target = None
     for preblock in preblocks.values():
         result = preblock(batch)
         if isinstance(result, tuple):
-            batch, meta = result
+            if len(result) == 3:
+                batch, target, meta = result
+            else:
+                batch, meta = result
         else:
             batch = result
     if meta is None:
         raise RuntimeError(
             'Metadata missing. "concat" must be present as the final preblock to concatenate data and prepare metadata.'
         )
-    return batch, meta
+    return batch, target, meta

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -54,6 +54,19 @@ def build_preblocks(preblock_cfg: dict | None = None) -> nn.ModuleDict:
 
 def apply_preblocks(preblocks: nn.ModuleDict, batch: dict):
     """Sequentially applies transform preblocks (dict→dict)."""
+    if not preblocks:
+        raise RuntimeError(
+            'No preblocks configured. "preblocks" must be present in the config, with "concat" as the final preblock.'
+        )
+    meta = None
     for preblock in preblocks.values():
-        batch = preblock(batch)
-    return batch
+        result = preblock(batch)
+        if isinstance(result, tuple):
+            batch, meta = result
+        else:
+            batch = result
+    if meta is None:
+        raise RuntimeError(
+            'Metadata missing. "concat" must be present as the final preblock to concatenate data and prepare metadata.'
+        )
+    return batch, meta

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -64,8 +64,6 @@ def apply_preblocks(preblocks: nn.ModuleDict, batch: dict, device=None):
     Tensors in the output are moved to ``device`` unless the concat preblock was
     configured with ``to_device: false``.
     """
-    if not preblocks:
-        raise RuntimeError('No preblocks configured. "preblocks" must be present in the config.')
     meta = None
     target = None
     to_device = True
@@ -78,7 +76,7 @@ def apply_preblocks(preblocks: nn.ModuleDict, batch: dict, device=None):
                 batch, meta = result
         else:
             batch = result
-        if hasattr(preblock, "to_device"):
+        if isinstance(preblock, ConcatToTensor):
             to_device = preblock.to_device
 
     out = {"input": batch}

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -77,4 +77,7 @@ def apply_preblocks(preblocks: nn.ModuleDict, batch: dict):
         raise RuntimeError(
             'Metadata missing. "concat" must be present as the final preblock to concatenate data and prepare metadata.'
         )
-    return batch, target, meta
+    out = {"input": batch, "meta": meta}
+    if target is not None:
+        out["target"] = target
+    return out

--- a/credit/preblock/concat.py
+++ b/credit/preblock/concat.py
@@ -46,8 +46,13 @@ class ConcatToTensor(BasePreblock):
     Example config::
 
         type: "concatenate_to_tensor"
-        args: {}
+        args:
+          to_device: true   # set false to skip .to(device) in apply_preblocks
     """
+
+    def __init__(self, to_device: bool = True):
+        super().__init__()
+        self.to_device = to_device
 
     def forward(self, batch):
         input_tensors = []

--- a/credit/trainers/trainerERA5gen2.py
+++ b/credit/trainers/trainerERA5gen2.py
@@ -171,7 +171,7 @@ class TrainerERA5Gen2(BaseTrainer):
 
             for t in range(1, self.forecast_len + 1):
                 batch = next(dl)
-                _batch = apply_preblocks(self.preblocks, batch)
+                _batch = apply_preblocks(self.preblocks, batch, device=self.device)
                 x_raw, y_raw = _batch["input"], _batch["target"]
                 # ERA5Dataset outputs 5D tensors (B, C, frames, H, W); collapse frames dim
                 if x_raw.dim() == 5:
@@ -179,7 +179,7 @@ class TrainerERA5Gen2(BaseTrainer):
                     y_raw = y_raw.flatten(1, 2)
 
                 if t == 1:
-                    x = x_raw.to(self.device).float()
+                    x = x_raw.float()
                     if self.ensemble_size > 1:
                         x = torch.repeat_interleave(x, self.ensemble_size, 0)
                 else:
@@ -187,7 +187,7 @@ class TrainerERA5Gen2(BaseTrainer):
                     # Build full input: start from previous x, update dynfrc and
                     # prognostic slices; static channels stay unchanged.
                     # ERA5Dataset insertion order: [dynfrc | static | prog]
-                    x_dynfrc = x_raw.to(self.device).float()
+                    x_dynfrc = x_raw.float()
                     if self.ensemble_size > 1:
                         x_dynfrc = torch.repeat_interleave(x_dynfrc, self.ensemble_size, 0)
                     n_dynfrc = x_dynfrc.shape[1]
@@ -229,7 +229,7 @@ class TrainerERA5Gen2(BaseTrainer):
 
                 # backprop on specified timesteps
                 if t in self.backprop_on_timestep:
-                    y = y_raw.to(self.device).float()
+                    y = y_raw.float()
                     if self.flag_clamp:
                         y = torch.clamp(y, min=self.clamp_min, max=self.clamp_max)
 
@@ -339,7 +339,7 @@ class TrainerERA5Gen2(BaseTrainer):
 
                 for t in range(1, self.valid_forecast_len + 1):
                     batch = next(dl)
-                    _batch = apply_preblocks(self.preblocks, batch)
+                    _batch = apply_preblocks(self.preblocks, batch, device=self.device)
                     x_raw, y_raw = _batch["input"], _batch["target"]
                     # ERA5Dataset outputs 5D tensors (B, C, frames, H, W); collapse frames dim
                     if x_raw.dim() == 5:
@@ -347,14 +347,14 @@ class TrainerERA5Gen2(BaseTrainer):
                         y_raw = y_raw.flatten(1, 2)
 
                     if t == 1:
-                        x = x_raw.to(self.device).float()
+                        x = x_raw.float()
                         if self.ensemble_size > 1:
                             x = torch.repeat_interleave(x, self.ensemble_size, 0)
                     else:
                         # At t > 1 ERA5Dataset returns only dynamic_forcing channels.
                         # Build full input: start from previous x, update dynfrc and
                         # prognostic slices; static channels stay unchanged.
-                        x_dynfrc = x_raw.to(self.device).float()
+                        x_dynfrc = x_raw.float()
                         if self.ensemble_size > 1:
                             x_dynfrc = torch.repeat_interleave(x_dynfrc, self.ensemble_size, 0)
                         n_dynfrc = x_dynfrc.shape[1]
@@ -392,7 +392,7 @@ class TrainerERA5Gen2(BaseTrainer):
 
                     # compute loss and metrics only at the final rollout step
                     if t == self.valid_forecast_len:
-                        y = y_raw.to(self.device).float()
+                        y = y_raw.float()
                         if self.flag_clamp:
                             y = torch.clamp(y, min=self.clamp_min, max=self.clamp_max)
 

--- a/credit/trainers/trainerERA5gen2.py
+++ b/credit/trainers/trainerERA5gen2.py
@@ -11,7 +11,6 @@ import optuna
 
 from credit.postblock.gen1 import GlobalMassFixer, GlobalWaterFixer, GlobalEnergyFixer
 from credit.preblock import build_preblocks, apply_preblocks
-from credit.preblock.concat import ConcatToTensor
 from credit.scheduler import update_on_batch
 from credit.trainers.base_trainer import BaseTrainer
 from credit.trainers.utils import accum_log, cycle
@@ -172,7 +171,8 @@ class TrainerERA5Gen2(BaseTrainer):
 
             for t in range(1, self.forecast_len + 1):
                 batch = next(dl)
-                x_raw, y_raw, _ = ConcatToTensor()(apply_preblocks(self.preblocks, batch))
+                _batch = apply_preblocks(self.preblocks, batch)
+                x_raw, y_raw = _batch["input"], _batch["target"]
                 # ERA5Dataset outputs 5D tensors (B, C, frames, H, W); collapse frames dim
                 if x_raw.dim() == 5:
                     x_raw = x_raw.flatten(1, 2)
@@ -339,7 +339,8 @@ class TrainerERA5Gen2(BaseTrainer):
 
                 for t in range(1, self.valid_forecast_len + 1):
                     batch = next(dl)
-                    x_raw, y_raw, _ = ConcatToTensor()(apply_preblocks(self.preblocks, batch))
+                    _batch = apply_preblocks(self.preblocks, batch)
+                    x_raw, y_raw = _batch["input"], _batch["target"]
                     # ERA5Dataset outputs 5D tensors (B, C, frames, H, W); collapse frames dim
                     if x_raw.dim() == 5:
                         x_raw = x_raw.flatten(1, 2)

--- a/tests/test_trainer_components.py
+++ b/tests/test_trainer_components.py
@@ -414,6 +414,7 @@ def _era5_gen2_multistep_conf(forecast_len, tmp_path):
         "mean_path": "/dev/null",
         "std_path": "/dev/null",
     }
+    base["preblocks"] = {"concat": {"type": "concat"}}
     return base
 
 

--- a/tests/test_trainer_components.py
+++ b/tests/test_trainer_components.py
@@ -527,7 +527,6 @@ class TestERA5Gen2MultiStepTraining:
         from unittest.mock import patch
         from credit.trainers.trainerERA5gen2 import TrainerERA5Gen2 as Trainer
         from credit.preblock import apply_preblocks
-        from credit.preblock.concat import ConcatToTensor
 
         B, C, H, W = 1, 4, 4, 4
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
@@ -555,9 +554,9 @@ class TestERA5Gen2MultiStepTraining:
 
         original_apply = apply_preblocks
 
-        def _patched_apply(preblocks, batch):
-            result = original_apply(preblocks, batch)
-            x_raw, _, __ = ConcatToTensor()(result)
+        def _patched_apply(preblocks, batch, device=None):
+            result = original_apply(preblocks, batch, device=device)
+            x_raw = result["input"]
             step[0] += 1
             if step[0] == 1:
                 x_at_step1_out[0] = x_raw.clone()
@@ -626,6 +625,7 @@ class TestERA5Gen2MultiStepTraining:
                 }
             },
         }
+        conf["preblocks"] = {"concat": {"type": "concat"}}
 
         # Model: outputs N_PROG channels, all zeros — makes y_pred easy to check.
         # Multiply by self.w so the output has a grad_fn for backprop.

--- a/tests/test_trainer_components.py
+++ b/tests/test_trainer_components.py
@@ -316,6 +316,7 @@ def _era5_gen2_conf(**overrides):
         "mean_path": "/dev/null",
         "std_path": "/dev/null",
     }
+    base["preblocks"] = {"concat": {"type": "concat"}}
     base.update(overrides)
     return base
 


### PR DESCRIPTION
<!-- Note: The pull request (PR) title will be included in the release notes. -->

### Description
Changes the output structure of `apply_preblocks()` to a single dictionary with keys `input`, `meta`, and `target` (if present) and adjusts all function calls accordingly. Also adds better error handling.

### Checklist
- [ x] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date.
