### PR TITLE
Fix Reconstruct Postblock

### DIFF
--- a/applications/rollout_realtime_gen2.py
+++ b/applications/rollout_realtime_gen2.py
@@ -337,8 +337,7 @@ def run_forecast(conf, init_time: pd.Timestamp, n_steps: int, save_dir: str, poo
     # ---- Load full initial state ----
     sample_full = dataset[(init_time, 0)]
     batch_full = _sample_to_batch(sample_full)
-    x, _ = apply_preblocks(preblocks, batch_full)
-    x = x.to(device).float()  # (1, C_in, 1, H, W)
+    x = apply_preblocks(preblocks, batch_full)["input"].to(device).float()  # (1, C_in, 1, H, W)
 
     results = []
     x_init = None
@@ -374,8 +373,7 @@ def run_forecast(conf, init_time: pd.Timestamp, n_steps: int, save_dir: str, poo
                 t_next = init_time + step * dt
                 sample_frc = dataset[(t_next, 1)]  # only dynamic_forcing
                 batch_frc = _sample_to_batch(sample_frc)
-                x_frc, _ = apply_preblocks(preblocks, batch_frc)
-                x_frc = x_frc.to(device).float()
+                x_frc = apply_preblocks(preblocks, batch_frc)["input"].to(device).float()
 
                 # ERA5Dataset insertion order: [dynfrc | static | prog]
                 x[:, :n_dyn, ...] = x_frc

--- a/applications/rollout_realtime_gen2.py
+++ b/applications/rollout_realtime_gen2.py
@@ -337,7 +337,7 @@ def run_forecast(conf, init_time: pd.Timestamp, n_steps: int, save_dir: str, poo
     # ---- Load full initial state ----
     sample_full = dataset[(init_time, 0)]
     batch_full = _sample_to_batch(sample_full)
-    x = apply_preblocks(preblocks, batch_full)["input"].to(device).float()  # (1, C_in, 1, H, W)
+    x = apply_preblocks(preblocks, batch_full, device=device)["input"].float()  # (1, C_in, 1, H, W)
 
     results = []
     x_init = None
@@ -373,7 +373,7 @@ def run_forecast(conf, init_time: pd.Timestamp, n_steps: int, save_dir: str, poo
                 t_next = init_time + step * dt
                 sample_frc = dataset[(t_next, 1)]  # only dynamic_forcing
                 batch_frc = _sample_to_batch(sample_frc)
-                x_frc = apply_preblocks(preblocks, batch_frc)["input"].to(device).float()
+                x_frc = apply_preblocks(preblocks, batch_frc, device=device)["input"].float()
 
                 # ERA5Dataset insertion order: [dynfrc | static | prog]
                 x[:, :n_dyn, ...] = x_frc

--- a/applications/rollout_to_netcdf_gen2.py
+++ b/applications/rollout_to_netcdf_gen2.py
@@ -280,7 +280,7 @@ def predict(rank, world_size, conf, p):
             # Step 0: load full initial state
             sample_full = dataset[(t0, 0)]
             batch_full = _sample_to_batch(sample_full)
-            x = apply_preblocks(preblocks, batch_full)["input"].to(device).float()  # (1, C_in, 1, H, W)
+            x = apply_preblocks(preblocks, batch_full, device=device)["input"].float()  # (1, C_in, 1, H, W)
 
             x_init = None
             results = []
@@ -320,7 +320,7 @@ def predict(rank, world_size, conf, p):
                     t_next = t0 + step * dt
                     sample_frc = dataset[(t_next, 1)]  # loads only dynamic_forcing
                     batch_frc = _sample_to_batch(sample_frc)
-                    x_frc = apply_preblocks(preblocks, batch_frc)["input"].to(device).float()  # (1, n_dyn, 1, H, W)
+                    x_frc = apply_preblocks(preblocks, batch_frc, device=device)["input"].float()  # (1, n_dyn, 1, H, W)
 
                     # ERA5Dataset insertion order: [dynfrc | static | prog]
                     x[:, :n_dyn, ...] = x_frc  # update dynamic forcing

--- a/applications/rollout_to_netcdf_gen2.py
+++ b/applications/rollout_to_netcdf_gen2.py
@@ -280,8 +280,7 @@ def predict(rank, world_size, conf, p):
             # Step 0: load full initial state
             sample_full = dataset[(t0, 0)]
             batch_full = _sample_to_batch(sample_full)
-            x, _ = apply_preblocks(preblocks, batch_full)
-            x = x.to(device).float()  # (1, C_in, 1, H, W)
+            x = apply_preblocks(preblocks, batch_full)["input"].to(device).float()  # (1, C_in, 1, H, W)
 
             x_init = None
             results = []
@@ -321,8 +320,7 @@ def predict(rank, world_size, conf, p):
                     t_next = t0 + step * dt
                     sample_frc = dataset[(t_next, 1)]  # loads only dynamic_forcing
                     batch_frc = _sample_to_batch(sample_frc)
-                    x_frc, _ = apply_preblocks(preblocks, batch_frc)
-                    x_frc = x_frc.to(device).float()  # (1, n_dyn, 1, H, W)
+                    x_frc = apply_preblocks(preblocks, batch_frc)["input"].to(device).float()  # (1, n_dyn, 1, H, W)
 
                     # ERA5Dataset insertion order: [dynfrc | static | prog]
                     x[:, :n_dyn, ...] = x_frc  # update dynamic forcing

--- a/credit/cli/_plot.py
+++ b/credit/cli/_plot.py
@@ -150,8 +150,8 @@ def _plot(args) -> None:
     sample = dataset[(ts, 0)]
     batch = default_collate([sample])
     preblocks = build_preblocks(conf.get("preblocks", {}))
-    _batch = apply_preblocks(preblocks, batch)
-    x, y, meta = _batch["input"].to(device), _batch["target"].to(device), _batch["meta"]
+    _batch = apply_preblocks(preblocks, batch, device=device)
+    x, y, meta = _batch["input"], _batch["target"], _batch["meta"]
     with torch.no_grad():
         y_pred = model(x)
 

--- a/credit/cli/_plot.py
+++ b/credit/cli/_plot.py
@@ -150,9 +150,8 @@ def _plot(args) -> None:
     sample = dataset[(ts, 0)]
     batch = default_collate([sample])
     preblocks = build_preblocks(conf.get("preblocks", {}))
-    x, y, _ = apply_preblocks(preblocks, batch)
-    x = x.to(device)
-
+    _batch = apply_preblocks(preblocks, batch)
+    x, y, meta = _batch["input"].to(device), _batch["target"].to(device), _batch["meta"]
     with torch.no_grad():
         y_pred = model(x)
 

--- a/credit/cli/_plot.py
+++ b/credit/cli/_plot.py
@@ -151,7 +151,11 @@ def _plot(args) -> None:
     batch = default_collate([sample])
     preblocks = build_preblocks(conf.get("preblocks", {}))
     _batch = apply_preblocks(preblocks, batch, device=device)
-    x, y, meta = _batch["input"], _batch["target"], _batch["meta"]
+    x = _batch["input"]
+    if "target" in _batch:
+        y = _batch["target"]
+    if "meta" in _batch:
+        meta = _batch["meta"]
     with torch.no_grad():
         y_pred = model(x)
 

--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -1,4 +1,3 @@
-import torch
 import torch.nn as nn
 
 from credit.postblock.reconstruct import Reconstruct
@@ -48,23 +47,22 @@ def build_postblocks(postblock_cfg: dict | None = None) -> nn.ModuleDict:
     return nn.ModuleDict(modules)
 
 
-def apply_postblocks(postblocks: nn.ModuleDict, y_pred: torch.Tensor, metadata: dict) -> dict:
-    """Applies all postblocks. Downstream postblocks require the "Reconstruct" postblock to be run in the config first.
+def apply_postblocks(postblocks: nn.ModuleDict, batch_dict: dict) -> dict:
+    """Applies all postblocks sequentially on a shared batch dict.
 
-    All registered postblocks are run sequentially on the resulting dict after reconstuct is called. If no postblocks
-    are present, the raw tensor is returned.
+    The caller is responsible for adding ``"prediction"`` (flat model output
+    tensor) to ``batch_dict`` before calling this function. Any additional data
+    needed by postblocks (e.g. ``"_raw"`` for a pre-transform batch) should
+    also be added to ``batch_dict`` by the caller beforehand.
 
     Args:
-        postblocks: ``nn.ModuleDict`` built by ``build_postblocks``.
-        y_pred:     Flat model output tensor, shape ``(B, C, H, W)``.
-        metadata:   Metadata dict from ``apply_preblocks``, must contain
-                    ``metadata["_channel_map"]["output"]``.
+        postblocks:  ``nn.ModuleDict`` built by ``build_postblocks``.
+        batch_dict:  Dict containing at minimum ``"prediction"`` and ``"meta"``.
 
     Returns:
-        Dict with keys ``"prediction"`` and ``"metadata"``, possibly further
-        transformed by registered postblocks.
+        The same ``batch_dict`` after all postblocks have run. ``"prediction"``
+        will be a nested variable dict after ``Reconstruct`` runs.
     """
-
     blocks = list(postblocks.values())
     if not blocks:
         raise RuntimeError(
@@ -76,7 +74,8 @@ def apply_postblocks(postblocks: nn.ModuleDict, y_pred: torch.Tensor, metadata: 
             '"reconstruct" must be present as the first postblock '
             "to reconstruct the output tensor into a named variable dict."
         )
-    y_pred = blocks[0](y_pred, metadata)
-    for postblock in blocks[1:]:
-        y_pred = postblock(y_pred)
-    return y_pred
+
+    for block in blocks:
+        batch_dict = block(batch_dict)
+
+    return batch_dict

--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -65,10 +65,18 @@ def apply_postblocks(postblocks: nn.ModuleDict, y_pred: torch.Tensor, metadata: 
         transformed by registered postblocks.
     """
 
-    for postblock in postblocks.values():
-        if isinstance(postblock, Reconstruct):
-            y_pred = postblock(y_pred, metadata)
-        else:
-            y_pred = postblock(y_pred)
-
+    blocks = list(postblocks.values())
+    if not blocks:
+        raise RuntimeError(
+            'No postblocks configured. "postblocks" must be present in the config, '
+            'with "reconstruct" as the first postblock.'
+        )
+    if not isinstance(blocks[0], Reconstruct):
+        raise RuntimeError(
+            '"reconstruct" must be present as the first postblock '
+            "to reconstruct the output tensor into a named variable dict."
+        )
+    y_pred = blocks[0](y_pred, metadata)
+    for postblock in blocks[1:]:
+        y_pred = postblock(y_pred)
     return y_pred

--- a/credit/postblock/reconstruct.py
+++ b/credit/postblock/reconstruct.py
@@ -41,17 +41,23 @@ class Reconstruct(BasePostblock):
     def forward(self, y_pred: torch.Tensor, metadata: dict) -> dict:
         output_map = metadata["_channel_map"]["output"]
 
+        # Flatten time dim if y_pred arrived as 5D (B, C, T, H, W) — unflatten needs 4D input
+        if y_pred.dim() == 5:
+            y_pred = y_pred.flatten(1, 2)
+
         prediction = {}
         for var_key, info in output_map.items():
             ch_slice = info["slice"]
-            n_levels, T = info["orig_shape"]
+            n_levels, n_time = info["orig_shape"]
 
-            # Slice the flat channel dim: (B, n_levels*T, H, W)
+            # Slice the flat channel dim: (B, n_levels*n_time, H, W)
             var_tensor = y_pred[:, ch_slice, ...]
 
-            # Restore level and time dims: (B, n_levels, T, H, W)
-            var_tensor = var_tensor.unflatten(1, (n_levels, T))
+            # Restore level and time dims: (B, n_levels, n_time, H, W)
+            var_tensor = var_tensor.unflatten(1, (n_levels, n_time))
 
-            prediction[var_key] = var_tensor
+            # Build nested dict matching input convention: source/data_type/dim/var_name
+            source, data_type, dim, var_name = var_key.split("/")
+            prediction.setdefault(source, {}).setdefault(data_type, {}).setdefault(dim, {})[var_name] = var_tensor
 
         return {"prediction": prediction, "metadata": metadata}

--- a/credit/postblock/reconstruct.py
+++ b/credit/postblock/reconstruct.py
@@ -1,45 +1,43 @@
 """
 reconstruct.py
 --------------
-Reconstruct: first hardcoded postblock that splits a flat model-output tensor
-back into a nested dict keyed by variable path.
+Reconstruct: first postblock that splits the flat ``batch_dict["prediction"]``
+tensor back into a nested variable dict in-place.
 
-Reads ``metadata["_channel_map"]["output"]`` built by ``ConcatToTensor`` to
-know which channels in ``y_pred`` correspond to which variables and what their
-original shape was before flattening.
+Reads ``batch_dict["meta"]["_channel_map"]["output"]`` built by
+``ConcatToTensor`` to know which channels correspond to which variables.
 
 Input
 -----
-y_pred   : torch.Tensor, shape (B, C, H, W)
-             Flat model output after ``flatten(1, 2)`` collapsed the time dim.
-metadata : dict
-             Must contain ``metadata["_channel_map"]["output"]``.
+batch_dict : dict
+    Must contain:
+      "prediction" — flat model output tensor, shape (B, C, H, W) or (B, C, T, H, W)
+      "meta"       — metadata dict with ``_channel_map["output"]``
+    May also contain "input", "target", "_raw", etc. — all passed through unchanged.
 
 Output
 ------
-dict with keys:
+The same ``batch_dict`` with ``"prediction"`` replaced by a nested dict:
 
-    "prediction" : {var_key: tensor}
-                   Each tensor has shape (B, n_levels, T, H, W), restoring the
-                   original level and time dimensions.
-    "metadata"   : the input metadata dict, passed through unchanged.
+    batch_dict["prediction"][source][data_type][dim][var_name]
+        -> tensor of shape (B, n_levels, n_time, H, W)
 """
 
-import torch
 from credit.postblock.base import BasePostblock
 
 
 class Reconstruct(BasePostblock):
-    """Splits a flat ``y_pred`` tensor into a per-variable dict.
+    """Splits ``batch_dict["prediction"]`` from a flat tensor into a nested variable dict.
 
-    Slices are read from ``metadata["_channel_map"]["output"]``, which is built
-    by ``ConcatToTensor`` and covers only prognostic + diagnostic variables.
-    Each slice is unflattened from ``(B, n_levels * T, H, W)`` back to
-    ``(B, n_levels, T, H, W)``.
+    Slices are read from ``batch_dict["meta"]["_channel_map"]["output"]``, built
+    by ``ConcatToTensor`` and covering only prognostic + diagnostic variables.
+    Each slice is unflattened from ``(B, n_levels * n_time, H, W)`` back to
+    ``(B, n_levels, n_time, H, W)``. All other keys in ``batch_dict`` pass through.
     """
 
-    def forward(self, y_pred: torch.Tensor, metadata: dict) -> dict:
-        output_map = metadata["_channel_map"]["output"]
+    def forward(self, batch_dict: dict) -> dict:
+        y_pred = batch_dict["prediction"]
+        output_map = batch_dict["meta"]["_channel_map"]["output"]
 
         # Flatten time dim if y_pred arrived as 5D (B, C, T, H, W) — unflatten needs 4D input
         if y_pred.dim() == 5:
@@ -60,4 +58,5 @@ class Reconstruct(BasePostblock):
             source, data_type, dim, var_name = var_key.split("/")
             prediction.setdefault(source, {}).setdefault(data_type, {}).setdefault(dim, {})[var_name] = var_tensor
 
-        return {"prediction": prediction, "metadata": metadata}
+        batch_dict["prediction"] = prediction
+        return batch_dict

--- a/credit/postblock/scaler.py
+++ b/credit/postblock/scaler.py
@@ -22,14 +22,15 @@ class BridgeScalerTransformer(BasePostblock):
             method: "inverse_transform"
     """
 
-    def __init__(self, scaler_path: str, variables: list[str], method: str):
+    def __init__(self, scaler_path: str, variables: list[str], method: str, key: str = "prediction"):
 
         super().__init__()
         self.variables = variables
         self.method = method
         self.scaler_path = scaler_path
+        self.key = key
         self.scaler = load_scaler(scaler_path)
 
     def forward(self, batch: dict) -> dict:
-
-        return scale_var_dict(batch, self.scaler, self.method, self.variables)
+        batch[self.key] = scale_var_dict(batch[self.key], self.scaler, self.method, self.variables)
+        return batch

--- a/credit/postblock/wet_mask_samudra.py
+++ b/credit/postblock/wet_mask_samudra.py
@@ -13,8 +13,9 @@ class WetMaskBlock(nn.Module):
     This encourages the model to focus learning on ocean regions.
     """
 
-    def __init__(self, conf):
+    def __init__(self, conf, key: str = "prediction"):
         super().__init__()
+        self.key = key
 
         data_path = conf["data"]["data_path"]
         data_means_path = conf["data"]["mean_path"]
@@ -51,26 +52,24 @@ class WetMaskBlock(nn.Module):
         self.register_buffer("wet_mask", wet.float())  # Main 3D ocean mask
         self.register_buffer("wet_surface_mask", wet_surface.float())  # Surface mask
 
-    def forward(self, predictions):
+    def forward(self, batch: dict) -> dict:
         """
-        Apply wet mask to predictions with gradient influence
+        Apply wet mask to predictions with gradient influence.
 
         Args:
-            predictions: tensor of shape (batch, n_vars, time, lat, lon)
+            batch: dict containing a tensor at ``batch[self.key]`` of shape
+                   (batch, n_vars, time, lat, lon).
 
         Returns:
-            masked_predictions: same shape, with land values set to zero
+            The same dict with ``batch[self.key]`` masked (land=0, ocean preserved).
         """
-        # Use the 3D wet mask for full predictions
-        # wet_mask shape depends on your data structure - adjust as needed
+        predictions = batch[self.key]
+
         if len(self.wet_mask.shape) == 4:  # (vars, levels, lat, lon)
-            # Flatten to (total_vars, lat, lon) to match prediction channels
             mask_flat = self.wet_mask.view(-1, self.wet_mask.shape[-2], self.wet_mask.shape[-1])
             mask_expanded = mask_flat.unsqueeze(0).unsqueeze(2)  # (1, vars, 1, lat, lon)
         else:  # Already (vars, lat, lon)
             mask_expanded = self.wet_mask.unsqueeze(0).unsqueeze(2)  # (1, vars, 1, lat, lon)
 
-        # Apply mask (ocean=1 preserves values, land=0 zeros out)
-        masked_predictions = predictions * mask_expanded.to(predictions.device)
-
-        return masked_predictions
+        batch[self.key] = predictions * mask_expanded.to(predictions.device)
+        return batch

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+import torch
 import torch.nn as nn
 
 from credit.preblock.log import LogTransform
@@ -52,18 +53,22 @@ def build_preblocks(preblock_cfg: dict | None = None) -> nn.ModuleDict:
     )
 
 
-def apply_preblocks(preblocks: nn.ModuleDict, batch: dict):
+def apply_preblocks(preblocks: nn.ModuleDict, batch: dict, device=None):
     """Sequentially applies transform preblocks (dict→dict).
 
-    Returns:
-        (x, target, meta) where target is None if no "target" data_type was present in the batch.
+    Returns a dict with keys:
+        "input"  — concatenated tensor (if concat preblock present) or nested batch dict
+        "meta"   — metadata dict (only present if concat preblock ran)
+        "target" — target tensor (only present if target data was in the batch)
+
+    Tensors in the output are moved to ``device`` unless the concat preblock was
+    configured with ``to_device: false``.
     """
     if not preblocks:
-        raise RuntimeError(
-            'No preblocks configured. "preblocks" must be present in the config, with "concat" as the final preblock.'
-        )
+        raise RuntimeError('No preblocks configured. "preblocks" must be present in the config.')
     meta = None
     target = None
+    to_device = True
     for preblock in preblocks.values():
         result = preblock(batch)
         if isinstance(result, tuple):
@@ -73,11 +78,16 @@ def apply_preblocks(preblocks: nn.ModuleDict, batch: dict):
                 batch, meta = result
         else:
             batch = result
-    if meta is None:
-        raise RuntimeError(
-            'Metadata missing. "concat" must be present as the final preblock to concatenate data and prepare metadata.'
-        )
-    out = {"input": batch, "meta": meta}
+        if hasattr(preblock, "to_device"):
+            to_device = preblock.to_device
+
+    out = {"input": batch}
+    if meta is not None:
+        out["meta"] = meta
     if target is not None:
         out["target"] = target
+
+    if device is not None and to_device:
+        out = {k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in out.items()}
+
     return out

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -53,20 +53,28 @@ def build_preblocks(preblock_cfg: dict | None = None) -> nn.ModuleDict:
 
 
 def apply_preblocks(preblocks: nn.ModuleDict, batch: dict):
-    """Sequentially applies transform preblocks (dict→dict)."""
+    """Sequentially applies transform preblocks (dict→dict).
+
+    Returns:
+        (x, target, meta) where target is None if no "target" data_type was present in the batch.
+    """
     if not preblocks:
         raise RuntimeError(
             'No preblocks configured. "preblocks" must be present in the config, with "concat" as the final preblock.'
         )
     meta = None
+    target = None
     for preblock in preblocks.values():
         result = preblock(batch)
         if isinstance(result, tuple):
-            batch, meta = result
+            if len(result) == 3:
+                batch, target, meta = result
+            else:
+                batch, meta = result
         else:
             batch = result
     if meta is None:
         raise RuntimeError(
             'Metadata missing. "concat" must be present as the final preblock to concatenate data and prepare metadata.'
         )
-    return batch, meta
+    return batch, target, meta

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -54,6 +54,19 @@ def build_preblocks(preblock_cfg: dict | None = None) -> nn.ModuleDict:
 
 def apply_preblocks(preblocks: nn.ModuleDict, batch: dict):
     """Sequentially applies transform preblocks (dict→dict)."""
+    if not preblocks:
+        raise RuntimeError(
+            'No preblocks configured. "preblocks" must be present in the config, with "concat" as the final preblock.'
+        )
+    meta = None
     for preblock in preblocks.values():
-        batch = preblock(batch)
-    return batch
+        result = preblock(batch)
+        if isinstance(result, tuple):
+            batch, meta = result
+        else:
+            batch = result
+    if meta is None:
+        raise RuntimeError(
+            'Metadata missing. "concat" must be present as the final preblock to concatenate data and prepare metadata.'
+        )
+    return batch, meta

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -64,8 +64,6 @@ def apply_preblocks(preblocks: nn.ModuleDict, batch: dict, device=None):
     Tensors in the output are moved to ``device`` unless the concat preblock was
     configured with ``to_device: false``.
     """
-    if not preblocks:
-        raise RuntimeError('No preblocks configured. "preblocks" must be present in the config.')
     meta = None
     target = None
     to_device = True
@@ -78,7 +76,7 @@ def apply_preblocks(preblocks: nn.ModuleDict, batch: dict, device=None):
                 batch, meta = result
         else:
             batch = result
-        if hasattr(preblock, "to_device"):
+        if isinstance(preblock, ConcatToTensor):
             to_device = preblock.to_device
 
     out = {"input": batch}

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -77,4 +77,7 @@ def apply_preblocks(preblocks: nn.ModuleDict, batch: dict):
         raise RuntimeError(
             'Metadata missing. "concat" must be present as the final preblock to concatenate data and prepare metadata.'
         )
-    return batch, target, meta
+    out = {"input": batch, "meta": meta}
+    if target is not None:
+        out["target"] = target
+    return out

--- a/credit/preblock/concat.py
+++ b/credit/preblock/concat.py
@@ -46,8 +46,13 @@ class ConcatToTensor(BasePreblock):
     Example config::
 
         type: "concatenate_to_tensor"
-        args: {}
+        args:
+          to_device: true   # set false to skip .to(device) in apply_preblocks
     """
+
+    def __init__(self, to_device: bool = True):
+        super().__init__()
+        self.to_device = to_device
 
     def forward(self, batch):
         input_tensors = []

--- a/credit/trainers/trainerERA5gen2.py
+++ b/credit/trainers/trainerERA5gen2.py
@@ -171,7 +171,7 @@ class TrainerERA5Gen2(BaseTrainer):
 
             for t in range(1, self.forecast_len + 1):
                 batch = next(dl)
-                _batch = apply_preblocks(self.preblocks, batch)
+                _batch = apply_preblocks(self.preblocks, batch, device=self.device)
                 x_raw, y_raw = _batch["input"], _batch["target"]
                 # ERA5Dataset outputs 5D tensors (B, C, frames, H, W); collapse frames dim
                 if x_raw.dim() == 5:
@@ -179,7 +179,7 @@ class TrainerERA5Gen2(BaseTrainer):
                     y_raw = y_raw.flatten(1, 2)
 
                 if t == 1:
-                    x = x_raw.to(self.device).float()
+                    x = x_raw.float()
                     if self.ensemble_size > 1:
                         x = torch.repeat_interleave(x, self.ensemble_size, 0)
                 else:
@@ -187,7 +187,7 @@ class TrainerERA5Gen2(BaseTrainer):
                     # Build full input: start from previous x, update dynfrc and
                     # prognostic slices; static channels stay unchanged.
                     # ERA5Dataset insertion order: [dynfrc | static | prog]
-                    x_dynfrc = x_raw.to(self.device).float()
+                    x_dynfrc = x_raw.float()
                     if self.ensemble_size > 1:
                         x_dynfrc = torch.repeat_interleave(x_dynfrc, self.ensemble_size, 0)
                     n_dynfrc = x_dynfrc.shape[1]
@@ -229,7 +229,7 @@ class TrainerERA5Gen2(BaseTrainer):
 
                 # backprop on specified timesteps
                 if t in self.backprop_on_timestep:
-                    y = y_raw.to(self.device).float()
+                    y = y_raw.float()
                     if self.flag_clamp:
                         y = torch.clamp(y, min=self.clamp_min, max=self.clamp_max)
 
@@ -339,7 +339,7 @@ class TrainerERA5Gen2(BaseTrainer):
 
                 for t in range(1, self.valid_forecast_len + 1):
                     batch = next(dl)
-                    _batch = apply_preblocks(self.preblocks, batch)
+                    _batch = apply_preblocks(self.preblocks, batch, device=self.device)
                     x_raw, y_raw = _batch["input"], _batch["target"]
                     # ERA5Dataset outputs 5D tensors (B, C, frames, H, W); collapse frames dim
                     if x_raw.dim() == 5:
@@ -347,14 +347,14 @@ class TrainerERA5Gen2(BaseTrainer):
                         y_raw = y_raw.flatten(1, 2)
 
                     if t == 1:
-                        x = x_raw.to(self.device).float()
+                        x = x_raw.float()
                         if self.ensemble_size > 1:
                             x = torch.repeat_interleave(x, self.ensemble_size, 0)
                     else:
                         # At t > 1 ERA5Dataset returns only dynamic_forcing channels.
                         # Build full input: start from previous x, update dynfrc and
                         # prognostic slices; static channels stay unchanged.
-                        x_dynfrc = x_raw.to(self.device).float()
+                        x_dynfrc = x_raw.float()
                         if self.ensemble_size > 1:
                             x_dynfrc = torch.repeat_interleave(x_dynfrc, self.ensemble_size, 0)
                         n_dynfrc = x_dynfrc.shape[1]
@@ -392,7 +392,7 @@ class TrainerERA5Gen2(BaseTrainer):
 
                     # compute loss and metrics only at the final rollout step
                     if t == self.valid_forecast_len:
-                        y = y_raw.to(self.device).float()
+                        y = y_raw.float()
                         if self.flag_clamp:
                             y = torch.clamp(y, min=self.clamp_min, max=self.clamp_max)
 

--- a/credit/trainers/trainerERA5gen2.py
+++ b/credit/trainers/trainerERA5gen2.py
@@ -11,7 +11,6 @@ import optuna
 
 from credit.postblock.gen1 import GlobalMassFixer, GlobalWaterFixer, GlobalEnergyFixer
 from credit.preblock import build_preblocks, apply_preblocks
-from credit.preblock.concat import ConcatToTensor
 from credit.scheduler import update_on_batch
 from credit.trainers.base_trainer import BaseTrainer
 from credit.trainers.utils import accum_log, cycle
@@ -172,7 +171,8 @@ class TrainerERA5Gen2(BaseTrainer):
 
             for t in range(1, self.forecast_len + 1):
                 batch = next(dl)
-                x_raw, y_raw, _ = ConcatToTensor()(apply_preblocks(self.preblocks, batch))
+                _batch = apply_preblocks(self.preblocks, batch)
+                x_raw, y_raw = _batch["input"], _batch["target"]
                 # ERA5Dataset outputs 5D tensors (B, C, frames, H, W); collapse frames dim
                 if x_raw.dim() == 5:
                     x_raw = x_raw.flatten(1, 2)
@@ -339,7 +339,8 @@ class TrainerERA5Gen2(BaseTrainer):
 
                 for t in range(1, self.valid_forecast_len + 1):
                     batch = next(dl)
-                    x_raw, y_raw, _ = ConcatToTensor()(apply_preblocks(self.preblocks, batch))
+                    _batch = apply_preblocks(self.preblocks, batch)
+                    x_raw, y_raw = _batch["input"], _batch["target"]
                     # ERA5Dataset outputs 5D tensors (B, C, frames, H, W); collapse frames dim
                     if x_raw.dim() == 5:
                         x_raw = x_raw.flatten(1, 2)

--- a/tests/test_postblock.py
+++ b/tests/test_postblock.py
@@ -278,12 +278,18 @@ class TestReconstruct:
     def _metadata(self, output_map):
         return {"_channel_map": {"output": output_map}}
 
+    def _batch_dict(self, y_pred, extra=None):
+        """Minimal batch_dict as the caller would build before apply_postblocks."""
+        d = {"prediction": y_pred, "meta": self._metadata(self._output_map())}
+        if extra:
+            d.update(extra)
+        return d
+
     def test_nested_dict_structure(self):
         """Output mirrors apply_preblocks input convention: source/data_type/dim/var_name."""
         from credit.postblock.reconstruct import Reconstruct
 
-        metadata = self._metadata(self._output_map())
-        result = Reconstruct()(torch.randn(2, 5, 8, 8), metadata)
+        result = Reconstruct()(self._batch_dict(torch.randn(2, 5, 8, 8)))
 
         pred = result["prediction"]
         assert "arco_era5" in pred
@@ -298,8 +304,7 @@ class TestReconstruct:
         from credit.postblock.reconstruct import Reconstruct
 
         B, H, W = 2, 8, 8
-        metadata = self._metadata(self._output_map())
-        result = Reconstruct()(torch.randn(B, 5, H, W), metadata)
+        result = Reconstruct()(self._batch_dict(torch.randn(B, 5, H, W)))
 
         pred = result["prediction"]
         assert pred["arco_era5"]["prognostic"]["3d"]["temperature"].shape == (B, 4, 1, H, W)
@@ -310,12 +315,11 @@ class TestReconstruct:
         from credit.postblock.reconstruct import Reconstruct
 
         B, H, W = 2, 8, 8
-        metadata = self._metadata(self._output_map())
         y_pred_4d = torch.randn(B, 5, H, W)
         y_pred_5d = y_pred_4d.unsqueeze(2)  # (B, 5, 1, H, W)
 
-        result_4d = Reconstruct()(y_pred_4d, metadata)
-        result_5d = Reconstruct()(y_pred_5d, metadata)
+        result_4d = Reconstruct()(self._batch_dict(y_pred_4d))
+        result_5d = Reconstruct()(self._batch_dict(y_pred_5d))
 
         shape_4d = result_4d["prediction"]["arco_era5"]["prognostic"]["3d"]["temperature"].shape
         shape_5d = result_5d["prediction"]["arco_era5"]["prognostic"]["3d"]["temperature"].shape
@@ -326,10 +330,8 @@ class TestReconstruct:
         from credit.postblock.reconstruct import Reconstruct
 
         B, H, W = 1, 4, 4
-        metadata = self._metadata(self._output_map())
         y_pred = torch.randn(B, 5, H, W)
-
-        result = Reconstruct()(y_pred, metadata)
+        result = Reconstruct()(self._batch_dict(y_pred))
         pred = result["prediction"]
 
         assert torch.equal(
@@ -341,14 +343,24 @@ class TestReconstruct:
             y_pred[:, 4:5].unflatten(1, (1, 1)),
         )
 
-    def test_metadata_passthrough(self):
-        """metadata dict is returned unchanged."""
+    def test_other_keys_pass_through(self):
+        """Keys other than 'prediction' are preserved unchanged."""
         from credit.postblock.reconstruct import Reconstruct
 
-        metadata = self._metadata(self._output_map())
-        metadata["extra_key"] = "sentinel"
-        result = Reconstruct()(torch.randn(1, 5, 4, 4), metadata)
-        assert result["metadata"] is metadata
+        raw = {"era5": {"input": {}}}
+        batch = self._batch_dict(torch.randn(1, 5, 4, 4), extra={"input": torch.zeros(1), "_raw": raw})
+        result = Reconstruct()(batch)
+        assert result["_raw"] is raw
+        assert "input" in result
+
+    def test_metadata_passthrough(self):
+        """meta dict is returned at the same key, unchanged."""
+        from credit.postblock.reconstruct import Reconstruct
+
+        batch = self._batch_dict(torch.randn(1, 5, 4, 4))
+        original_meta = batch["meta"]
+        result = Reconstruct()(batch)
+        assert result["meta"] is original_meta
 
 
 if __name__ == "__main__":

--- a/tests/test_postblock.py
+++ b/tests/test_postblock.py
@@ -261,6 +261,96 @@ def test_GlobalEnergyFixerUpDown_rand():
     assert y_pred_fix.shape == y_pred.shape
 
 
+class TestReconstruct:
+    """Tests for credit.postblock.reconstruct.Reconstruct."""
+
+    def _output_map(self):
+        """Minimal channel map matching ConcatToTensor output format.
+
+        Simulates: one 3D variable (4 levels) and one 2D surface variable.
+        Slash-joined key format: source/data_type/dim/var_name.
+        """
+        return {
+            "arco_era5/prognostic/3d/temperature": {"slice": slice(0, 4), "orig_shape": (4, 1)},
+            "arco_era5/prognostic/2d/surface_pressure": {"slice": slice(4, 5), "orig_shape": (1, 1)},
+        }
+
+    def _metadata(self, output_map):
+        return {"_channel_map": {"output": output_map}}
+
+    def test_nested_dict_structure(self):
+        """Output mirrors apply_preblocks input convention: source/data_type/dim/var_name."""
+        from credit.postblock.reconstruct import Reconstruct
+
+        metadata = self._metadata(self._output_map())
+        result = Reconstruct()(torch.randn(2, 5, 8, 8), metadata)
+
+        pred = result["prediction"]
+        assert "arco_era5" in pred
+        assert "prognostic" in pred["arco_era5"]
+        assert "3d" in pred["arco_era5"]["prognostic"]
+        assert "2d" in pred["arco_era5"]["prognostic"]
+        assert "temperature" in pred["arco_era5"]["prognostic"]["3d"]
+        assert "surface_pressure" in pred["arco_era5"]["prognostic"]["2d"]
+
+    def test_tensor_shapes_4d_input(self):
+        """3D var → (B, n_levels, 1, H, W), 2D var → (B, 1, 1, H, W)."""
+        from credit.postblock.reconstruct import Reconstruct
+
+        B, H, W = 2, 8, 8
+        metadata = self._metadata(self._output_map())
+        result = Reconstruct()(torch.randn(B, 5, H, W), metadata)
+
+        pred = result["prediction"]
+        assert pred["arco_era5"]["prognostic"]["3d"]["temperature"].shape == (B, 4, 1, H, W)
+        assert pred["arco_era5"]["prognostic"]["2d"]["surface_pressure"].shape == (B, 1, 1, H, W)
+
+    def test_5d_input_no_extra_dim(self):
+        """5D y_pred (B, C, 1, H, W) produces the same shape as 4D — no spurious singleton."""
+        from credit.postblock.reconstruct import Reconstruct
+
+        B, H, W = 2, 8, 8
+        metadata = self._metadata(self._output_map())
+        y_pred_4d = torch.randn(B, 5, H, W)
+        y_pred_5d = y_pred_4d.unsqueeze(2)  # (B, 5, 1, H, W)
+
+        result_4d = Reconstruct()(y_pred_4d, metadata)
+        result_5d = Reconstruct()(y_pred_5d, metadata)
+
+        shape_4d = result_4d["prediction"]["arco_era5"]["prognostic"]["3d"]["temperature"].shape
+        shape_5d = result_5d["prediction"]["arco_era5"]["prognostic"]["3d"]["temperature"].shape
+        assert shape_4d == shape_5d == (B, 4, 1, H, W)
+
+    def test_values_match_input_channels(self):
+        """Reconstructed tensors contain exactly the channels sliced from y_pred."""
+        from credit.postblock.reconstruct import Reconstruct
+
+        B, H, W = 1, 4, 4
+        metadata = self._metadata(self._output_map())
+        y_pred = torch.randn(B, 5, H, W)
+
+        result = Reconstruct()(y_pred, metadata)
+        pred = result["prediction"]
+
+        assert torch.equal(
+            pred["arco_era5"]["prognostic"]["3d"]["temperature"],
+            y_pred[:, 0:4].unflatten(1, (4, 1)),
+        )
+        assert torch.equal(
+            pred["arco_era5"]["prognostic"]["2d"]["surface_pressure"],
+            y_pred[:, 4:5].unflatten(1, (1, 1)),
+        )
+
+    def test_metadata_passthrough(self):
+        """metadata dict is returned unchanged."""
+        from credit.postblock.reconstruct import Reconstruct
+
+        metadata = self._metadata(self._output_map())
+        metadata["extra_key"] = "sentinel"
+        result = Reconstruct()(torch.randn(1, 5, 4, 4), metadata)
+        assert result["metadata"] is metadata
+
+
 if __name__ == "__main__":
     # Set up logger to print stuff
     root = logging.getLogger()

--- a/tests/test_trainer_components.py
+++ b/tests/test_trainer_components.py
@@ -414,6 +414,7 @@ def _era5_gen2_multistep_conf(forecast_len, tmp_path):
         "mean_path": "/dev/null",
         "std_path": "/dev/null",
     }
+    base["preblocks"] = {"concat": {"type": "concat"}}
     return base
 
 

--- a/tests/test_trainer_components.py
+++ b/tests/test_trainer_components.py
@@ -527,7 +527,6 @@ class TestERA5Gen2MultiStepTraining:
         from unittest.mock import patch
         from credit.trainers.trainerERA5gen2 import TrainerERA5Gen2 as Trainer
         from credit.preblock import apply_preblocks
-        from credit.preblock.concat import ConcatToTensor
 
         B, C, H, W = 1, 4, 4, 4
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
@@ -555,9 +554,9 @@ class TestERA5Gen2MultiStepTraining:
 
         original_apply = apply_preblocks
 
-        def _patched_apply(preblocks, batch):
-            result = original_apply(preblocks, batch)
-            x_raw, _, __ = ConcatToTensor()(result)
+        def _patched_apply(preblocks, batch, device=None):
+            result = original_apply(preblocks, batch, device=device)
+            x_raw = result["input"]
             step[0] += 1
             if step[0] == 1:
                 x_at_step1_out[0] = x_raw.clone()
@@ -626,6 +625,7 @@ class TestERA5Gen2MultiStepTraining:
                 }
             },
         }
+        conf["preblocks"] = {"concat": {"type": "concat"}}
 
         # Model: outputs N_PROG channels, all zeros — makes y_pred easy to check.
         # Multiply by self.w so the output has a grad_fn for backprop.

--- a/tests/test_trainer_components.py
+++ b/tests/test_trainer_components.py
@@ -316,6 +316,7 @@ def _era5_gen2_conf(**overrides):
         "mean_path": "/dev/null",
         "std_path": "/dev/null",
     }
+    base["preblocks"] = {"concat": {"type": "concat"}}
     base.update(overrides)
     return base
 


### PR DESCRIPTION
<!-- Note: The pull request (PR) title will be included in the release notes. -->

### Description
This fixes two bugs in the `Reconstruct()` postblock and adds unit tests:

1. Previously had an extra singleton time dimension if input was 5D. Now supports 4D or 5D output and corrects to 5D if 4D.
2. Outputs the data dictionary in the same structure that comes out of the Multi_Source dataloader: `dict[source][var_type][dim_size][long_var_name]`

### Checklist
- [x] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date.
