### PR TITLE
deps: add healpy to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ haversine
 pvlib
 torch-harmonics
 torch_geometric
+healpy
 fsspec
 gcsfs
 h5py<=3.14.0


### PR DESCRIPTION
## Summary

- Adds `healpy` to `requirements.txt` so the HEALPix model in the model zoo uses real spherical geometry instead of the approximate lat/lon grid fallback.

## Test plan

- `healpy 1.19.0` installed and verified in `credit-main-casper` env
- HEALPix model smoke test passes cleanly (no "approximate grid" warning)