### PR TITLE
Fix reconstruct and add tests

### DIFF
--- a/credit/postblock/reconstruct.py
+++ b/credit/postblock/reconstruct.py
@@ -1,57 +1,62 @@
 """
 reconstruct.py
 --------------
-Reconstruct: first hardcoded postblock that splits a flat model-output tensor
-back into a nested dict keyed by variable path.
+Reconstruct: first postblock that splits the flat ``batch_dict["prediction"]``
+tensor back into a nested variable dict in-place.
 
-Reads ``metadata["_channel_map"]["output"]`` built by ``ConcatToTensor`` to
-know which channels in ``y_pred`` correspond to which variables and what their
-original shape was before flattening.
+Reads ``batch_dict["meta"]["_channel_map"]["output"]`` built by
+``ConcatToTensor`` to know which channels correspond to which variables.
 
 Input
 -----
-y_pred   : torch.Tensor, shape (B, C, H, W)
-             Flat model output after ``flatten(1, 2)`` collapsed the time dim.
-metadata : dict
-             Must contain ``metadata["_channel_map"]["output"]``.
+batch_dict : dict
+    Must contain:
+      "prediction" — flat model output tensor, shape (B, C, H, W) or (B, C, T, H, W)
+      "meta"       — metadata dict with ``_channel_map["output"]``
+    May also contain "input", "target", "_raw", etc. — all passed through unchanged.
 
 Output
 ------
-dict with keys:
+The same ``batch_dict`` with ``"prediction"`` replaced by a nested dict:
 
-    "prediction" : {var_key: tensor}
-                   Each tensor has shape (B, n_levels, T, H, W), restoring the
-                   original level and time dimensions.
-    "metadata"   : the input metadata dict, passed through unchanged.
+    batch_dict["prediction"][source][data_type][dim][var_name]
+        -> tensor of shape (B, n_levels, n_time, H, W)
 """
 
-import torch
 from credit.postblock.base import BasePostblock
 
 
 class Reconstruct(BasePostblock):
-    """Splits a flat ``y_pred`` tensor into a per-variable dict.
+    """Splits ``batch_dict["prediction"]`` from a flat tensor into a nested variable dict.
 
-    Slices are read from ``metadata["_channel_map"]["output"]``, which is built
-    by ``ConcatToTensor`` and covers only prognostic + diagnostic variables.
-    Each slice is unflattened from ``(B, n_levels * T, H, W)`` back to
-    ``(B, n_levels, T, H, W)``.
+    Slices are read from ``batch_dict["meta"]["_channel_map"]["output"]``, built
+    by ``ConcatToTensor`` and covering only prognostic + diagnostic variables.
+    Each slice is unflattened from ``(B, n_levels * n_time, H, W)`` back to
+    ``(B, n_levels, n_time, H, W)``. All other keys in ``batch_dict`` pass through.
     """
 
-    def forward(self, y_pred: torch.Tensor, metadata: dict) -> dict:
-        output_map = metadata["_channel_map"]["output"]
+    def forward(self, batch_dict: dict) -> dict:
+        y_pred = batch_dict["prediction"]
+        output_map = batch_dict["meta"]["_channel_map"]["output"]
+
+        # Flatten time dim if y_pred arrived as 5D (B, C, T, H, W) — unflatten needs 4D input
+        if y_pred.dim() == 5:
+            y_pred = y_pred.flatten(1, 2)
 
         prediction = {}
         for var_key, info in output_map.items():
             ch_slice = info["slice"]
-            n_levels, T = info["orig_shape"]
+            n_levels, n_time = info["orig_shape"]
 
-            # Slice the flat channel dim: (B, n_levels*T, H, W)
+            # Slice the flat channel dim: (B, n_levels*n_time, H, W)
             var_tensor = y_pred[:, ch_slice, ...]
 
-            # Restore level and time dims: (B, n_levels, T, H, W)
-            var_tensor = var_tensor.unflatten(1, (n_levels, T))
+            # Restore level and time dims: (B, n_levels, n_time, H, W)
+            var_tensor = var_tensor.unflatten(1, (n_levels, n_time))
 
-            prediction[var_key] = var_tensor
+            # Build nested dict matching input convention: source/data_type/dim/var_name
+            source, data_type, dim, var_name = var_key.split("/")
+            prediction.setdefault(source, {}).setdefault(data_type, {}).setdefault(dim, {})[var_name] = var_tensor
 
-        return {"prediction": prediction, "metadata": metadata}
+        batch_dict["prediction"] = prediction
+        return batch_dict

--- a/tests/test_postblock.py
+++ b/tests/test_postblock.py
@@ -261,6 +261,108 @@ def test_GlobalEnergyFixerUpDown_rand():
     assert y_pred_fix.shape == y_pred.shape
 
 
+class TestReconstruct:
+    """Tests for credit.postblock.reconstruct.Reconstruct."""
+
+    def _output_map(self):
+        """Minimal channel map matching ConcatToTensor output format.
+
+        Simulates: one 3D variable (4 levels) and one 2D surface variable.
+        Slash-joined key format: source/data_type/dim/var_name.
+        """
+        return {
+            "arco_era5/prognostic/3d/temperature": {"slice": slice(0, 4), "orig_shape": (4, 1)},
+            "arco_era5/prognostic/2d/surface_pressure": {"slice": slice(4, 5), "orig_shape": (1, 1)},
+        }
+
+    def _metadata(self, output_map):
+        return {"_channel_map": {"output": output_map}}
+
+    def _batch_dict(self, y_pred, extra=None):
+        """Minimal batch_dict as the caller would build before apply_postblocks."""
+        d = {"prediction": y_pred, "meta": self._metadata(self._output_map())}
+        if extra:
+            d.update(extra)
+        return d
+
+    def test_nested_dict_structure(self):
+        """Output mirrors apply_preblocks input convention: source/data_type/dim/var_name."""
+        from credit.postblock.reconstruct import Reconstruct
+
+        result = Reconstruct()(self._batch_dict(torch.randn(2, 5, 8, 8)))
+
+        pred = result["prediction"]
+        assert "arco_era5" in pred
+        assert "prognostic" in pred["arco_era5"]
+        assert "3d" in pred["arco_era5"]["prognostic"]
+        assert "2d" in pred["arco_era5"]["prognostic"]
+        assert "temperature" in pred["arco_era5"]["prognostic"]["3d"]
+        assert "surface_pressure" in pred["arco_era5"]["prognostic"]["2d"]
+
+    def test_tensor_shapes_4d_input(self):
+        """3D var → (B, n_levels, 1, H, W), 2D var → (B, 1, 1, H, W)."""
+        from credit.postblock.reconstruct import Reconstruct
+
+        B, H, W = 2, 8, 8
+        result = Reconstruct()(self._batch_dict(torch.randn(B, 5, H, W)))
+
+        pred = result["prediction"]
+        assert pred["arco_era5"]["prognostic"]["3d"]["temperature"].shape == (B, 4, 1, H, W)
+        assert pred["arco_era5"]["prognostic"]["2d"]["surface_pressure"].shape == (B, 1, 1, H, W)
+
+    def test_5d_input_no_extra_dim(self):
+        """5D y_pred (B, C, 1, H, W) produces the same shape as 4D — no spurious singleton."""
+        from credit.postblock.reconstruct import Reconstruct
+
+        B, H, W = 2, 8, 8
+        y_pred_4d = torch.randn(B, 5, H, W)
+        y_pred_5d = y_pred_4d.unsqueeze(2)  # (B, 5, 1, H, W)
+
+        result_4d = Reconstruct()(self._batch_dict(y_pred_4d))
+        result_5d = Reconstruct()(self._batch_dict(y_pred_5d))
+
+        shape_4d = result_4d["prediction"]["arco_era5"]["prognostic"]["3d"]["temperature"].shape
+        shape_5d = result_5d["prediction"]["arco_era5"]["prognostic"]["3d"]["temperature"].shape
+        assert shape_4d == shape_5d == (B, 4, 1, H, W)
+
+    def test_values_match_input_channels(self):
+        """Reconstructed tensors contain exactly the channels sliced from y_pred."""
+        from credit.postblock.reconstruct import Reconstruct
+
+        B, H, W = 1, 4, 4
+        y_pred = torch.randn(B, 5, H, W)
+        result = Reconstruct()(self._batch_dict(y_pred))
+        pred = result["prediction"]
+
+        assert torch.equal(
+            pred["arco_era5"]["prognostic"]["3d"]["temperature"],
+            y_pred[:, 0:4].unflatten(1, (4, 1)),
+        )
+        assert torch.equal(
+            pred["arco_era5"]["prognostic"]["2d"]["surface_pressure"],
+            y_pred[:, 4:5].unflatten(1, (1, 1)),
+        )
+
+    def test_other_keys_pass_through(self):
+        """Keys other than 'prediction' are preserved unchanged."""
+        from credit.postblock.reconstruct import Reconstruct
+
+        raw = {"era5": {"input": {}}}
+        batch = self._batch_dict(torch.randn(1, 5, 4, 4), extra={"input": torch.zeros(1), "_raw": raw})
+        result = Reconstruct()(batch)
+        assert result["_raw"] is raw
+        assert "input" in result
+
+    def test_metadata_passthrough(self):
+        """meta dict is returned at the same key, unchanged."""
+        from credit.postblock.reconstruct import Reconstruct
+
+        batch = self._batch_dict(torch.randn(1, 5, 4, 4))
+        original_meta = batch["meta"]
+        result = Reconstruct()(batch)
+        assert result["meta"] is original_meta
+
+
 if __name__ == "__main__":
     # Set up logger to print stuff
     root = logging.getLogger()


### PR DESCRIPTION
<!-- Note: The pull request (PR) title will be included in the release notes. -->

### Description
Fix two bugs in Reconstrcut() postblock:
1. Remove extra singlton dimension -- now supprts 4D and 5D data to always move to 5D 
2. Reconstructs data into a nested dictionary in line with input data
3. Add tests 

Closes #XXX

### Checklist
- [x] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date.
