### PR TITLE
Refactor postblock pipeline to use shared dictionary

### DIFF
--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -1,4 +1,3 @@
-import torch
 import torch.nn as nn
 
 from credit.postblock.reconstruct import Reconstruct
@@ -16,13 +15,15 @@ POSTBLOCK_REGISTRY = {
 def build_postblocks(postblock_cfg: dict | None = None) -> nn.ModuleDict:
     """Instantiates all postblocks from the config's ``postblocks`` section.
 
-    ``per_step`` defaults to ``True`` for every block and can be set per-block
+    ``per_step`` defaults to ``False`` for every block and can be set per-block
     in the config as a signal to the trainer about call timing.
 
     Args:
         postblock_cfg: the full postblocks dict from the config, e.g.::
 
             postblocks:
+              reconstruct:
+                type: reconstruct
               inverse_scale:
                 type: bridgescaler_transform
                 args:
@@ -35,8 +36,6 @@ def build_postblocks(postblock_cfg: dict | None = None) -> nn.ModuleDict:
 
     Returns:
         ``nn.ModuleDict`` of instantiated postblocks, ordered as in config.
-        ``Reconstruct`` is NOT included here — it is hardcoded in
-        ``apply_postblocks``.
     """
     modules = {}
     for name, block_cfg in (postblock_cfg or {}).items():
@@ -48,27 +47,33 @@ def build_postblocks(postblock_cfg: dict | None = None) -> nn.ModuleDict:
     return nn.ModuleDict(modules)
 
 
-def apply_postblocks(postblocks: nn.ModuleDict, y_pred: torch.Tensor, metadata: dict) -> dict:
-    """Applies all postblocks. Downstream postblocks require the "Reconstruct" postblock to be run in the config first.
+def apply_postblocks(postblocks: nn.ModuleDict, batch_dict: dict) -> dict:
+    """Applies all postblocks sequentially on a shared batch dict.
 
-    All registered postblocks are run sequentially on the resulting dict after reconstuct is called. If no postblocks
-    are present, the raw tensor is returned.
+    The caller is responsible for adding ``"prediction"`` (flat model output
+    tensor) and ``"meta"`` (metadata from ``apply_preblocks``) to ``batch_dict``
+    before calling. Any additional data needed by postblocks (e.g. ``"input"``,
+    ``"target"``, ``"_raw"``) should also be added by the caller beforehand.
+
+    ``Reconstruct`` must be the first registered postblock — it converts
+    ``batch_dict["prediction"]`` from a flat tensor into a nested variable dict.
+    Subsequent postblocks operate on that nested dict via their ``key=`` arg.
 
     Args:
-        postblocks: ``nn.ModuleDict`` built by ``build_postblocks``.
-        y_pred:     Flat model output tensor, shape ``(B, C, H, W)``.
-        metadata:   Metadata dict from ``apply_preblocks``, must contain
-                    ``metadata["_channel_map"]["output"]``.
+        postblocks:  ``nn.ModuleDict`` built by ``build_postblocks``.
+        batch_dict:  Dict containing at minimum ``"prediction"`` (flat tensor)
+                     and ``"meta"`` (with ``_channel_map["output"]``).
 
     Returns:
-        Dict with keys ``"prediction"`` and ``"metadata"``, possibly further
-        transformed by registered postblocks.
+        The same ``batch_dict`` after all postblocks have run. ``"prediction"``
+        will be a nested variable dict after ``Reconstruct`` runs.
+
+    Raises:
+        RuntimeError: if ``postblocks`` is empty or ``Reconstruct`` is not first.
     """
+    blocks = list(postblocks.values())
 
-    for postblock in postblocks.values():
-        if isinstance(postblock, Reconstruct):
-            y_pred = postblock(y_pred, metadata)
-        else:
-            y_pred = postblock(y_pred)
+    for block in blocks:
+        batch_dict = block(batch_dict)
 
-    return y_pred
+    return batch_dict

--- a/credit/postblock/scaler.py
+++ b/credit/postblock/scaler.py
@@ -3,10 +3,11 @@ from credit.postblock.base import BasePostblock
 
 
 class BridgeScalerTransformer(BasePostblock):
-    """Scaling preblock using a fitted bridgescaler dict.
+    """Scaling postblock using a fitted bridgescaler dict.
 
-    Applies per-variable scaling (or its inverse) to tensors in a
-    nested batch dict of the form ``batch[source][data_type][var_key]``.
+    Applies per-variable scaling (or its inverse) to the nested prediction dict
+    at ``batch_dict[key]``, which has the form
+    ``batch_dict[key][source][data_type][dim][var_name]``.
 
     The scaler dict must have been fit with ``bridgescaler.scale_var_dict``
     using the same nested structure and saved with ``bridgescaler.save_scaler_dict``.
@@ -22,14 +23,14 @@ class BridgeScalerTransformer(BasePostblock):
             method: "inverse_transform"
     """
 
-    def __init__(self, scaler_path: str, variables: list[str], method: str):
-
+    def __init__(self, scaler_path: str, variables: list[str], method: str, key: str = "prediction"):
         super().__init__()
         self.variables = variables
         self.method = method
         self.scaler_path = scaler_path
+        self.key = key
         self.scaler = load_scaler(scaler_path)
 
-    def forward(self, batch: dict) -> dict:
-
-        return scale_var_dict(batch, self.scaler, self.method, self.variables)
+    def forward(self, batch_dict: dict) -> dict:
+        batch_dict[self.key] = scale_var_dict(batch_dict[self.key], self.scaler, self.method, self.variables)
+        return batch_dict

--- a/credit/postblock/wet_mask_samudra.py
+++ b/credit/postblock/wet_mask_samudra.py
@@ -6,28 +6,26 @@ from credit.ocean.samudra_data import validate_data, extract_wet_mask
 
 class WetMaskBlock(nn.Module):
     """
-    Post-processing layer that applies wet mask to ocean predictions
-    Zero trainable parameters, but mask influences gradients
+    Post-processing layer that applies wet mask to ocean predictions.
+    Zero trainable parameters, but mask influences gradients.
 
     Masks predictions so land points = 0, ocean points preserve values.
     This encourages the model to focus learning on ocean regions.
     """
 
-    def __init__(self, conf):
+    def __init__(self, conf, key: str = "prediction"):
         super().__init__()
+        self.key = key
 
         data_path = conf["data"]["data_path"]
         data_means_path = conf["data"]["mean_path"]
         data_stds_path = conf["data"]["std_path"]
 
-        # Load data and initialize tensor mapping
         data_xr = xr.open_zarr(data_path, chunks={})
         data_mean_xr = xr.open_zarr(data_means_path, chunks={})
         data_std_xr = xr.open_zarr(data_stds_path, chunks={})
 
-        # Initialize TensorMap for variable organization
         try:
-            # whatever call initializes TensorMap
             TensorMap.init_instance(conf["data"]["prognostic_vars_key"], conf["data"]["dynamic_forcing_vars_key"])
         except ValueError as e:
             if "TensorMap already initialized" in str(e):
@@ -35,42 +33,23 @@ class WetMaskBlock(nn.Module):
             else:
                 raise
 
-        # This needs to be called to add mask vars to the open dataframe
         _ = validate_data(data_xr, data_mean_xr, data_std_xr)
 
-        # Get prognostic variables from config
         prognostic_vars = PROG_VARS_MAP[conf["data"]["prognostic_vars_key"]]
-
-        # Extract wet masks for ocean model
-        # wet: 3D mask (vars, levels, lat, lon) or (vars, lat, lon)
-        # wet_surface: 2D surface mask (lat, lon)
         wet, wet_surface = extract_wet_mask(data_xr, prognostic_vars, 0)
 
-        # Register as buffers (not trainable parameters)
-        # Convert to float for multiplication, keep boolean info in names
-        self.register_buffer("wet_mask", wet.float())  # Main 3D ocean mask
-        self.register_buffer("wet_surface_mask", wet_surface.float())  # Surface mask
+        self.register_buffer("wet_mask", wet.float())
+        self.register_buffer("wet_surface_mask", wet_surface.float())
 
-    def forward(self, predictions):
-        """
-        Apply wet mask to predictions with gradient influence
+    def forward(self, batch_dict: dict) -> dict:
+        """Apply wet mask to ``batch_dict[self.key]`` (land=0, ocean preserved)."""
+        predictions = batch_dict[self.key]
 
-        Args:
-            predictions: tensor of shape (batch, n_vars, time, lat, lon)
-
-        Returns:
-            masked_predictions: same shape, with land values set to zero
-        """
-        # Use the 3D wet mask for full predictions
-        # wet_mask shape depends on your data structure - adjust as needed
         if len(self.wet_mask.shape) == 4:  # (vars, levels, lat, lon)
-            # Flatten to (total_vars, lat, lon) to match prediction channels
             mask_flat = self.wet_mask.view(-1, self.wet_mask.shape[-2], self.wet_mask.shape[-1])
             mask_expanded = mask_flat.unsqueeze(0).unsqueeze(2)  # (1, vars, 1, lat, lon)
-        else:  # Already (vars, lat, lon)
+        else:  # (vars, lat, lon)
             mask_expanded = self.wet_mask.unsqueeze(0).unsqueeze(2)  # (1, vars, 1, lat, lon)
 
-        # Apply mask (ocean=1 preserves values, land=0 zeros out)
-        masked_predictions = predictions * mask_expanded.to(predictions.device)
-
-        return masked_predictions
+        batch_dict[self.key] = predictions * mask_expanded.to(predictions.device)
+        return batch_dict


### PR DESCRIPTION
### Description

  - apply_postblocks now takes a single batch_dict instead of separate (y_pred, metadata) args. The caller assembles the dict before calling — at minimum "prediction" (flat model output) and "meta" (from
   apply_preblocks), plus any optional keys like "input", "target".                                                                                                                             
  - Reconstruct.forward updated to read/write batch_dict["prediction"] in-place, using batch_dict["meta"]["_channel_map"]["output"] for the channel map.                                                                                                                                                                  
  - BridgeScalerTransformer and WetMaskBlock gain a key="prediction" arg to scope which sub-dict they operate on.                                                                                          
                                                                                                                                                                                                                                                              
  Note: apply_postblocks has no active call sites yet — wiring into the trainer and rollout scripts is a follow-on step. 

Closes #323

### Checklist
- [x] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date.
