### PR TITLE
fix: Remove John's flatten bug from main

### DIFF
--- a/credit/trainers/trainerERA5gen2.py
+++ b/credit/trainers/trainerERA5gen2.py
@@ -169,10 +169,6 @@ class TrainerERA5Gen2(BaseTrainer):
                 batch = next(dl)
                 _batch = apply_preblocks(self.preblocks, batch, device=self.device)
                 x_raw, y_raw = _batch["input"], _batch["target"]
-                # ERA5Dataset outputs 5D tensors (B, C, frames, H, W); collapse frames dim
-                if x_raw.dim() == 5:
-                    x_raw = x_raw.flatten(1, 2)
-                    y_raw = y_raw.flatten(1, 2)
 
                 if t == 1:
                     x = x_raw.float()
@@ -325,10 +321,6 @@ class TrainerERA5Gen2(BaseTrainer):
                     batch = next(dl)
                     _batch = apply_preblocks(self.preblocks, batch, device=self.device)
                     x_raw, y_raw = _batch["input"], _batch["target"]
-                    # ERA5Dataset outputs 5D tensors (B, C, frames, H, W); collapse frames dim
-                    if x_raw.dim() == 5:
-                        x_raw = x_raw.flatten(1, 2)
-                        y_raw = y_raw.flatten(1, 2)
 
                     if t == 1:
                         x = x_raw.float()


### PR DESCRIPTION
## Summary

- `trainerERA5gen2` was flattening 5-D tensors `(B, C, T, H, W)` → 4-D `(B, C*T, H, W)` inside both `train_one_epoch` and `validate` via `x_raw.flatten(1, 2)` / `y_raw.flatten(1, 2)`
- All Gen-2 models handle 5-D input directly; `update_x`, loss, and metrics are all shape-agnostic (they use `[..., :]` slicing and `.mean()` that absorb the T dim)
- The flatten was incorrect and unnecessary — removed from both loops

## Test plan

- [x] Existing smoke tests pass (`smoke_gen2_casper.yml` with `crossformer`, `fuxi`, `nextgen_wxformer`)
- [x] `update_x` still works: uses `[:, sl, ...]` slicing — unchanged by 5-D vs 4-D
- [x] Loss still works: lat-weighted MSE broadcasts correctly to 5-D targets
- [x] Metrics still work: RMSE/MAE/MSE all call `.mean()` which absorbs the T=1 dim