### PR TITLE
Nuke gen2 flat-key injection: derive variables from preblock channel_map

### DIFF
--- a/config/gen_2/smoke/smoke_gen2_casper.yml
+++ b/config/gen_2/smoke/smoke_gen2_casper.yml
@@ -9,7 +9,7 @@ seed: 1000
 data:
   source:
     ERA5:
-      dataset_type: "era5"
+      dataset_type: "local"
       level_coord: "level"
       levels: [10, 30, 40, 50, 60, 70, 80, 90, 95, 100, 105, 110, 120, 130, 136, 137]
       variables:

--- a/config/gen_2/smoke/smoke_gen2_multistep_casper.yml
+++ b/config/gen_2/smoke/smoke_gen2_multistep_casper.yml
@@ -10,7 +10,7 @@ seed: 1000
 data:
   source:
     ERA5:
-      dataset_type: "era5"
+      dataset_type: "local"
       level_coord: "level"
       levels: [1., 9., 19., 29., 39., 49., 59., 69., 79., 89., 97., 104., 111., 116., 122., 126., 131., 136.]
       variables:

--- a/credit/applications/rollout_realtime_gen2.py
+++ b/credit/applications/rollout_realtime_gen2.py
@@ -47,6 +47,7 @@ from credit.models.checkpoint import load_model_state, load_state_dict_error_han
 from credit.output import load_metadata, make_xarray, save_netcdf_increment
 from credit.postblock.gen1 import GlobalMassFixer, GlobalWaterFixer, GlobalEnergyFixer
 from credit.nwp import build_GFS_init
+from credit.trainers.utils import extract_flat_keys_from_channel_map
 
 logger = logging.getLogger(__name__)
 warnings.filterwarnings("ignore")
@@ -60,20 +61,18 @@ os.environ["MKL_NUM_THREADS"] = "1"
 # ---------------------------------------------------------------------------
 
 
-def _inject_flat_schema(conf):
-    """Inject v1-style flat keys into conf['data'] so output.py utilities work."""
-    if "variables" in conf["data"]:
-        return
+def _set_output_conf(conf, preblocks, dataset, init_time):
+    """Populate output conf keys from a preblock channel_map probe."""
     src = conf["data"]["source"]["ERA5"]
-    v = src["variables"]
-    prog = v.get("prognostic") or {}
-    diag = v.get("diagnostic") or {}
-    conf["data"]["variables"] = prog.get("vars_3D", [])
-    conf["data"]["surface_variables"] = prog.get("vars_2D", [])
-    conf["data"]["diagnostic_variables"] = diag.get("vars_2D", []) if diag else []
-    conf["data"]["level_ids"] = src.get("levels", list(range(conf["model"]["levels"])))
-    if "scaler_type" not in conf["data"]:
-        conf["data"]["scaler_type"] = "std_new"
+    _probe = apply_preblocks(preblocks, _sample_to_batch(dataset[(init_time, 0)]))
+    variables, surface_variables, diagnostic_variables = extract_flat_keys_from_channel_map(
+        _probe["metadata"]["target"]["_channel_map"]
+    )
+    conf["data"]["variables"] = variables
+    conf["data"]["surface_variables"] = surface_variables
+    conf["data"]["diagnostic_variables"] = diagnostic_variables
+    conf["data"].setdefault("level_ids", src.get("levels", list(range(conf["model"]["levels"]))))
+    conf["data"].setdefault("scaler_type", "std_new")
 
 
 def _inject_tracer_inds(conf):
@@ -321,6 +320,9 @@ def run_forecast(conf, init_time: pd.Timestamp, n_steps: int, save_dir: str, poo
     dataset_conf["forecast_len"] = 1
     dataset = LocalDataset(dataset_conf, return_target=False)
 
+    # ---- Populate output conf keys from preblock channel_map ----
+    _set_output_conf(conf, preblocks, dataset, init_time)
+
     init_str = init_time.strftime("%Y-%m-%dT%HZ")
     conf["predict"]["save_forecast"] = save_dir
 
@@ -443,7 +445,6 @@ Examples:
     )
 
     conf["save_loc"] = os.path.expandvars(conf["save_loc"])
-    _inject_flat_schema(conf)
 
     # ---- CLI overrides ----
     if args.mode in ["none", "ddp", "fsdp"]:

--- a/credit/applications/rollout_realtime_gen2.py
+++ b/credit/applications/rollout_realtime_gen2.py
@@ -76,17 +76,18 @@ def _set_output_conf(conf, preblocks, dataset, init_time):
 
 
 def _inject_tracer_inds(conf):
-    """Compute tracer_inds for TracerFixer from v2 variable layout."""
+    """Compute tracer_inds for TracerFixer from the flat keys already set by _set_output_conf.
+
+    # TODO: remove when postblock config work is done — tracer_inds will be derived
+    # from the new postblock schema instead of being injected here.
+    """
     tracer_conf = conf.get("model", {}).get("post_conf", {}).get("tracer_fixer", {})
     if not tracer_conf.get("activate", False) or "tracer_inds" in tracer_conf:
         return
-    src = conf["data"]["source"]["ERA5"]
-    n_levels = len(src.get("levels", []))
-    v = src["variables"]
-    vars_3d = (v.get("prognostic") or {}).get("vars_3D", [])
-    vars_2d = (v.get("prognostic") or {}).get("vars_2D", [])
-    diag_2d = (v.get("diagnostic") or {}).get("vars_2D", [])
-    output_vars = [vn for vn in vars_3d for _ in range(n_levels)] + vars_2d + diag_2d
+    levels = conf["model"].get("levels") or conf["model"].get("frames")
+    output_vars = [vn for vn in conf["data"]["variables"] for _ in range(levels)]
+    output_vars += conf["data"]["surface_variables"]
+    output_vars += conf["data"]["diagnostic_variables"]
     thres_map = dict(zip(tracer_conf.get("tracer_name", []), tracer_conf.get("tracer_thres", [])))
     inds, thres = [], []
     for i, vn in enumerate(output_vars):
@@ -291,6 +292,17 @@ def run_forecast(conf, init_time: pd.Timestamp, n_steps: int, save_dir: str, poo
             flag_energy = True
             opt_energy = GlobalEnergyFixer(post_conf)
 
+    # ---- Dataset: build a config that covers the requested init time ----
+    # LocalDataset uses start/end datetimes only for __len__; we access by timestamp directly.
+    dataset_conf = dict(conf["data"])
+    dataset_conf["start_datetime"] = str(init_time.date())
+    dataset_conf["end_datetime"] = str((init_time + n_steps * dt).date())
+    dataset_conf["forecast_len"] = 1
+    dataset = LocalDataset(dataset_conf, return_target=False)
+
+    # ---- Populate output conf keys from preblock channel_map ----
+    _set_output_conf(conf, preblocks, dataset, init_time)
+
     # ---- Model ----
     _inject_tracer_inds(conf)
     mode = conf["predict"]["mode"]
@@ -311,17 +323,6 @@ def run_forecast(conf, init_time: pd.Timestamp, n_steps: int, save_dir: str, poo
     else:
         raise ValueError(f"Unsupported predict mode: {mode}")
     model.eval()
-
-    # ---- Dataset: build a config that covers the requested init time ----
-    # LocalDataset uses start/end datetimes only for __len__; we access by timestamp directly.
-    dataset_conf = dict(conf["data"])
-    dataset_conf["start_datetime"] = str(init_time.date())
-    dataset_conf["end_datetime"] = str((init_time + n_steps * dt).date())
-    dataset_conf["forecast_len"] = 1
-    dataset = LocalDataset(dataset_conf, return_target=False)
-
-    # ---- Populate output conf keys from preblock channel_map ----
-    _set_output_conf(conf, preblocks, dataset, init_time)
 
     init_str = init_time.strftime("%Y-%m-%dT%HZ")
     conf["predict"]["save_forecast"] = save_dir

--- a/credit/applications/rollout_to_netcdf_gen2.py
+++ b/credit/applications/rollout_to_netcdf_gen2.py
@@ -73,20 +73,19 @@ def _set_output_conf(conf, preblocks, dataset):
 
 
 def _inject_tracer_inds(conf):
-    """Compute tracer_inds for TracerFixer from v2 variable layout (same as train_gen2.py)."""
+    """Compute tracer_inds for TracerFixer from the flat keys already set by _set_output_conf.
+
+    # TODO: remove when postblock config work is done — tracer_inds will be derived
+    # from the new postblock schema instead of being injected here.
+    """
     tracer_conf = conf.get("model", {}).get("post_conf", {}).get("tracer_fixer", {})
     if not tracer_conf.get("activate", False) or "tracer_inds" in tracer_conf:
         return
-    src = conf["data"]["source"]["ERA5"]
-    n_levels = len(src.get("levels", []))
-    v = src["variables"]
-    vars_3d = (v.get("prognostic") or {}).get("vars_3D", [])
-    vars_2d = (v.get("prognostic") or {}).get("vars_2D", [])
-    diag_2d = (v.get("diagnostic") or {}).get("vars_2D", [])
-    output_vars = [vn for vn in vars_3d for _ in range(n_levels)] + vars_2d + diag_2d
-    tracer_names = tracer_conf.get("tracer_name", [])
-    tracer_thres_cfg = tracer_conf.get("tracer_thres", [])
-    thres_map = dict(zip(tracer_names, tracer_thres_cfg))
+    levels = conf["model"].get("levels") or conf["model"].get("frames")
+    output_vars = [vn for vn in conf["data"]["variables"] for _ in range(levels)]
+    output_vars += conf["data"]["surface_variables"]
+    output_vars += conf["data"]["diagnostic_variables"]
+    thres_map = dict(zip(tracer_conf.get("tracer_name", []), tracer_conf.get("tracer_thres", [])))
     tracer_inds, tracer_thres = [], []
     for i, vn in enumerate(output_vars):
         if vn in thres_map:
@@ -247,11 +246,6 @@ def predict(rank, world_size, conf, p):
             flag_energy_conserve = True
             opt_energy = GlobalEnergyFixer(post_conf)
 
-    # ---- Model ----
-    _inject_tracer_inds(conf)
-    model = _load_model(conf, device)
-    model.eval()
-
     # ---- Dataset (predict uses full data range; we select specific inits below) ----
     dataset_conf = dict(conf["data"])
     dataset_conf["forecast_len"] = 1
@@ -260,6 +254,11 @@ def predict(rank, world_size, conf, p):
 
     # ---- Populate output conf keys from preblock channel_map ----
     _set_output_conf(conf, preblocks, dataset)
+
+    # ---- Model ----
+    _inject_tracer_inds(conf)
+    model = _load_model(conf, device)
+    model.eval()
 
     # ---- Forecast init times: distribute across ranks ----
     all_forecasts = conf["predict"]["forecasts"]

--- a/credit/applications/rollout_to_netcdf_gen2.py
+++ b/credit/applications/rollout_to_netcdf_gen2.py
@@ -43,6 +43,7 @@ from credit.output import load_metadata, make_xarray, save_netcdf_increment
 from credit.postblock.gen1 import GlobalMassFixer, GlobalWaterFixer, GlobalEnergyFixer
 from credit.forecast import load_forecasts
 from credit.pbs import launch_script, launch_script_mpi
+from credit.trainers.utils import extract_flat_keys_from_channel_map
 
 logger = logging.getLogger(__name__)
 warnings.filterwarnings("ignore")
@@ -56,23 +57,19 @@ os.environ["MKL_NUM_THREADS"] = "1"
 # ---------------------------------------------------------------------------
 
 
-def _inject_flat_schema(conf):
-    """Inject v1-style flat keys into conf['data'] so output.py utilities work."""
-    if "variables" in conf["data"]:
-        return
+def _set_output_conf(conf, preblocks, dataset):
+    """Populate output conf keys from a preblock channel_map probe."""
     src = conf["data"]["source"]["ERA5"]
-    v = src["variables"]
-    prog = v.get("prognostic") or {}
-    diag = v.get("diagnostic") or {}
-    conf["data"]["variables"] = prog.get("vars_3D", [])
-    conf["data"]["surface_variables"] = prog.get("vars_2D", [])
-    # diagnostic_variables is the list of names shown in xarray output
-    conf["data"]["diagnostic_variables"] = diag.get("vars_2D", []) if diag else []
-    # level_ids: actual pressure/model-level values for xarray coordinate
-    conf["data"]["level_ids"] = src.get("levels", list(range(conf["model"]["levels"])))
-    # scaler_type needed by save_netcdf_increment
-    if "scaler_type" not in conf["data"]:
-        conf["data"]["scaler_type"] = "std_new"
+    _t0 = pd.Timestamp(conf["predict"]["forecasts"][0]).tz_localize(None)
+    _probe = apply_preblocks(preblocks, _sample_to_batch(dataset[(_t0, 0)]))
+    variables, surface_variables, diagnostic_variables = extract_flat_keys_from_channel_map(
+        _probe["metadata"]["target"]["_channel_map"]
+    )
+    conf["data"]["variables"] = variables
+    conf["data"]["surface_variables"] = surface_variables
+    conf["data"]["diagnostic_variables"] = diagnostic_variables
+    conf["data"].setdefault("level_ids", src.get("levels", list(range(conf["model"]["levels"]))))
+    conf["data"].setdefault("scaler_type", "std_new")
 
 
 def _inject_tracer_inds(conf):
@@ -261,6 +258,9 @@ def predict(rank, world_size, conf, p):
     dataset = LocalDataset(dataset_conf, return_target=False)
     dt = pd.Timedelta(conf["data"]["timestep"]) if "timestep" in conf["data"] else pd.Timedelta(hours=lead_time_periods)
 
+    # ---- Populate output conf keys from preblock channel_map ----
+    _set_output_conf(conf, preblocks, dataset)
+
     # ---- Forecast init times: distribute across ranks ----
     all_forecasts = conf["predict"]["forecasts"]
     forecasts = [f for i, f in enumerate(all_forecasts) if i % world_size == rank]
@@ -400,7 +400,6 @@ def main():
     )
 
     conf["save_loc"] = os.path.expandvars(conf["save_loc"])
-    _inject_flat_schema(conf)
 
     if "predict" not in conf:
         logger.error(

--- a/credit/applications/train_gen2.py
+++ b/credit/applications/train_gen2.py
@@ -29,11 +29,12 @@ from credit.trainers import load_trainer
 from credit.pbs import launch_script, launch_script_mpi
 from credit.models import load_model
 from credit.metrics import LatWeightedMetrics
+from credit.preblock import build_preblocks, apply_preblocks
 from credit.trainers.utils import (
-    inject_flat_var_keys,
     load_dataset,
     load_dataloader,
     load_model_states_and_optimizer,
+    extract_flat_keys_from_channel_map,
 )
 
 warnings.filterwarnings("ignore")
@@ -126,7 +127,6 @@ def main_cli():
 
     seed = conf.get("seed", 42) + rank
     seed_everything(seed)
-    inject_flat_var_keys(conf)
     if "post_conf" in conf["model"]:
         warnings.warn(
             "Gen 2 training does not support Gen 1 postblocks. Any postblocks included in the conf will be ignored."
@@ -144,6 +144,22 @@ def main_cli():
         model = m
 
     conf, model, optimizer, scheduler, scaler = load_model_states_and_optimizer(conf, model, device)
+
+    logging.info("Probing preblocks to populate loss/metrics conf keys from channel metadata")
+    _preblocks = build_preblocks(conf.get("preblocks", {}))
+    _probe = apply_preblocks(_preblocks, next(iter(train_loader)))
+    _channel_map = _probe["metadata"]["target"]["_channel_map"]
+    variables, surface_variables, diagnostic_variables = extract_flat_keys_from_channel_map(_channel_map)
+    conf["data"]["variables"] = variables
+    conf["data"]["surface_variables"] = surface_variables
+    conf["data"]["diagnostic_variables"] = diagnostic_variables
+    logging.info(
+        "Configured from preblock metadata: %d 3D vars, %d surface vars, %d diagnostic vars",
+        len(variables),
+        len(surface_variables),
+        len(diagnostic_variables),
+    )
+    del _preblocks, _probe, _channel_map
 
     train_criterion = load_loss(conf)
     valid_criterion = load_loss(conf, validation=True)

--- a/credit/trainers/utils.py
+++ b/credit/trainers/utils.py
@@ -33,28 +33,56 @@ def accum_log(log, new_logs):
     return log
 
 
-def inject_flat_var_keys(conf: dict) -> None:
-    """Inject Gen1-compatible variable keys into conf["data"] for metrics/loss.
+def vars_from_channel_map(channel_map: dict) -> list:
+    """Build the flat var list that loss/metrics iterate over from a preblock channel_map.
 
-    ``LatWeightedMetrics`` and ``VariableTotalLoss2D`` expect flat lists at:
-    - ``conf["data"]["variables"]``
-    - ``conf["data"]["surface_variables"]``
-    - ``conf["data"]["diagnostic_variables"]``
-
-    These are derived from the nested Gen2 source config.
+    Matches the format used by VariableTotalLoss2D and LatWeightedMetrics:
+    3D vars expanded as ``"{varname}_{level_idx}"``, 2D vars as ``"{varname}"``.
+    Sorted by channel slice start so the list is in tensor channel order.
     """
-    if "variables" in conf["data"]:
-        return
+    result = []
+    for key in sorted(channel_map, key=lambda k: channel_map[k]["slice"].start):
+        parts = key.split("/")
+        if len(parts) < 4:
+            continue
+        dim, varname = parts[2], parts[3]
+        n_levels = channel_map[key]["orig_shape"][0]
+        if dim == "3d":
+            result.extend(f"{varname}_{k}" for k in range(n_levels))
+        else:
+            result.append(varname)
+    return result
 
-    source_conf = next(iter(conf["data"]["source"].values()))
-    vars_conf = source_conf.get("variables", {})
 
-    prog = vars_conf.get("prognostic") or {}
-    diag = vars_conf.get("diagnostic") or {}
+def extract_flat_keys_from_channel_map(channel_map: dict) -> tuple:
+    """Extract the three conf flat key lists that loss/metrics read at init time.
 
-    conf["data"]["variables"] = prog.get("vars_3D", [])
-    conf["data"]["surface_variables"] = prog.get("vars_2D", [])
-    conf["data"]["diagnostic_variables"] = (diag.get("vars_3D", []) + diag.get("vars_2D", [])) if diag else []
+    Parses the preblock target channel_map (keys of the form
+    ``"source/field_type/dim/varname"``) and returns the unexpanded name lists
+    that populate ``conf["data"]["variables"]``, ``conf["data"]["surface_variables"]``,
+    and ``conf["data"]["diagnostic_variables"]``.
+
+    Returns:
+        (variables, surface_variables, diagnostic_variables)
+    """
+    variables = []
+    surface_variables = []
+    diagnostic_variables = []
+
+    for key in sorted(channel_map, key=lambda k: channel_map[k]["slice"].start):
+        parts = key.split("/")
+        if len(parts) < 4:
+            continue
+        field_type, dim, varname = parts[1], parts[2], parts[3]
+        if field_type == "prognostic":
+            if dim == "3d":
+                variables.append(varname)
+            else:
+                surface_variables.append(varname)
+        elif field_type == "diagnostic":
+            diagnostic_variables.append(varname)
+
+    return variables, surface_variables, diagnostic_variables
 
 
 def inject_postblock_info(conf: dict) -> None:


### PR DESCRIPTION
## Summary

- Removes `inject_flat_var_keys()` shim from `train_gen2.py`; replaces with a one-batch preblock probe that reads `metadata["target"]["_channel_map"]` from `ConcatToTensor` to populate `conf["data"]["variables"]`, `conf["data"]["surface_variables"]`, and `conf["data"]["diagnostic_variables"]` before loss and metrics are initialized
- Adds `extract_flat_keys_from_channel_map()` to `credit/trainers/utils.py` — the shared helper used by both trainer and rollout probes
- Removes `_inject_flat_schema()` from both rollout scripts (`rollout_to_netcdf_gen2.py`, `rollout_realtime_gen2.py`); replaces with `_set_output_conf()` using the same channel_map probe pattern. `level_ids` and `scaler_type` still read from source config (no channel_map equivalent)
- Rewrites `_inject_tracer_inds()` in both rollout scripts to use the flat keys set by `_set_output_conf()` instead of re-parsing the nested source config. Moves dataset construction before model loading so the probe runs first

## Unrelated smoke config fix

`smoke_gen2_casper.yml` and `smoke_gen2_multistep_casper.yml` had stale `dataset_type: "era5"` — this was left broken by d637004 ("Convert ERA5 to Local"), which renamed the registry key to `"local"`. We discovered it while running the smoke test to validate this PR and fixed it here. It is otherwise unrelated to the flat-key work.

## Note for @charlie-becker

`_inject_tracer_inds()` in both rollout scripts is still a shim — it computes channel indices for `TracerFixer` from the flat keys since the postblock doesn't derive them itself yet. Once the postblock config work is completed, `_inject_tracer_inds()` can be removed entirely. Each function has a `# TODO` marking the spot.

## Scope

V1 pipeline is unaffected. `metrics.py`, `losses/weighted_loss.py`, and `trainerERA5gen2.py` are untouched.

## Test plan

- [x] Smoke test `smoke_gen2_casper.yml` ran to completion on Casper V100 (job 3705386): 5 train batches + 2 validation batches, checkpoint saved
- [x] Log confirms correct extraction: `Configured from preblock metadata: 4 3D vars, 7 surface vars, 0 diagnostic vars`
- [x] Channel count matches previous runs: `C_in=74`, GPU memory footprint identical