### PR TITLE
Cbecker update

### DIFF
--- a/config/gen_2/examples/example-v2026.2.yml
+++ b/config/gen_2/examples/example-v2026.2.yml
@@ -66,7 +66,7 @@ data:
 
 
 # ---- USER SETTINGS: validation data ---- #
-data_valid:
+validation_data:
   source:
     ERA5_Validation:
       dataset_type: "local"

--- a/config/gen_2/examples/example-v2026.2.yml
+++ b/config/gen_2/examples/example-v2026.2.yml
@@ -21,7 +21,7 @@ seed: 1000
 data:
   source:
     ERA5:
-      dataset_type: "era5"
+      dataset_type: "local"
       level_coord: "level"
       levels: [ 1., 9., 19., 29., 39., 49., 59., 69., 79., 89., 97., 104., 111., 116., 122., 126., 131., 136. ]
       variables:
@@ -68,7 +68,8 @@ data:
 # ---- USER SETTINGS: validation data ---- #
 data_valid:
   source:
-    ERA5:
+    ERA5_Validation:
+      dataset_type: "local"
       level_coord: "level"
       levels: [ 1., 9., 19., 29., 39., 49., 59., 69., 79., 89., 97., 104., 111., 116., 122., 126., 131., 136. ]
       variables:

--- a/config/gen_2/examples/multi_source_data.yml
+++ b/config/gen_2/examples/multi_source_data.yml
@@ -50,14 +50,9 @@ preblocks:
       type: "log_transform"
       args:
           variables:
-                - 'ERA5_LowerAir/prognostic/3d/U'
-                - 'ERA5_LowerAir/prognostic/3d/V'
-                - 'ERA5_LowerAir/prognostic/3d/T'
                 - 'ERA5_LowerAir/prognostic/3d/Q'
                 - 'ERA5_LowerAir/prognostic/2d/SP'
-                - 'ERA5_LowerAir/prognostic/2d/t2m'
                 - 'ERA5_LowerAir/dynamic_forcing/2d/tsi'
-                - 'ERA5_LowerAir/static/2d/LSM'
           data_types:
             - 'input'
             - 'target'

--- a/config/gen_2/examples/wxformer_era5_025deg_6hr.yml
+++ b/config/gen_2/examples/wxformer_era5_025deg_6hr.yml
@@ -54,7 +54,7 @@ data:
   std_path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/mean_std/std_6h_1979_2019_13lev_0.25deg.nc'
 
 # Validation data block (same schema, different date range)
-data_valid:
+validation_data:
   source:
     ERA5_Validation:
       dataset_type: "local"

--- a/config/gen_2/examples/wxformer_era5_025deg_6hr.yml
+++ b/config/gen_2/examples/wxformer_era5_025deg_6hr.yml
@@ -13,7 +13,7 @@ seed: 1000
 data:
   source:
     ERA5:
-      dataset_type: "era5"
+      dataset_type: "local"
       level_coord: "level"
       levels: [ 25.5, 75.0, 125.0, 175.0, 225.0, 275.0, 350.0, 450.0, 550.0, 650.0, 775.0, 887.5, 962.5 ]
       variables:
@@ -56,7 +56,8 @@ data:
 # Validation data block (same schema, different date range)
 data_valid:
   source:
-    ERA5:
+    ERA5_Validation:
+      dataset_type: "local"
       level_coord: "level"
       levels: [ 25.5, 75.0, 125.0, 175.0, 225.0, 275.0, 350.0, 450.0, 550.0, 650.0, 775.0, 887.5, 962.5 ]
       variables:

--- a/config/gen_2/examples/wxformer_npj_era5_028deg.yml
+++ b/config/gen_2/examples/wxformer_npj_era5_028deg.yml
@@ -11,7 +11,7 @@ save_loc: '/glade/derecho/scratch/$USER/CREDIT_runs/wxformer_npj_1h'
 data:
   source:
     ERA5:
-      dataset_type: "era5"
+      dataset_type: "local"
       level_coord: "level"
       levels: [10, 30, 40, 50, 60, 70, 80, 90, 95, 100, 105, 110, 120, 130, 136, 137]
       variables:

--- a/config/gen_2/smoke/smoke_gen2_casper.yml
+++ b/config/gen_2/smoke/smoke_gen2_casper.yml
@@ -3,13 +3,13 @@
 # tsi from solar NC, static from static_norm_old.nc
 # Reduced model size and 2-year training window for quick Casper single-GPU validation.
 
-save_loc: '/glade/derecho/scratch/schreck/credit_tests/smoke_gen2'
+save_loc: '/glade/derecho/scratch/$USER/credit_tests/smoke_gen2'
 seed: 1000
 
 data:
   source:
     ERA5:
-      dataset_type: "era5"
+      dataset_type: "local"
       level_coord: "level"
       levels: [10, 30, 40, 50, 60, 70, 80, 90, 95, 100, 105, 110, 120, 130, 136, 137]
       variables:
@@ -145,7 +145,7 @@ trainer:
 
 predict:
     mode: none
-    save_forecast: '/glade/derecho/scratch/schreck/credit_tests/smoke_gen2/rollout'
+    save_forecast: '/glade/derecho/scratch/$USER/credit_tests/smoke_gen2/rollout'
     forecasts:
         type: "custom"
         start_year: 2017

--- a/config/gen_2/smoke/smoke_gen2_multistep_casper.yml
+++ b/config/gen_2/smoke/smoke_gen2_multistep_casper.yml
@@ -4,13 +4,13 @@
 # the full input from the previous x + y_pred.
 # Otherwise identical to smoke_gen2_casper.yml.
 
-save_loc: '/glade/work/schreck/runs/CREDIT_runs/smoke_gen2_multistep'
+save_loc: '/glade/work/$USER/runs/CREDIT_runs/smoke_gen2_multistep'
 seed: 1000
 
 data:
   source:
     ERA5:
-      dataset_type: "era5"
+      dataset_type: "local"
       level_coord: "level"
       levels: [1., 9., 19., 29., 39., 49., 59., 69., 79., 89., 97., 104., 111., 116., 122., 126., 131., 136.]
       variables:

--- a/config/gen_2/smoke/smoke_v2branch_casper.yml
+++ b/config/gen_2/smoke/smoke_v2branch_casper.yml
@@ -3,7 +3,7 @@
 #   upper-air+surface from SixHourly_y_TOTAL zarr, tsi from solar NC, static from static_norm_old.nc
 # Reduced model size and 2-year training window for quick Casper single-GPU validation.
 
-save_loc: '/glade/derecho/scratch/schreck/credit_tests/smoke_gen1'
+save_loc: '/glade/derecho/scratch/$USER/credit_tests/smoke_gen1'
 seed: 1000
 
 data:

--- a/credit/applications/train_gen2.py
+++ b/credit/applications/train_gen2.py
@@ -5,7 +5,7 @@ Gen2 training entry point for the nested ERA5 data schema.
 
 This script bypasses ``credit_main_parser`` entirely. It reads the config
 directly and assumes the new ``conf["data"]["source"]`` structure produced by
-``MultiSourceDataset`` / ``ERA5Dataset``.
+``MultiSourceDataset`` / ``BaseDataset``.
 
 For the legacy flat schema (v1), use ``applications/train.py``.
 """

--- a/credit/datasets/base_dataset.py
+++ b/credit/datasets/base_dataset.py
@@ -225,6 +225,11 @@ class BaseDataset(AbstractBaseDataset):
         if "mode" in self.curr_source_cfg:
             self.mode = self.curr_source_cfg["mode"]
 
+        # temporal_mode: None (default, exact timestamp match required) or
+        # "persist" (snap to last native timestamp via asof(); used for coarser sources)
+        self.temporal_mode: str | None = self.curr_source_cfg.get("temporal_mode")
+        self._persist_cache: dict = {}
+
         # Placeholder for static metadata
         self.static_metadata: dict[str, Any] = {}
 
@@ -245,6 +250,12 @@ class BaseDataset(AbstractBaseDataset):
     def __getitem__(self, args: tuple[pd.Timestamp, int]) -> dict[str, Any]:
         """Return a nested input/target sample dict.
 
+        When ``temporal_mode == "persist"``, the requested timestamp *t* is
+        snapped to the last native timestamp at-or-before *t* via
+        ``pd.DatetimeIndex.asof()``.  The result is cached so that multiple
+        fine-resolution master-clock ticks within the same native interval
+        only trigger a single file read.
+
         Args:
             args: ``(t, i)`` where *t* is the current timestamp (nanoseconds
                 or pd.Timestamp) and *i* is the within-sequence step index
@@ -259,8 +270,57 @@ class BaseDataset(AbstractBaseDataset):
         """
         t, i = args
         t = pd.Timestamp(t)
-        t_target = t + self.dt
 
+        if self.temporal_mode == "persist":
+            t_resolved = self._resolve_persist_timestamp(t)
+            cache_key = (t_resolved, i == 0)
+            if cache_key not in self._persist_cache:
+                # Evict entries from previous native intervals to keep cache small
+                stale = [k for k in self._persist_cache if k[0] != t_resolved]
+                for k in stale:
+                    del self._persist_cache[k]
+                self._persist_cache[cache_key] = self._load_sample(t_resolved, i)
+            return self._persist_cache[cache_key]
+
+        return self._load_sample(t, i)
+
+    def _resolve_persist_timestamp(self, t: pd.Timestamp) -> pd.Timestamp:
+        """Snap *t* to the last native timestamp at or before *t*.
+
+        Uses ``pd.DatetimeIndex.asof()`` so non-uniform or non-zero-aligned
+        cadences are handled correctly.
+
+        Args:
+            t: Master-clock timestamp to resolve.
+
+        Returns:
+            The last native timestamp ``<= t``.
+
+        Raises:
+            ValueError: If *t* is before the first native timestamp.
+        """
+        resolved = self.datetimes.asof(t)
+        if pd.isna(resolved):
+            raise ValueError(
+                f"Persist source '{self.curr_source_name}': timestamp {t} is before "
+                f"the first available native timestamp {self.datetimes[0]}."
+            )
+        return resolved
+
+    def _load_sample(self, t: pd.Timestamp, i: int) -> dict[str, Any]:
+        """Build and return the sample dict for timestamp *t* and step index *i*.
+
+        This is the inner implementation called by ``__getitem__``, separated
+        so the persist cache can call it without re-entering the dispatch logic.
+
+        Args:
+            t: Timestamp to load (already resolved for persist sources).
+            i: Within-sequence step index (0 = initial step).
+
+        Returns:
+            Sample dict with ``"input"``, ``"metadata"``, and optionally ``"target"``.
+        """
+        t_target = t + self.dt
         input_data: dict[str, Any] = {}
 
         # Dynamic forcing is loaded at every step
@@ -283,7 +343,6 @@ class BaseDataset(AbstractBaseDataset):
         if self.return_target:
             target_data: dict[str, Any] = {}
             for field_type in ("prognostic", "diagnostic"):
-                # if self.file_dict.get(field_type) and
                 if field_type in self.var_dict:
                     self._extract_field(field_type, t_target, target_data)
 

--- a/credit/datasets/base_dataset.py
+++ b/credit/datasets/base_dataset.py
@@ -225,9 +225,9 @@ class BaseDataset(AbstractBaseDataset):
         if "mode" in self.curr_source_cfg:
             self.mode = self.curr_source_cfg["mode"]
 
-        # temporal_mode: None (default, exact timestamp match required) or
+        # temporal_mode: "exact" (default, exact timestamp match required) or
         # "persist" (snap to last native timestamp via asof(); used for coarser sources)
-        self.temporal_mode: str | None = self.curr_source_cfg.get("temporal_mode")
+        self.temporal_mode: str = self.curr_source_cfg.get("temporal_mode", "exact")
         self._persist_cache: dict = {}
 
         # Placeholder for static metadata

--- a/credit/datasets/local.py
+++ b/credit/datasets/local.py
@@ -32,7 +32,8 @@ Output key format (flat, slash-delimited):
 
     field_type: "prognostic" | "dynamic_forcing" | "static" | "diagnostic"
     dim       : "2d"  (surface / single-level)
-                "3d"  (multi-level upper-air; requires level_coord + levels in config)
+                "3d"  (multi-level upper-air; requires level_coord in config;
+                       if levels is omitted all levels in the file are used)
     varname   : variable name as given in config (e.g. "T", "SP", "tsi")
 
 Tensor shapes (no batch dimension):
@@ -126,15 +127,13 @@ class LocalDataset(BaseDataset):
 
         self.dataset_type = "local"
         self.level_coord: str | None = self.curr_source_cfg.get("level_coord")
-        self.levels: list[int] | None = self.curr_source_cfg.get("levels")
+        self.levels: list | None = self.curr_source_cfg.get("levels")
         self.static_metadata: dict[str, Any] = {
             "levels": self.levels,
             "datetime_fmt": "unix_ns",
         }
         self.mode = "local"
         self.time_coord = self.curr_source_cfg.get("time_coord", "time")
-        # Initialize the field registration based on the provided config and populate
-        #   dictionary of variables and file paths for each field type
         self.init_register_all_fields()
 
     def _extract_field(
@@ -169,8 +168,8 @@ class LocalDataset(BaseDataset):
         with xr.open_dataset(_find_file(file_intervals, t)) as ds:
             # Select the time step; static fields have no time dim
             if self.time_coord in ds.dims:
-                if isinstance(ds.time.values[0], cftime.datetime):
-                    calendar = ds.time.values[0].calendar
+                if isinstance(ds[self.time_coord].values[0], cftime.datetime):
+                    calendar = ds[self.time_coord].values[0].calendar
                     t_sel = _to_cftime(t, calendar)
                 else:
                     t_sel = t
@@ -180,9 +179,13 @@ class LocalDataset(BaseDataset):
 
             # 3D variables: (n_levels, lat, lon) → (n_levels, 1, lat, lon)
             for vname in vars_3D:
-                if not self.level_coord or not self.levels:
-                    raise ValueError(f"Cannot load 3D variable '{vname}' without 'level_coord' and 'levels' in config.")
-                arr = ds_t[vname].sel({self.level_coord: self.levels}).values
+                if self.levels is None:
+                    arr = ds_t[vname].values
+                    if self.level_coord in ds_t.coords:
+                        self.levels = ds_t[self.level_coord].values.tolist()
+                        self.static_metadata["levels"] = self.levels
+                else:
+                    arr = ds_t[vname].sel({self.level_coord: self.levels}).values
                 tensor = torch.tensor(arr, dtype=torch.float32).unsqueeze(1)
                 key = self._get_field_name(field_type, "3d", vname)
                 sample[key] = tensor

--- a/credit/datasets/multi_source.py
+++ b/credit/datasets/multi_source.py
@@ -147,7 +147,7 @@ class MultiSourceDataset(AbstractBaseDataset):
             self.datasets[user_dataset_name] = cls(sub_config, return_target)
             logger.info(f"MultiSourceDataset: registered dataset '{user_dataset_name}' with class '{cls.__name__}'")
 
-        self.datetimes: pd.DatetimeIndex = self._intersect_timestamps()
+        self.datetimes: pd.DatetimeIndex = self._build_master_clock(config)
 
         self.static_metadata: dict[str, dict[str, Any]] = {
             name: ds.static_metadata for name, ds in self.datasets.items()
@@ -185,16 +185,56 @@ class MultiSourceDataset(AbstractBaseDataset):
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _intersect_timestamps(self) -> pd.DatetimeIndex:
-        """Return timestamps common to all active source datasets."""
+    def _build_master_clock(self, config: dict[str, Any]) -> pd.DatetimeIndex:
+        """Build the master sampling clock from the global config.
+
+        The clock is anchored to the global ``start_datetime``, ``end_datetime``,
+        and ``timestep``.  For each source:
+
+        - **Normal sources** (no ``temporal_mode``): the clock is filtered to
+          timestamps that exist exactly in that source's native datetimes.  A
+          warning is emitted when the source's native timestep differs from the
+          master clock timestep and ``temporal_mode`` is not set.
+        - **Persist sources** (``temporal_mode: persist``): the clock is only
+          clipped to the source's coverage range.  Fine-resolution master-clock
+          ticks are snapped to the last native timestamp inside
+          ``BaseDataset.__getitem__``.
+        """
         if not self.datasets:
             return pd.DatetimeIndex([])
 
-        sets: list[set[pd.Timestamp]] = [set(ds.datetimes) for ds in self.datasets.values()]
-        common = sets[0].intersection(*sets[1:])
-        if not common:
+        master_dt = pd.Timedelta(config["timestep"])
+        num_steps = config.get("forecast_len", 1)
+        master_start = pd.Timestamp(config["start_datetime"])
+        master_end = pd.Timestamp(config["end_datetime"])
+
+        master = pd.date_range(master_start, master_end - num_steps * master_dt, freq=master_dt)
+
+        source_cfg = config.get("source", {})
+        for name, ds in self.datasets.items():
+            if not len(ds.datetimes):
+                continue
+            temporal_mode = source_cfg.get(name, {}).get("temporal_mode")
+
+            if temporal_mode == "persist":
+                # Clip master clock to the source's coverage window only
+                ds_start = ds.datetimes[0]
+                ds_end = ds.datetimes[-1]
+                master = master[(master >= ds_start) & (master <= ds_end + ds.dt)]
+            else:
+                # Exact match required — warn if resolutions differ
+                if hasattr(ds, "dt") and ds.dt != master_dt:
+                    logger.warning(
+                        f"MultiSourceDataset: source '{name}' has timestep {ds.dt} which differs "
+                        f"from the master clock timestep {master_dt}, but 'temporal_mode' is not set. "
+                        "Consider setting temporal_mode: persist in the source config if this source "
+                        "should persist its last sample between master-clock ticks."
+                    )
+                master = master[master.isin(ds.datetimes)]
+
+        if not len(master):
             logger.warning(
-                "MultiSourceDataset: timestamp intersection across sources is empty. "
-                "Check that start_datetime/end_datetime overlap for all configured sources."
+                "MultiSourceDataset: master clock is empty after applying source constraints. "
+                "Check that start_datetime/end_datetime and timestep are consistent across sources."
             )
-        return pd.DatetimeIndex(sorted(common))
+        return master

--- a/credit/datasets/multi_source.py
+++ b/credit/datasets/multi_source.py
@@ -29,7 +29,7 @@ Usage::
 Extending with a new source::
 
     # In _SOURCE_REGISTRY, add:
-    "NewSource": NewSourceDataset,
+    "NEW_SOURCE": ("credit.datasets.new_source", "NewSourceDataset"),
 
     # The dataset class must accept (config, return_target) and expose
     # a ``datetimes`` attribute (pd.DatetimeIndex).
@@ -37,6 +37,7 @@ Extending with a new source::
 
 from __future__ import annotations
 
+import importlib
 import logging
 from typing import Any
 
@@ -44,26 +45,21 @@ import pandas as pd
 
 from credit.datasets.base_dataset import AbstractBaseDataset
 
-from credit.datasets.base_dataset import BaseDataset
-from credit.datasets.local import LocalDataset
-from credit.datasets.era5 import ARCOERA5Dataset
-from credit.datasets.mrms import MRMSDataset
-from credit.datasets.goes import GOESDataset
-from credit.datasets.hrrr import HRRRDataset
-
 logger = logging.getLogger(__name__)
 
-# Maps config["source"] keys to Dataset classes.
-# Add entries here to register new data sources.
-_SOURCE_REGISTRY: dict[str, type] = {
-    "BASE": BaseDataset,  # for placeholders, testing, and examples
-    "LOCAL": LocalDataset,
-    "ARCO_ERA5": ARCOERA5Dataset,
-    "MRMS": MRMSDataset,
-    "GOES": GOESDataset,
-    "HRRR": HRRRDataset,
-    "HRRR_NAT": HRRRDataset,
-    "HRRR_SUBH": HRRRDataset,
+# Maps config["source"] dataset_type keys to (module_path, class_name) pairs.
+# Modules are imported on first use so optional heavy dependencies (gcsfs,
+# herbie, s3fs, …) are never loaded unless that source type is actually
+# requested.  Add entries here to register new data sources.
+_SOURCE_REGISTRY: dict[str, tuple[str, str]] = {
+    "BASE": ("credit.datasets.base_dataset", "BaseDataset"),  # placeholders / testing
+    "LOCAL": ("credit.datasets.local", "LocalDataset"),
+    "ARCO_ERA5": ("credit.datasets.era5", "ARCOERA5Dataset"),
+    "MRMS": ("credit.datasets.mrms", "MRMSDataset"),
+    "GOES": ("credit.datasets.goes", "GOESDataset"),
+    "HRRR": ("credit.datasets.hrrr", "HRRRDataset"),
+    "HRRR_NAT": ("credit.datasets.hrrr", "HRRRDataset"),
+    "HRRR_SUBH": ("credit.datasets.hrrr", "HRRRDataset"),
 }
 
 
@@ -92,6 +88,9 @@ def route_to_dataset_class(source_cfg: dict[str, Any]) -> type:
     """
     Return the appropriate Dataset class based on the "dataset_type" field in the source config.
 
+    The module containing the class is imported lazily on first call so that
+    optional heavy dependencies are not loaded unless this source type is used.
+
     Args:
         source_cfg: Config dict for a single source (e.g. config["source"]["Example_ERA5"]).
 
@@ -104,12 +103,13 @@ def route_to_dataset_class(source_cfg: dict[str, Any]) -> type:
     dataset_type = source_cfg.get("dataset_type", "").upper()
     if not dataset_type:
         raise ValueError("Source config must contain a 'dataset_type' field.")
-    cls = _SOURCE_REGISTRY.get(dataset_type)
-    if not cls:
+    entry = _SOURCE_REGISTRY.get(dataset_type)
+    if not entry:
         raise ValueError(
             f"Unrecognized dataset_type '{dataset_type}' in source config. Must be one of: {list(_SOURCE_REGISTRY.keys())}"
         )
-    return cls
+    module_path, class_name = entry
+    return getattr(importlib.import_module(module_path), class_name)
 
 
 class MultiSourceDataset(AbstractBaseDataset):

--- a/credit/grid.py
+++ b/credit/grid.py
@@ -1,105 +1,437 @@
+"""
+scrip_generator.py
+==================
+Generate SCRIP-format NetCDF files for use with ESMFRegridWeightGen.
+
+Supports two grid types:
+    - Rectilinear  : 1D lon + 1D lat arrays (uniform, regional, or Gaussian spacing)
+    - Curvilinear  : 2D lon + 2D lat arrays (HRRR, GOES, ocean tripolar, etc.)
+
+All functions produce SCRIP files containing both cell centers and cell corners,
+making them compatible with all ESMFRegridWeightGen methods (bilinear, patch,
+nearest-neighbor, 1st- and 2nd-order conservative).
+
+Entry points
+------------
+    scrip_from_netcdf(nc_file, scrip_file, grid_name=None, mask_var=None)
+        Auto-detects grid type from file; preferred entry point.
+
+    scrip_from_rectilinear(lon_1d, lat_1d, grid_name, grid_file, mask=None)
+    scrip_from_curvilinear(lon_2d, lat_2d, grid_name, grid_file, mask=None)
+        Direct API for when coordinates are already in hand.
+
+Dependencies
+------------
+    numpy, xarray
+"""
+
 import numpy as np
 import xarray as xr
 
 
-def scrip_from_latlon_grid(lons, lats, grid_name, grid_file):
+# ---------------------------------------------------------------------------
+# Shared SCRIP writer
+# ---------------------------------------------------------------------------
+
+
+def _write_scrip(lon_centers, lat_centers, lon_corners, lat_corners, grid_name, grid_file, mask=None, grid_dims=None):
     """
-    Generate a SCRIP netCDF file defining the centers and corners of each element in a latitude-longitude grid.
-    This function supports both equiangular lat-lon grids and full Gaussian grids.
+    Write a SCRIP-format NetCDF file from pre-computed center and corner arrays.
 
-    SCRIP is a legacy software package for regridding model output. The SCRIP grid format is supported by ESMF for
-    regridding definitions. See https://github.com/SCRIP-Project/SCRIP/blob/master/SCRIP/doc/SCRIPusers.pdf for
-    details about SCRIP and
+    Parameters
+    ----------
+    lon_centers : np.ndarray, shape (grid_size,)
+    lat_centers : np.ndarray, shape (grid_size,)
+    lon_corners : np.ndarray, shape (grid_size, 4)
+        Corner longitudes in CCW order: SW, SE, NE, NW.
+    lat_corners : np.ndarray, shape (grid_size, 4)
+        Corner latitudes in CCW order: SW, SE, NE, NW.
+    grid_name   : str
+    grid_file   : str
+    mask        : np.ndarray of int32, shape (grid_size,), optional
+        1 = valid, 0 = masked.  Defaults to all-ones (fully unmasked).
 
-    Args:
-        lons: 1D array of longitudes
-        lats: 1D array of latitudes
-        grid_name: Name of the output grid map
-        grid_file: path to netCDF file containing the grid information
-
-    Returns:
-        scrip_ds: xr.Dataset containing grid information in SCRIP format.
+    Returns
+    -------
+    xr.Dataset written to grid_file.
     """
-    dlat = np.abs(lats[1:] - lats[:-1])
-    dlat = np.append(dlat, dlat[-1])
-    dlon = np.abs(lons[1:] - lons[:-1])
-    dlon = np.append(dlon, dlon[-1])
-    lon_grid, lat_grid = np.meshgrid(lons, lats)
-    grid_indices = np.indices(lat_grid.shape)
-    row_indices = grid_indices[0].ravel()
-    col_indices = grid_indices[1].ravel()
-    grid_size = lat_grid.size
-    grid_corners = 4
-    grid_dims = xr.DataArray(
-        np.array(lat_grid.shape[::-1], dtype=np.int32),
-        dims=("grid_rank",),
-        name="grid_dims",
-    )
-    grid_center_lon = xr.DataArray(
-        lon_grid.ravel(),
-        dims=("grid_size",),
-        name="grid_center_lon",
-        attrs=dict(units="degrees"),
-    )
-    grid_center_lat = xr.DataArray(
-        lat_grid.ravel(),
-        dims=("grid_size",),
-        name="grid_center_lat",
-        attrs=dict(units="degrees"),
-    )
-    grid_imask = xr.DataArray(
-        np.ones(grid_size, dtype=np.int32),
-        dims=("grid_size",),
-        name="grid_imask",
-        attrs=dict(units="unitless"),
-    )
-    grid_corner_lat = xr.DataArray(
-        np.zeros((grid_size, grid_corners)),
-        dims=("grid_size", "grid_corners"),
-        name="grid_corner_lat",
-        attrs=dict(units="degrees"),
-    )
-    grid_corner_lon = xr.DataArray(
-        np.zeros((grid_size, grid_corners)),
-        dims=("grid_size", "grid_corners"),
-        name="grid_corner_lat",
-        attrs=dict(units="degrees"),
-    )
-    grid_corner_lon.encoding["_FillValue"] = None
-    grid_corner_lat.encoding["_FillValue"] = None
-    grid_center_lat.encoding["_FillValue"] = None
-    grid_center_lon.encoding["_FillValue"] = None
-    # corners are defined in counter clockwise order starting from the bottom left corner
-    lon_sign = [-1, 1, 1, -1]
-    lat_sign = [-1, -1, 1, 1]
-    for i in range(grid_corners):
-        grid_corner_lat[:, i] = np.minimum(
-            np.maximum(lat_grid.ravel() + lat_sign[i] * dlat[row_indices] / 2.0, -90),
-            90,
-        )
-        grid_corner_lon[:, i] = lon_grid.ravel() + lon_sign[i] * dlon[col_indices] / 2.0
-    scrip_ds = xr.Dataset(
+    grid_size = lon_centers.size
+    if mask is None:
+        mask = np.ones(grid_size, dtype=np.int32)
+    else:
+        mask = np.asarray(mask, dtype=np.int32).ravel()
+
+    # grid_dims: [nlon, nlat] for structured grids (SCRIP convention: lon first).
+    # ESMF uses len(grid_dims) to determine grid rank: 2 → structured (bilinear
+    # works at poles without extra flags), 1 → unstructured.
+    if grid_dims is None:
+        _grid_dims = np.array([grid_size], dtype=np.int32)
+    else:
+        _grid_dims = np.asarray(grid_dims, dtype=np.int32)
+
+    def _da(data, dims, name, units):
+        da = xr.DataArray(data, dims=dims, name=name, attrs={"units": units})
+        if np.issubdtype(data.dtype, np.floating):
+            da.encoding["_FillValue"] = None
+        return da
+
+    ds = xr.Dataset(
         {
-            "grid_dims": grid_dims,
-            "grid_center_lon": grid_center_lon,
-            "grid_center_lat": grid_center_lat,
-            "grid_imask": grid_imask,
-            "grid_corner_lat": grid_corner_lat,
-            "grid_corner_lon": grid_corner_lon,
+            "grid_dims": _da(_grid_dims, ("grid_rank",), "grid_dims", "unitless"),
+            "grid_center_lon": _da(lon_centers.astype(np.float64), ("grid_size",), "grid_center_lon", "degrees"),
+            "grid_center_lat": _da(lat_centers.astype(np.float64), ("grid_size",), "grid_center_lat", "degrees"),
+            "grid_imask": _da(mask, ("grid_size",), "grid_imask", "unitless"),
+            "grid_corner_lon": _da(
+                lon_corners.astype(np.float64), ("grid_size", "grid_corners"), "grid_corner_lon", "degrees"
+            ),
+            "grid_corner_lat": _da(
+                lat_corners.astype(np.float64), ("grid_size", "grid_corners"), "grid_corner_lat", "degrees"
+            ),
         }
     )
-    scrip_ds.attrs["title"] = grid_name
-    scrip_ds.to_netcdf(grid_file, format="NETCDF3_64BIT")
-    return scrip_ds
+    ds.attrs["title"] = grid_name
+    ds.to_netcdf(grid_file, format="NETCDF3_64BIT")
+    return ds
 
+
+# ---------------------------------------------------------------------------
+# Corner computation
+# ---------------------------------------------------------------------------
+
+
+def _corners_rectilinear(lons_1d, lats_1d):
+    """
+    Compute cell corners for a rectilinear grid from 1D center arrays.
+
+    Edges are midpoints between adjacent centers.  Boundary edges are
+    extrapolated using the nearest interior spacing.  Latitude edges are
+    clamped to [-90, 90].  Longitude edges are kept monotonically increasing
+    (not wrapped) so that west < east is guaranteed for every cell.
+
+    Returns
+    -------
+    lon_corners, lat_corners : np.ndarray, shape (nlat*nlon, 4)
+        CCW order: SW, SE, NE, NW.
+    """
+    nlat, nlon = lats_1d.size, lons_1d.size
+
+    lat_edges = np.empty(nlat + 1)
+    lat_edges[1:-1] = 0.5 * (lats_1d[:-1] + lats_1d[1:])
+    lat_edges[0] = lats_1d[0] - (lat_edges[1] - lats_1d[0])
+    lat_edges[-1] = lats_1d[-1] + (lats_1d[-1] - lat_edges[-2])
+    lat_edges = np.clip(lat_edges, -90.0, 90.0)
+
+    lon_edges = np.empty(nlon + 1)
+    lon_edges[1:-1] = 0.5 * (lons_1d[:-1] + lons_1d[1:])
+    lon_edges[0] = lons_1d[0] - (lon_edges[1] - lons_1d[0])
+    lon_edges[-1] = lons_1d[-1] + (lons_1d[-1] - lon_edges[-2])
+
+    jj, ii = np.indices((nlat, nlon))
+    row, col = jj.ravel(), ii.ravel()
+
+    south = lat_edges[row]
+    north = lat_edges[row + 1]
+    west = lon_edges[col]
+    east = lon_edges[col + 1]
+
+    lat_corners = np.stack([south, south, north, north], axis=1)
+    lon_corners = np.stack([west, east, east, west], axis=1)
+    return lon_corners, lat_corners
+
+
+def _corners_curvilinear(lons_2d, lats_2d):
+    """
+    Compute cell corners for a curvilinear grid from 2D center arrays.
+
+    Interior corners are the average of the four surrounding cell centers.
+    Boundary corners are extrapolated using a one-cell ghost layer.
+
+    Returns
+    -------
+    lon_corners, lat_corners : np.ndarray, shape (ny*nx, 4)
+        CCW order: SW, SE, NE, NW.
+    """
+    ny, nx = lons_2d.shape
+
+    def _extend(arr):
+        """Pad array by one cell on all sides via linear extrapolation."""
+        out = np.empty((ny + 2, nx + 2), dtype=np.float64)
+        out[1:-1, 1:-1] = arr
+        out[0, 1:-1] = 2 * arr[0, :] - arr[1, :]
+        out[-1, 1:-1] = 2 * arr[-1, :] - arr[-2, :]
+        out[1:-1, 0] = 2 * arr[:, 0] - arr[:, 1]
+        out[1:-1, -1] = 2 * arr[:, -1] - arr[:, -2]
+        out[0, 0] = 2 * arr[0, 0] - arr[1, 1]
+        out[0, -1] = 2 * arr[0, -1] - arr[1, -2]
+        out[-1, 0] = 2 * arr[-1, 0] - arr[-2, 1]
+        out[-1, -1] = 2 * arr[-1, -1] - arr[-2, -2]
+        return out
+
+    lon_ext = _extend(lons_2d)
+    lat_ext = _extend(lats_2d)
+
+    # Average four surrounding centers to get corner positions
+    c_lon = 0.25 * (lon_ext[:-1, :-1] + lon_ext[:-1, 1:] + lon_ext[1:, :-1] + lon_ext[1:, 1:])
+    c_lat = 0.25 * (lat_ext[:-1, :-1] + lat_ext[:-1, 1:] + lat_ext[1:, :-1] + lat_ext[1:, 1:])
+
+    jj, ii = np.indices((ny, nx))
+    j, i = jj.ravel(), ii.ravel()
+
+    lon_corners = np.stack([c_lon[j, i], c_lon[j, i + 1], c_lon[j + 1, i + 1], c_lon[j + 1, i]], axis=1)
+    lat_corners = np.stack([c_lat[j, i], c_lat[j, i + 1], c_lat[j + 1, i + 1], c_lat[j + 1, i]], axis=1)
+    return lon_corners, lat_corners
+
+
+# ---------------------------------------------------------------------------
+# Coordinate detection  (used by scrip_from_netcdf)
+# ---------------------------------------------------------------------------
+
+# Supported name pairs in priority order: (lon_name, lat_name)
+_COORD_CANDIDATES = [
+    ("longitude", "latitude"),
+    ("lon", "lat"),
+]
+
+
+def _find_coord_pair(ds):
+    """
+    Find a lon/lat coordinate pair in an xr.Dataset.
+
+    Searches _COORD_CANDIDATES in order across both ds.coords and ds.data_vars.
+
+    Returns
+    -------
+    (lon_array, lat_array, lon_name, lat_name)
+
+    Raises
+    ------
+    ValueError if no recognised pair is found.
+    """
+    all_names = set(ds.data_vars) | set(ds.coords)
+    for lon_name, lat_name in _COORD_CANDIDATES:
+        if lon_name in all_names and lat_name in all_names:
+            return (
+                ds[lon_name].values.astype(float),
+                ds[lat_name].values.astype(float),
+                lon_name,
+                lat_name,
+            )
+
+    raise ValueError(
+        "Could not find a recognised lon/lat coordinate pair.\n"
+        f"Expected one of: {_COORD_CANDIDATES}\n"
+        f"Available names: {sorted(all_names)}\n"
+        "Rename your coordinates or call scrip_from_rectilinear / "
+        "scrip_from_curvilinear directly."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def scrip_from_rectilinear(lon_1d, lat_1d, grid_name, grid_file, mask=None):
+    """
+    Generate a SCRIP file for a rectilinear (regular lat/lon) grid.
+
+    Parameters
+    ----------
+    lon_1d    : array-like, shape (nlon,)
+    lat_1d    : array-like, shape (nlat,)
+    grid_name : str
+    grid_file : str
+    mask      : array-like, shape (nlat, nlon), optional  1=valid, 0=masked.
+
+    Returns
+    -------
+    xr.Dataset
+    """
+    lons = np.mod(np.asarray(lon_1d, dtype=float), 360.0)
+    lons = lons[np.argsort(lons)]
+    lats = np.asarray(lat_1d, dtype=float)
+    lats = lats[np.argsort(lats)]
+
+    lon_corners, lat_corners = _corners_rectilinear(lons, lats)
+    lon_grid, lat_grid = np.meshgrid(lons, lats)
+
+    flat_mask = np.asarray(mask, dtype=np.int32).ravel() if mask is not None else None
+
+    return _write_scrip(
+        lon_grid.ravel(),
+        lat_grid.ravel(),
+        lon_corners,
+        lat_corners,
+        grid_name,
+        grid_file,
+        mask=flat_mask,
+        grid_dims=np.array([lons.size, lats.size], dtype=np.int32),  # [nlon, nlat]
+    )
+
+
+def scrip_from_curvilinear(lon_2d, lat_2d, grid_name, grid_file, mask=None):
+    """
+    Generate a SCRIP file for a curvilinear grid.
+
+    Parameters
+    ----------
+    lon_2d    : array-like, shape (ny, nx)
+    lat_2d    : array-like, shape (ny, nx)
+    grid_name : str
+    grid_file : str
+    mask      : array-like, shape (ny, nx), optional  1=valid, 0=masked.
+
+    Returns
+    -------
+    xr.Dataset
+    """
+    lon_2d = np.asarray(lon_2d, dtype=float)
+    lat_2d = np.asarray(lat_2d, dtype=float)
+    assert lon_2d.shape == lat_2d.shape, "lon_2d and lat_2d must have the same shape"
+    assert lon_2d.ndim == 2, "lon_2d and lat_2d must be 2D arrays"
+
+    lon_corners, lat_corners = _corners_curvilinear(lon_2d, lat_2d)
+
+    flat_mask = np.asarray(mask, dtype=np.int32).ravel() if mask is not None else None
+
+    ny, nx = lon_2d.shape
+    return _write_scrip(
+        lon_2d.ravel(),
+        lat_2d.ravel(),
+        lon_corners,
+        lat_corners,
+        grid_name,
+        grid_file,
+        mask=flat_mask,
+        grid_dims=np.array([nx, ny], dtype=np.int32),  # [nx, ny] — lon dim first
+    )
+
+
+def scrip_from_netcdf(nc_file, scrip_file, grid_name=None, mask_var=None):
+    """
+    Auto-detect grid type from a NetCDF file and write a SCRIP file.
+
+    Coordinate names supported: lon/lat, longitude/latitude.
+    1D coordinates → rectilinear.  2D coordinates → curvilinear.
+
+    Parameters
+    ----------
+    nc_file    : str   Path to input NetCDF file.
+    scrip_file : str   Path for output SCRIP file.
+    grid_name  : str, optional  Defaults to the input filename stem.
+    mask_var   : str, optional  Variable to use as mask (1=valid, 0=masked).
+
+    Returns
+    -------
+    xr.Dataset
+    """
+    import os
+
+    if not os.path.exists(nc_file):
+        raise FileNotFoundError(f"Input file not found: {nc_file}")
+
+    if grid_name is None:
+        grid_name = os.path.splitext(os.path.basename(nc_file))[0]
+
+    ds = xr.open_dataset(nc_file)
+
+    lon_arr, lat_arr, lon_name, lat_name = _find_coord_pair(ds)
+    print(f"[scrip_from_netcdf] Coordinates : {lon_name} / {lat_name}")
+
+    if lon_arr.ndim == 1 and lat_arr.ndim == 1:
+        grid_type = "rectilinear"
+    elif lon_arr.ndim == 2 and lat_arr.ndim == 2:
+        grid_type = "curvilinear"
+    else:
+        raise ValueError(
+            f"Unexpected coordinate shapes: lon={lon_arr.shape}, lat={lat_arr.shape}. "
+            "Expected both 1D (rectilinear) or both 2D (curvilinear)."
+        )
+    print(f"[scrip_from_netcdf] Grid type   : {grid_type} (lon shape: {lon_arr.shape})")
+
+    mask = None
+    if mask_var is not None:
+        if mask_var not in ds:
+            raise ValueError(
+                f"mask_var '{mask_var}' not found. Available: {sorted(set(ds.data_vars) | set(ds.coords))}"
+            )
+        mask = ds[mask_var].values.astype(np.int32)
+
+    ds.close()
+
+    if grid_type == "rectilinear":
+        result = scrip_from_rectilinear(lon_arr, lat_arr, grid_name, scrip_file, mask=mask)
+    else:
+        result = scrip_from_curvilinear(lon_arr, lat_arr, grid_name, scrip_file, mask=mask)
+
+    print(f"[scrip_from_netcdf] SCRIP written: {scrip_file}")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    grid_file = "/glade/derecho/scratch/kjmayer/CREDIT_runs/S2Socnlndatm_MLdata/AIWQ_inits/b.e21.CREDIT_climate_branch_allvars_GEFSicefracandsst_2025-08-08.zarr"
-    ds = xr.open_zarr(grid_file)
-    print(ds)
-    scrip_from_latlon_grid(
-        ds["longitude"].values,
-        ds["latitude"].values,
-        "camulator_grid",
-        "/glade/work/dgagne/camulator_grid_scrip.nc",
-    )
+    import os
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate a SCRIP-format file from a NetCDF grid file.")
+    parser.add_argument("-i", "--input", default=None, help="Input NetCDF file path")
+    parser.add_argument("-o", "--output", default=None, help="Output SCRIP file path")
+    parser.add_argument("-n", "--name", default=None, help="Grid name (default: input filename stem)")
+    parser.add_argument("-m", "--mask", default=None, help="Mask variable name in input file")
+    parser.add_argument("--test", action="store_true", help="Run synthetic tests")
+    args = parser.parse_args()
+
+    if args.input and args.output:
+        scrip_from_netcdf(args.input, args.output, grid_name=args.name, mask_var=args.mask)
+
+    elif args.test:
+        outdir = "/tmp/scrip_test"
+        os.makedirs(outdir, exist_ok=True)
+
+        # Rectilinear
+        scrip_from_rectilinear(
+            np.arange(0.0, 360.0, 1.0),
+            np.arange(-90.0, 91.0, 1.0),
+            "test_rectilinear",
+            f"{outdir}/test_rectilinear_scrip.nc",
+        )
+        print("Rectilinear SCRIP written.")
+
+        # Curvilinear
+        lo = np.linspace(-134.0, -60.0, 64)
+        la = np.linspace(21.0, 52.0, 64)
+        lo2, la2 = np.meshgrid(lo, la)
+        lo2 += 0.01 * np.sin(np.radians(la2))
+        la2 += 0.01 * np.cos(np.radians(lo2))
+        scrip_from_curvilinear(lo2, la2, "test_curvilinear", f"{outdir}/test_curvilinear_scrip.nc")
+        print("Curvilinear SCRIP written.")
+
+        # scrip_from_netcdf: rectilinear (lon/lat names)
+        lon_s, lat_s = np.arange(0.0, 10.0, 1.0), np.arange(30.0, 40.0, 1.0)
+        ds_r = xr.Dataset(
+            {"t": (["lat", "lon"], np.random.randn(lat_s.size, lon_s.size))},
+            coords={"lon": lon_s, "lat": lat_s},
+        )
+        rect_nc = f"{outdir}/synthetic_rect.nc"
+        ds_r.to_netcdf(rect_nc)
+        print("\n--- scrip_from_netcdf: rectilinear ---")
+        scrip_from_netcdf(rect_nc, f"{outdir}/auto_rect_scrip.nc")
+
+        # scrip_from_netcdf: curvilinear (longitude/latitude names)
+        lo2s, la2s = lo2[:8, :10].copy(), la2[:8, :10].copy()
+        ds_c = xr.Dataset(
+            {"r": (["y", "x"], np.random.randn(8, 10))},
+            coords={"longitude": (["y", "x"], lo2s), "latitude": (["y", "x"], la2s)},
+        )
+        curv_nc = f"{outdir}/synthetic_curv.nc"
+        ds_c.to_netcdf(curv_nc)
+        print("\n--- scrip_from_netcdf: curvilinear ---")
+        scrip_from_netcdf(curv_nc, f"{outdir}/auto_curv_scrip.nc")
+
+        print(f"\nAll test SCRIP files written to {outdir}/")
+
+    else:
+        parser.print_help()

--- a/scripts/multi_source_example.py
+++ b/scripts/multi_source_example.py
@@ -9,8 +9,8 @@ import torch
 import numpy as np
 
 BASE_DIR = pathlib.Path(__file__).resolve().parent
-config_path = BASE_DIR.parent / "config" / "gen_2" / "examples" / "multi_source_data.yaml"
-# config_path = BASE_DIR.parent / "config" / "multi_source_data_local.yaml"
+config_path = BASE_DIR.parent / "config" / "gen_2" / "examples" / "multi_source_data.yml"
+# config_path = BASE_DIR.parent / "config" / "multi_source_data_local.yml"
 
 with open(config_path, "r") as f:
     config = yaml.safe_load(f)
@@ -28,8 +28,10 @@ print(sample["input"]["ERA5_UpperAir"].keys())
 preblocks = build_preblocks(config["preblocks"])
 batch = apply_preblocks(preblocks, sample)
 print("BATCH KEYS:", batch.keys())
-print(batch["input"].shape)
-print(batch["target"].shape)
+print("Input shape:", batch["input"].shape)
+print("Target shape:", batch["target"].shape)
+target_shape = batch["target"].shape
+
 print("METADATA KEYS:", batch["metadata"].keys())
 print("METADATA KEYS:", batch["metadata"]["input"].keys())
 print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"].keys())
@@ -37,7 +39,7 @@ print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"]["datetime"])
 # print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['target']['_channel_map']['ERA5_LowerAir/prognostic/3d/V'].keys())
 # print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['input']['_channel_map']['ERA5_LowerAir/prognostic/3d/V']['slice'])
 
-fake_prediction = torch.tensor(np.random.normal(0, 1, (4, 68, 1, 192, 288)))
+fake_prediction = torch.tensor(np.random.normal(0, 1, target_shape))
 batch["prediction"] = fake_prediction
 sample["prediction"] = fake_prediction
 

--- a/scripts/multi_source_example.py
+++ b/scripts/multi_source_example.py
@@ -3,45 +3,43 @@ import pathlib
 from credit.datasets.multi_source import MultiSourceDataset
 from credit.samplers import DistributedMultiStepBatchSampler
 from torch.utils.data import DataLoader
-from credit.preblock import build_preblocks, apply_preblocks
-from credit.postblock import build_postblocks, apply_postblocks
-import torch
-import numpy as np
 
 BASE_DIR = pathlib.Path(__file__).resolve().parent
-config_path = BASE_DIR.parent / "config" / "gen_2" / "examples" / "multi_source_data.yaml"
+# config_path = BASE_DIR.parent / "config" / "gen_2" / "examples" / "multi_source_data.yml"
 # config_path = BASE_DIR.parent / "config" / "multi_source_data_local.yaml"
+config_path = BASE_DIR.parent / "config" / "persist.yml"
+
 
 with open(config_path, "r") as f:
     config = yaml.safe_load(f)
 
 nfs = config["data"]["forecast_len"]
-ms_dataset = MultiSourceDataset(config["data"], return_target=True)
+ms_dataset = MultiSourceDataset(config["data"], return_target=False)
 ms_sampler = DistributedMultiStepBatchSampler(
-    ms_dataset, batch_size=4, num_forecast_steps=nfs, shuffle=True, num_replicas=1, rank=0
+    ms_dataset, batch_size=2, num_forecast_steps=nfs, shuffle=True, num_replicas=1, rank=0
 )
 ms_loader = DataLoader(ms_dataset, batch_sampler=ms_sampler, num_workers=0, pin_memory=False, prefetch_factor=None)
 sample = next(iter(ms_loader))
 print(sample.keys())
 print(sample["input"].keys())
-print(sample["input"]["ERA5_UpperAir"].keys())
-preblocks = build_preblocks(config["preblocks"])
-batch = apply_preblocks(preblocks, sample)
-print("BATCH KEYS:", batch.keys())
-print(batch["input"].shape)
-print(batch["target"].shape)
-print("METADATA KEYS:", batch["metadata"].keys())
-print("METADATA KEYS:", batch["metadata"]["input"].keys())
-print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"].keys())
-print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"]["datetime"])
-# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['target']['_channel_map']['ERA5_LowerAir/prognostic/3d/V'].keys())
-# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['input']['_channel_map']['ERA5_LowerAir/prognostic/3d/V']['slice'])
-
-fake_prediction = torch.tensor(np.random.normal(0, 1, (4, 68, 1, 192, 288)))
-batch["prediction"] = fake_prediction
-sample["prediction"] = fake_prediction
-
-postblocks = build_postblocks(config["postblocks"])
-postbatch = apply_postblocks(postblocks, batch)
-print("POSTBATCH KEYS:", postbatch.keys())
-print(postbatch["prediction"]["ERA5_UpperAir"].keys())
+# print(sample["input"]["ERA5_UpperAir"].keys())
+# preblocks = build_preblocks(config["preblocks"])
+# batch = apply_preblocks(preblocks, sample)
+# print("BATCH KEYS:", batch.keys())
+# print(batch["input"].shape)
+# print(batch["target"].shape)
+# print("METADATA KEYS:", batch["metadata"].keys())
+# print("METADATA KEYS:", batch["metadata"]["input"].keys())
+# print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"].keys())
+# print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"]["datetime"])
+# # print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['target']['_channel_map']['ERA5_LowerAir/prognostic/3d/V'].keys())
+# # print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['input']['_channel_map']['ERA5_LowerAir/prognostic/3d/V']['slice'])
+#
+# fake_prediction = torch.tensor(np.random.normal(0, 1, (4, 68, 1, 192, 288)))
+# batch["prediction"] = fake_prediction
+# sample["prediction"] = fake_prediction
+#
+# postblocks = build_postblocks(config["postblocks"])
+# postbatch = apply_postblocks(postblocks, batch)
+# print("POSTBATCH KEYS:", postbatch.keys())
+# print(postbatch["prediction"]["ERA5_UpperAir"].keys())

--- a/scripts/multi_source_example.py
+++ b/scripts/multi_source_example.py
@@ -3,43 +3,45 @@ import pathlib
 from credit.datasets.multi_source import MultiSourceDataset
 from credit.samplers import DistributedMultiStepBatchSampler
 from torch.utils.data import DataLoader
+from credit.preblock import build_preblocks, apply_preblocks
+from credit.postblock import build_postblocks, apply_postblocks
+import torch
+import numpy as np
 
 BASE_DIR = pathlib.Path(__file__).resolve().parent
-# config_path = BASE_DIR.parent / "config" / "gen_2" / "examples" / "multi_source_data.yml"
+config_path = BASE_DIR.parent / "config" / "gen_2" / "examples" / "multi_source_data.yaml"
 # config_path = BASE_DIR.parent / "config" / "multi_source_data_local.yaml"
-config_path = BASE_DIR.parent / "config" / "persist.yml"
-
 
 with open(config_path, "r") as f:
     config = yaml.safe_load(f)
 
 nfs = config["data"]["forecast_len"]
-ms_dataset = MultiSourceDataset(config["data"], return_target=False)
+ms_dataset = MultiSourceDataset(config["data"], return_target=True)
 ms_sampler = DistributedMultiStepBatchSampler(
-    ms_dataset, batch_size=2, num_forecast_steps=nfs, shuffle=True, num_replicas=1, rank=0
+    ms_dataset, batch_size=4, num_forecast_steps=nfs, shuffle=True, num_replicas=1, rank=0
 )
 ms_loader = DataLoader(ms_dataset, batch_sampler=ms_sampler, num_workers=0, pin_memory=False, prefetch_factor=None)
 sample = next(iter(ms_loader))
 print(sample.keys())
 print(sample["input"].keys())
-# print(sample["input"]["ERA5_UpperAir"].keys())
-# preblocks = build_preblocks(config["preblocks"])
-# batch = apply_preblocks(preblocks, sample)
-# print("BATCH KEYS:", batch.keys())
-# print(batch["input"].shape)
-# print(batch["target"].shape)
-# print("METADATA KEYS:", batch["metadata"].keys())
-# print("METADATA KEYS:", batch["metadata"]["input"].keys())
-# print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"].keys())
-# print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"]["datetime"])
-# # print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['target']['_channel_map']['ERA5_LowerAir/prognostic/3d/V'].keys())
-# # print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['input']['_channel_map']['ERA5_LowerAir/prognostic/3d/V']['slice'])
-#
-# fake_prediction = torch.tensor(np.random.normal(0, 1, (4, 68, 1, 192, 288)))
-# batch["prediction"] = fake_prediction
-# sample["prediction"] = fake_prediction
-#
-# postblocks = build_postblocks(config["postblocks"])
-# postbatch = apply_postblocks(postblocks, batch)
-# print("POSTBATCH KEYS:", postbatch.keys())
-# print(postbatch["prediction"]["ERA5_UpperAir"].keys())
+print(sample["input"]["ERA5_UpperAir"].keys())
+preblocks = build_preblocks(config["preblocks"])
+batch = apply_preblocks(preblocks, sample)
+print("BATCH KEYS:", batch.keys())
+print(batch["input"].shape)
+print(batch["target"].shape)
+print("METADATA KEYS:", batch["metadata"].keys())
+print("METADATA KEYS:", batch["metadata"]["input"].keys())
+print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"].keys())
+print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"]["datetime"])
+# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['target']['_channel_map']['ERA5_LowerAir/prognostic/3d/V'].keys())
+# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['input']['_channel_map']['ERA5_LowerAir/prognostic/3d/V']['slice'])
+
+fake_prediction = torch.tensor(np.random.normal(0, 1, (4, 68, 1, 192, 288)))
+batch["prediction"] = fake_prediction
+sample["prediction"] = fake_prediction
+
+postblocks = build_postblocks(config["postblocks"])
+postbatch = apply_postblocks(postblocks, batch)
+print("POSTBATCH KEYS:", postbatch.keys())
+print(postbatch["prediction"]["ERA5_UpperAir"].keys())

--- a/tests/multi_source_dataset_test.py
+++ b/tests/multi_source_dataset_test.py
@@ -265,6 +265,100 @@ def test_multi_source_timestamp_intersection_time_subsets(multi_config_time_subs
     assert ds.datetimes[-1] == DATETIMES_SUBSET[-2]
 
 
+@pytest.fixture
+def persist_config() -> dict[str, Any]:
+    """Config with a 6h master clock and a 12h-resolution persist source."""
+    return {
+        "source": {
+            "Base1": {
+                "dataset_type": "base",
+                "variables": {
+                    "prognostic": {"vars_3D": ["T"], "vars_2D": ["t2m"]},
+                },
+            },
+            "Base2": {
+                "dataset_type": "base",
+                "variables": {"dynamic_forcing": {"vars_2D": ["precip"]}},
+                "timestep": "12h",
+                "temporal_mode": "persist",
+            },
+        },
+        "timestep": "6h",
+        "forecast_len": 1,
+        "start_datetime": "2024-01-01",
+        "end_datetime": "2024-01-03",
+    }
+
+
+def test_persist_master_clock_retains_fine_ticks(persist_config):
+    """Persist sources clip the master clock to coverage range but don't filter
+    to exact timestamps, so a 6h master clock survives even when a persist source
+    has 12h native resolution."""
+    ds = MultiSourceDataset(persist_config)
+    # Expected: all 6h ticks from start to end - 1 * 6h
+    expected_count = len(
+        pd.date_range(
+            persist_config["start_datetime"],
+            pd.Timestamp(persist_config["end_datetime"]) - pd.Timedelta(persist_config["timestep"]),
+            freq=persist_config["timestep"],
+        )
+    )
+    assert len(ds.datetimes) == expected_count
+    # Consecutive ticks are 6h apart, not 12h
+    assert (ds.datetimes[1] - ds.datetimes[0]) == pd.Timedelta("6h")
+
+
+def test_persist_source_returns_data_at_fine_tick(persist_config):
+    """Persist sources should return data even at timestamps between their native ticks."""
+    ds = MultiSourceDataset(persist_config)
+    # datetimes[1] is 06:00 — falls between Base2's native 00:00 and 12:00
+    t = ds.datetimes[1]
+    sample = ds[(t, 0)]
+    assert "input" in sample
+    assert "Base1" in sample["input"]
+    assert "Base2" in sample["input"]
+
+
+def test_persist_cache_reuse_via_multisource(persist_config):
+    """Two consecutive fine-resolution ticks that snap to the same native interval
+    should return the identical (cached) Base2 input dict."""
+    ds = MultiSourceDataset(persist_config)
+    base2_ds = ds.datasets["Base2"]
+
+    # Both 00:00 and 06:00 resolve to Base2's native 00:00
+    t0 = ds.datetimes[0]  # 2024-01-01 00:00
+    t1 = ds.datetimes[1]  # 2024-01-01 06:00
+    sample0 = ds[(t0, 0)]
+    sample1 = ds[(t1, 0)]
+
+    # The persist cache should be populated
+    assert len(base2_ds._persist_cache) > 0
+
+    # Both samples should hold the same (cached) Base2 input dict
+    assert sample0["input"]["Base2"] is sample1["input"]["Base2"]
+
+
+def test_persist_cache_evicts_on_new_interval(persist_config):
+    """Accessing a tick in a new native interval evicts the stale cache entry."""
+    ds = MultiSourceDataset(persist_config)
+    base2_ds = ds.datasets["Base2"]
+
+    # First native interval: 00:00–06:00 both snap to 00:00
+    t0 = ds.datetimes[0]  # 2024-01-01 00:00
+    t1 = ds.datetimes[1]  # 2024-01-01 06:00
+    ds[(t0, 0)]
+    ds[(t1, 0)]
+    assert len(base2_ds._persist_cache) == 1  # only one resolved timestamp in cache
+
+    # Second native interval: 12:00 snaps to 12:00 (different resolved timestamp)
+    t2 = ds.datetimes[2]  # 2024-01-01 12:00
+    ds[(t2, 0)]
+    # Stale 00:00 entry is evicted; only 12:00 entry remains
+    assert len(base2_ds._persist_cache) == 1
+    cached_ts = next(iter(base2_ds._persist_cache))[0]
+    assert cached_ts == pd.Timestamp("2024-01-01 12:00")
+
+
 def test_multi_source_dataloader_default_collate(multi_config):
     """DataLoader + DistributedMultiStepBatchSampler should work without custom collate."""
     batch_size = 7  # Something different than the other dimensions

--- a/tests/test_dataset_basedataset.py
+++ b/tests/test_dataset_basedataset.py
@@ -376,6 +376,94 @@ def test_getitem_return_target_false(minimal_config: Dict[str, Any], patch_base_
 
 
 # ---------------------------------------------------------------------------
+# temporal_mode: persist tests
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_mode_default_is_none(minimal_config: Dict[str, Any], patch_base_dataset_io: None) -> None:
+    """temporal_mode is None by default (no key in source config)."""
+    ds = BaseDataset(minimal_config)
+    assert ds.temporal_mode is None
+
+
+def test_temporal_mode_set_from_config(minimal_config: Dict[str, Any], patch_base_dataset_io: None) -> None:
+    """temporal_mode is read from the source config block."""
+    minimal_config["source"]["TestSource_Base"]["temporal_mode"] = "persist"
+    ds = BaseDataset(minimal_config)
+    assert ds.temporal_mode == "persist"
+
+
+def test_persist_snaps_to_last_native_timestamp(minimal_config: Dict[str, Any], patch_base_dataset_io: None) -> None:
+    """__getitem__ with temporal_mode=persist snaps fine-resolution t to last native timestamp."""
+    minimal_config["source"]["TestSource_Base"]["temporal_mode"] = "persist"
+    ds = BaseDataset(minimal_config)
+    t_native = ds.datetimes[0]
+
+    # A timestamp 1 hour after the first native tick (within the same 6h native interval)
+    t_fine = t_native + pd.Timedelta("1h")
+    sample_native = ds[(t_native, 0)]
+    sample_fine = ds[(t_fine, 0)]
+
+    # Both should resolve to the same native timestamp
+    assert sample_fine["metadata"]["input_datetime"] == sample_native["metadata"]["input_datetime"]
+
+
+def test_persist_before_range_raises(minimal_config: Dict[str, Any], patch_base_dataset_io: None) -> None:
+    """_resolve_persist_timestamp raises ValueError when t < first native timestamp."""
+    minimal_config["source"]["TestSource_Base"]["temporal_mode"] = "persist"
+    ds = BaseDataset(minimal_config)
+    t_before = ds.datetimes[0] - pd.Timedelta("1h")
+
+    with pytest.raises(ValueError, match="before the first available native timestamp"):
+        ds._resolve_persist_timestamp(t_before)  # pyright: ignore[reportPrivateUsage]
+
+
+def test_persist_cache_hit_returns_same_object(minimal_config: Dict[str, Any], patch_base_dataset_io: None) -> None:
+    """Two calls with t values that resolve to the same native timestamp return the same cached dict."""
+    minimal_config["source"]["TestSource_Base"]["temporal_mode"] = "persist"
+    ds = BaseDataset(minimal_config)
+    t_native = ds.datetimes[0]
+    t_fine = t_native + pd.Timedelta("1h")
+
+    sample_a = ds[(t_native, 0)]
+    sample_b = ds[(t_fine, 0)]
+
+    assert sample_a is sample_b
+
+
+def test_persist_new_interval_evicts_cache(minimal_config: Dict[str, Any], patch_base_dataset_io: None) -> None:
+    """Moving to a new native interval evicts the previous cached entries."""
+    minimal_config["source"]["TestSource_Base"]["temporal_mode"] = "persist"
+    ds = BaseDataset(minimal_config)
+    t0 = ds.datetimes[0]
+    t1 = ds.datetimes[1]  # next native tick
+
+    sample_t0 = ds[(t0, 0)]
+    assert len(ds._persist_cache) == 1  # pyright: ignore[reportPrivateUsage]
+
+    # Advance to next native interval — cache should evict t0 entry
+    ds[(t1, 0)]
+    cached_keys = list(ds._persist_cache.keys())  # pyright: ignore[reportPrivateUsage]
+    assert all(k[0] == t1 for k in cached_keys)
+    assert sample_t0 is not ds._persist_cache.get((t0, True))  # pyright: ignore[reportPrivateUsage]
+
+
+def test_persist_i0_and_i1_are_separate_cache_entries(
+    minimal_config: Dict[str, Any], patch_base_dataset_io: None
+) -> None:
+    """i==0 and i>0 are cached under separate keys for the same native timestamp."""
+    minimal_config["source"]["TestSource_Base"]["temporal_mode"] = "persist"
+    ds = BaseDataset(minimal_config)
+    t = ds.datetimes[0]
+
+    sample_i0 = ds[(t, 0)]
+    sample_i1 = ds[(t, 1)]
+
+    assert sample_i0 is not sample_i1
+    assert len(ds._persist_cache) == 2  # pyright: ignore[reportPrivateUsage]
+
+
+# ---------------------------------------------------------------------------
 # AbstractBaseDataset method tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dataset_basedataset.py
+++ b/tests/test_dataset_basedataset.py
@@ -383,7 +383,7 @@ def test_getitem_return_target_false(minimal_config: Dict[str, Any], patch_base_
 def test_temporal_mode_default_is_none(minimal_config: Dict[str, Any], patch_base_dataset_io: None) -> None:
     """temporal_mode is None by default (no key in source config)."""
     ds = BaseDataset(minimal_config)
-    assert ds.temporal_mode is None
+    assert ds.temporal_mode == "exact"
 
 
 def test_temporal_mode_set_from_config(minimal_config: Dict[str, Any], patch_base_dataset_io: None) -> None:


### PR DESCRIPTION
### Description
Three main changes:

- Adds a persistence feature to the `BaseDataset` class which allows a user to "persist" data from a different source, particularly when it has a different temporal resolution. The general procedure to implement this is to use the `conf["data"]` global start / end / dt times at the **finest** resolution. Then under a `conf["data"]["source"]` a user can add a `temporal_mode: "persist"` key along with a `time_step:` key defining a coarser resolution for that source. If a datafile in the "global" timestep is not found, it will cache the previous timestep and use that. Future expansions will just need a different `temporal_mode:` key.
- Refactor and fix a bug in `grid.py` to generate SCRIP file formats for `ESMF_RegridWeightGen` to be used in the regridding preblock. 
- Fix a small time bug in `LocalDataset`

Closes #359, #380 (duplicate), #388

### Checklist
- [x] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date.
