### PR TITLE
Add new postblock scheme into Trainer

### DIFF
--- a/config/gen_2/smoke/smoke_gen2_casper.yml
+++ b/config/gen_2/smoke/smoke_gen2_casper.yml
@@ -3,13 +3,13 @@
 # tsi from solar NC, static from static_norm_old.nc
 # Reduced model size and 2-year training window for quick Casper single-GPU validation.
 
-save_loc: '/glade/derecho/scratch/schreck/credit_tests/smoke_gen2'
+save_loc: '/glade/derecho/scratch/$USER/credit_tests/smoke_gen2'
 seed: 1000
 
 data:
   source:
     ERA5:
-      dataset_type: "era5"
+      dataset_type: "local"
       level_coord: "level"
       levels: [10, 30, 40, 50, 60, 70, 80, 90, 95, 100, 105, 110, 120, 130, 136, 137]
       variables:
@@ -28,7 +28,7 @@ data:
         diagnostic: null
 
   timestep: "6h"
-  forecast_len: 1
+  forecast_len: 3
   start_datetime: "2015-01-01"
   end_datetime: "2016-12-31"
 
@@ -44,6 +44,10 @@ preblocks:
       std_path:  "/glade/campaign/cisl/aiml/credit/static_scalers/std_6h_1979_2018_16lev_0.25deg.nc"
   concat:
     type: concat
+
+postblocks:
+  construct:
+    type: reconstruct
 
 model:
     type: "crossformer"

--- a/credit/applications/train_gen2.py
+++ b/credit/applications/train_gen2.py
@@ -129,7 +129,8 @@ def main_cli():
     inject_flat_var_keys(conf)
     if "post_conf" in conf["model"]:
         warnings.warn(
-            "Gen 2 training does not support Gen 1 postblocks. Any postblocks included in the conf will be ignored."
+            "Gen 2 training does not support Gen 1 postblocks (conf['model']['post_conf']). "
+            "These will be ignored. Gen 2 postblocks (conf['postblocks']) are still applied normally."
         )
         conf["model"].pop("post_conf", None)
     m = load_model(conf)

--- a/credit/datasets/base_dataset.py
+++ b/credit/datasets/base_dataset.py
@@ -650,6 +650,7 @@ class BaseDataset(AbstractBaseDataset):
             field_config (dict[str, Any]): Validated field-type config dict.
 
         Raises:
+            FileNotFoundError: If ``self.mode == "local"`` and the glob pattern matches no files.
             ValueError: If ``self.mode`` is not a recognised mode.
 
         Returns:
@@ -659,9 +660,14 @@ class BaseDataset(AbstractBaseDataset):
                 The expected return type should be consistent within a dataset class.
         """
         if self.mode == "local":
-            files = sorted(glob(field_config.get("path", "")))
+            path = field_config.get("path", "")
+            files = sorted(glob(path))
+            if not files:
+                raise FileNotFoundError(
+                    f"No files found matching '{path}'. Check that the path exists and is accessible from this machine."
+                )
             time_fmt: str = field_config.get("filename_time_format", "%Y")
-            return _map_files(files, time_fmt) if files else None
+            return _map_files(files, time_fmt)
         elif self.mode == "remote":
             return True
         else:

--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -88,7 +88,7 @@ def apply_postblocks(postblocks: nn.ModuleDict, batch_dict: dict) -> dict:
 
     Args:
         postblocks: ``nn.ModuleDict`` built by ``build_postblocks`` for a single phase.
-        batch_dict: dict containing at minimum ``"predicted"`` and ``"metadata"``.
+        batch_dict: dict containing at minimum ``"y_pred"`` and ``"metadata"``.
 
     Returns:
         The same ``batch_dict`` after all blocks in the group have run.

--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -19,69 +19,80 @@ POSTBLOCK_REGISTRY = {
     "global_energy_fixer": GlobalEnergyFixer,
 }
 
+_VALID_SECTIONS = {"per_step", "post_rollout"}
 
-def build_postblocks(postblock_cfg: dict | None = None) -> nn.ModuleDict:
-    """Instantiates all postblocks from the config's ``postblocks`` section.
 
-    ``per_step`` defaults to ``False`` for every block and can be set per-block
-    in the config as a signal to the trainer about call timing.
-
-    Args:
-        postblock_cfg: the full postblocks dict from the config, e.g.::
-
-            postblocks:
-              reconstruct:
-                type: reconstruct
-              inverse_scale:
-                type: bridgescaler_transform
-                args:
-                  method: inverse_transform
-                  scaler_path: /path/to/scaler.json
-                  per_step: false
-              mass_fixer:
-                type: global_mass_fixer
-                args: ...
-
-    Returns:
-        ``nn.ModuleDict`` of instantiated postblocks, ordered as in config.
-    """
+def _build_postblock_section(section_cfg: dict) -> nn.ModuleDict:
     modules = {}
-    for name, block_cfg in (postblock_cfg or {}).items():
-        block_type = block_cfg["type"]
-        args = block_cfg.get("args") or {}
-        instance = POSTBLOCK_REGISTRY[block_type](**args)
-        instance.per_step = block_cfg.get("per_step", False)
-        modules[name] = instance
+    for name, block_cfg in section_cfg.items():
+        modules[name] = POSTBLOCK_REGISTRY[block_cfg["type"]](**(block_cfg.get("args") or {}))
     return nn.ModuleDict(modules)
 
 
-def apply_postblocks(postblocks: nn.ModuleDict, batch_dict: dict) -> dict:
-    """Applies all postblocks sequentially on a shared batch dict.
+def build_postblocks(postblock_cfg: dict | None = None, phase: str = "per_step") -> nn.ModuleDict:
+    """Instantiate postblocks for a single phase from a two-section config.
 
-    The caller is responsible for adding ``"prediction"`` (flat model output
-    tensor) and ``"meta"`` (metadata from ``apply_preblocks``) to ``batch_dict``
-    before calling. Any additional data needed by postblocks (e.g. ``"input"``,
-    ``"target"``, ``"_raw"``) should also be added by the caller beforehand.
+    Config format::
 
-    ``Reconstruct`` must be the first registered postblock — it converts
-    ``batch_dict["prediction"]`` from a flat tensor into a nested variable dict.
-    Subsequent postblocks operate on that nested dict via their ``key=`` arg.
+        postblocks:
+          per_step:          # run after every forward pass in the rollout loop
+            reconstruct:
+              type: reconstruct
+            inverse_scale:
+              type: bridgescaler_transform
+              args:
+                method: inverse_transform
+                scaler_path: /path/to/scaler.json
+          post_rollout:      # run once after all rollout steps complete
+            mass_fixer:
+              type: global_mass_fixer
+              args: ...
+
+    Typical usage — build once per phase, store separately::
+
+        step_postblocks    = build_postblocks(cfg, phase="per_step")
+        rollout_postblocks = build_postblocks(cfg, phase="post_rollout")
+
+        # inside rollout loop, after each forward pass:
+        full_data_dict = apply_postblocks(step_postblocks, full_data_dict)
+
+        # once after rollout loop completes:
+        apply_postblocks(rollout_postblocks, full_data_dict)
 
     Args:
-        postblocks:  ``nn.ModuleDict`` built by ``build_postblocks``.
-        batch_dict:  Dict containing at minimum ``"prediction"`` (flat tensor)
-                     and ``"meta"`` (with ``_channel_map["output"]``).
+        postblock_cfg: the full ``postblocks`` config dict (both sections).
+        phase: which section to build — ``"per_step"`` or ``"post_rollout"``.
 
     Returns:
-        The same ``batch_dict`` after all postblocks have run. ``"prediction"``
-        will be a nested variable dict after ``Reconstruct`` runs.
+        ``nn.ModuleDict`` of instantiated blocks for the requested phase.
 
     Raises:
-        RuntimeError: if ``postblocks`` is empty or ``Reconstruct`` is not first.
+        ValueError: if the config contains keys other than ``"per_step"`` / ``"post_rollout"``,
+            or if ``phase`` is not one of those values.
     """
-    blocks = list(postblocks.values())
+    cfg = postblock_cfg or {}
+    unknown = set(cfg) - _VALID_SECTIONS
+    if unknown:
+        raise ValueError(
+            f"build_postblocks: unexpected top-level keys {sorted(unknown)}. "
+            "Expected only 'per_step' and/or 'post_rollout'. "
+            "If you are using the old flat postblock format, migrate to the two-section layout."
+        )
+    if phase not in _VALID_SECTIONS:
+        raise ValueError(f"build_postblocks: phase must be one of {sorted(_VALID_SECTIONS)}, got {phase!r}.")
+    return _build_postblock_section(cfg.get(phase) or {})
 
-    for block in blocks:
+
+def apply_postblocks(postblocks: nn.ModuleDict, batch_dict: dict) -> dict:
+    """Apply a postblock group built by ``build_postblocks``.
+
+    Args:
+        postblocks: ``nn.ModuleDict`` built by ``build_postblocks`` for a single phase.
+        batch_dict: dict containing at minimum ``"predicted"`` and ``"metadata"``.
+
+    Returns:
+        The same ``batch_dict`` after all blocks in the group have run.
+    """
+    for block in postblocks.values():
         batch_dict = block(batch_dict)
-
     return batch_dict

--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -3,12 +3,20 @@ import torch.nn as nn
 from credit.postblock.reconstruct import Reconstruct
 from credit.postblock.wet_mask_samudra import WetMaskBlock
 from credit.postblock.scaler import BridgeScalerTransformer
+from credit.postblock.tracer_fixer import TracerFixer
+from credit.postblock.mass_fixer import GlobalMassFixer
+from credit.postblock.water_fixer import GlobalWaterFixer
+from credit.postblock.energy_fixer import GlobalEnergyFixer
 
 
 POSTBLOCK_REGISTRY = {
     "reconstruct": Reconstruct,
     "bridgescaler_transform": BridgeScalerTransformer,
     "wet_mask_samudra": WetMaskBlock,
+    "tracer_fixer": TracerFixer,
+    "global_mass_fixer": GlobalMassFixer,
+    "global_water_fixer": GlobalWaterFixer,
+    "global_energy_fixer": GlobalEnergyFixer,
 }
 
 

--- a/credit/postblock/base.py
+++ b/credit/postblock/base.py
@@ -4,10 +4,6 @@ import torch.nn as nn
 class BasePostblock(nn.Module):
     """Base class for all postblocks.
 
-    Subclasses that need to run at every rollout step (e.g. conservation fixers)
-    should set ``per_step = True``.  All others leave it at the default ``False``
-    and will be called once after the full rollout, on the reconstructed dict.
-
     Forward signature for all postblocks::
 
         forward(batch: dict) -> dict
@@ -19,8 +15,6 @@ class BasePostblock(nn.Module):
             "metadata":   {...},
         }
     """
-
-    per_step: bool = True
 
     def forward(self, batch: dict) -> dict:
         pass

--- a/credit/postblock/reconstruct.py
+++ b/credit/postblock/reconstruct.py
@@ -36,8 +36,8 @@ class Reconstruct(BasePostblock):
     """
 
     def forward(self, batch_dict: dict) -> dict:
-        y_pred = batch_dict["prediction"]
-        output_map = batch_dict["metadata"]["target"]["_channel_map"]
+        y_pred = batch_dict["predicted"]
+        output_map = batch_dict["preprocessed"]["metadata"]["target"]["_channel_map"]
 
         # Flatten time dim if y_pred arrived as 5D (B, C, T, H, W) — unflatten needs 4D input
         if y_pred.dim() == 5:
@@ -57,5 +57,5 @@ class Reconstruct(BasePostblock):
             source = var_key.split("/")[0]
             prediction.setdefault(source, {})[var_key] = var_tensor
 
-        batch_dict["prediction"] = prediction
+        batch_dict["predicted"] = prediction
         return batch_dict

--- a/credit/postblock/reconstruct.py
+++ b/credit/postblock/reconstruct.py
@@ -1,8 +1,8 @@
 """
 reconstruct.py
 --------------
-Reconstruct: first postblock that splits the flat ``batch_dict["predicted"]``
-tensor back into a nested variable dict in-place.
+Reconstruct: first postblock that splits the flat ``batch_dict["y_pred"]``
+tensor into a nested variable dict, writing the result to ``batch_dict["y_processed"]``.
 
 Reads ``batch_dict["metadata"]["target"]["_channel_map"]`` built by
 ``ConcatToTensor`` to know which channels correspond to which variables.
@@ -11,51 +11,54 @@ Input
 -----
 batch_dict : dict
     Must contain:
-      "predicted" — flat model output tensor, shape (B, C, H, W) or (B, C, T, H, W)
-      "metadata"  — metadata dict with ``["target"]["_channel_map"]``
+      "y_pred"   — flat model output tensor, shape (B, C, H, W) or (B, C, T, H, W)
+      "metadata" — metadata dict with ``["target"]["_channel_map"]``
     All other keys pass through unchanged.
 
 Output
 ------
-The same ``batch_dict`` with ``"predicted"`` replaced by a nested dict:
+The same ``batch_dict`` with ``"y_processed"`` added as a nested dict:
 
-    batch_dict["predicted"][source][var_key]
+    batch_dict["y_processed"][source][var_key]
         -> tensor of shape (B, n_levels, n_time, H, W)
+
+``"y_pred"`` is left intact (grad-attached) for use in loss computation.
 """
 
 from credit.postblock.base import BasePostblock
 
 
 class Reconstruct(BasePostblock):
-    """Splits ``batch_dict["predicted"]`` from a flat tensor into a nested variable dict.
+    """Splits ``batch_dict["y_pred"]`` into a nested variable dict at ``batch_dict["y_processed"]``.
 
     Slices are read from ``batch_dict["metadata"]["target"]["_channel_map"]``, built
     by ``ConcatToTensor`` and covering only prognostic + diagnostic variables.
     Each slice is unflattened from ``(B, n_levels * n_time, H, W)`` back to
-    ``(B, n_levels, n_time, H, W)``. All other keys in ``batch_dict`` pass through.
+    ``(B, n_levels, n_time, H, W)``. ``y_pred`` is left untouched. All other
+    keys in ``batch_dict`` pass through unchanged.
     """
 
     def forward(self, batch_dict: dict) -> dict:
-        y_pred = batch_dict["predicted"]
+        y_pred = batch_dict["y_pred"]
         output_map = batch_dict["metadata"]["target"]["_channel_map"]
 
         # Flatten time dim if y_pred arrived as 5D (B, C, T, H, W) — unflatten needs 4D input
         if y_pred.dim() == 5:
             y_pred = y_pred.flatten(1, 2)
 
-        prediction = {}
+        y_processed = {}
         for var_key, info in output_map.items():
             ch_slice = info["slice"]
             n_levels, n_time = info["orig_shape"]
 
             # Slice the flat channel dim: (B, n_levels*n_time, H, W)
-            var_tensor = y_pred[:, ch_slice, ...]
+            var_tensor = y_pred[:, ch_slice, ...].detach()
 
             # Restore level and time dims: (B, n_levels, n_time, H, W)
             var_tensor = var_tensor.unflatten(1, (n_levels, n_time))
 
             source = var_key.split("/")[0]
-            prediction.setdefault(source, {})[var_key] = var_tensor
+            y_processed.setdefault(source, {})[var_key] = var_tensor
 
-        batch_dict["predicted"] = prediction
+        batch_dict["y_processed"] = y_processed
         return batch_dict

--- a/credit/postblock/reconstruct.py
+++ b/credit/postblock/reconstruct.py
@@ -1,25 +1,25 @@
 """
 reconstruct.py
 --------------
-Reconstruct: first postblock that splits the flat ``batch_dict["prediction"]``
+Reconstruct: first postblock that splits the flat ``batch_dict["predicted"]``
 tensor back into a nested variable dict in-place.
 
-Reads ``batch_dict["meta"]["_channel_map"]["output"]`` built by
+Reads ``batch_dict["metadata"]["target"]["_channel_map"]`` built by
 ``ConcatToTensor`` to know which channels correspond to which variables.
 
 Input
 -----
 batch_dict : dict
     Must contain:
-      "prediction" — flat model output tensor, shape (B, C, H, W) or (B, C, T, H, W)
-      "meta"       — metadata dict with ``_channel_map["output"]``
-    May also contain "input", "target", "_raw", etc. — all passed through unchanged.
+      "predicted" — flat model output tensor, shape (B, C, H, W) or (B, C, T, H, W)
+      "metadata"  — metadata dict with ``["target"]["_channel_map"]``
+    All other keys pass through unchanged.
 
 Output
 ------
-The same ``batch_dict`` with ``"prediction"`` replaced by a nested dict:
+The same ``batch_dict`` with ``"predicted"`` replaced by a nested dict:
 
-    batch_dict["prediction"][source][var_string]
+    batch_dict["predicted"][source][var_key]
         -> tensor of shape (B, n_levels, n_time, H, W)
 """
 
@@ -27,7 +27,7 @@ from credit.postblock.base import BasePostblock
 
 
 class Reconstruct(BasePostblock):
-    """Splits ``batch_dict["prediction"]`` from a flat tensor into a nested variable dict.
+    """Splits ``batch_dict["predicted"]`` from a flat tensor into a nested variable dict.
 
     Slices are read from ``batch_dict["metadata"]["target"]["_channel_map"]``, built
     by ``ConcatToTensor`` and covering only prognostic + diagnostic variables.
@@ -37,7 +37,7 @@ class Reconstruct(BasePostblock):
 
     def forward(self, batch_dict: dict) -> dict:
         y_pred = batch_dict["predicted"]
-        output_map = batch_dict["preprocessed"]["metadata"]["target"]["_channel_map"]
+        output_map = batch_dict["metadata"]["target"]["_channel_map"]
 
         # Flatten time dim if y_pred arrived as 5D (B, C, T, H, W) — unflatten needs 4D input
         if y_pred.dim() == 5:

--- a/credit/postblock/scaler.py
+++ b/credit/postblock/scaler.py
@@ -7,7 +7,12 @@ class BridgeScalerTransformer(BasePostblock):
 
     Applies per-variable scaling (or its inverse) to the nested prediction dict
     at ``batch_dict[key]``, which has the form
-    ``batch_dict[key][source][data_type][dim][var_name]``.
+    ``batch_dict[key][source][var_key]`` where ``var_key`` is
+    ``"source/field_type/dim/varname"`` (e.g. ``"era5/prognostic/3d/T"``).
+
+    Defaults to operating on ``"y_processed"`` — the nested dict written by
+    ``Reconstruct``. Use ``method="inverse_transform"`` to convert normalized
+    predictions back to physical units before physics fixers.
 
     The scaler dict must have been fit with ``bridgescaler.scale_var_dict``
     using the same nested structure and saved with ``bridgescaler.save_scaler_dict``.
@@ -23,7 +28,7 @@ class BridgeScalerTransformer(BasePostblock):
             method: "inverse_transform"
     """
 
-    def __init__(self, scaler_path: str, variables: list[str], method: str, key: str = "prediction"):
+    def __init__(self, scaler_path: str, variables: list[str], method: str, key: str = "y_processed"):
         super().__init__()
         self.variables = variables
         self.method = method

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -115,11 +115,11 @@ def _run_preblock_group(group: nn.ModuleDict, batch: dict, device=None):
     if not concat_ran:
         return batch
 
-    out = {"input": batch}
+    out = {"x": batch}
     if meta is not None:
         out["metadata"] = meta
     if target is not None:
-        out["target"] = target
+        out["y"] = target
 
     if device is not None and to_device:
         out = {k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in out.items()}
@@ -140,7 +140,7 @@ def apply_preblocks(
         device: move output tensors here after concat.
 
     Returns:
-        When concat has run: ``{"input": tensor, "metadata": ..., "target": tensor}``.
-        Otherwise: the transformed nested batch dict.
+        When concat has run: ``{"x": tensor, "y": tensor, "metadata": ...}``.
+        Otherwise: the transformed nested batch dict (pre-concat).
     """
     return _run_preblock_group(preblocks, batch, device)

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -30,45 +30,76 @@ PREBLOCK_REGISTRY = {
 if _BRIDGESCALER_AVAILABLE:
     PREBLOCK_REGISTRY["bridgescaler_transform"] = BridgeScalerTransformer
 
+_VALID_SECTIONS = {"ic_only", "per_step"}
 
-def build_preblocks(preblock_cfg: dict | None = None) -> nn.ModuleDict:
-    """
-    Instantiates all preblocks from the config's 'preblocks' section.
+
+def _build_preblock_section(section_cfg: dict) -> nn.ModuleDict:
+    modules = {}
+    for name, block_cfg in section_cfg.items():
+        modules[name] = PREBLOCK_REGISTRY[block_cfg["type"]](**(block_cfg.get("args") or {}))
+    return nn.ModuleDict(modules)
+
+
+def build_preblocks(preblock_cfg: dict | None = None, phase: str = "per_step") -> nn.ModuleDict:
+    """Instantiate preblocks for a single phase from a two-section config.
+
+    Config format::
+
+        preblocks:
+          ic_only:          # run once at t=0 on the raw batch (e.g. static regrid)
+            regrid_static:
+              type: regrid
+              args: ...
+          per_step:         # run every rollout step (e.g. log_transform, concat)
+            log_transform:
+              type: log_transform
+            concat:
+              type: concat
+
+    Typical usage — build once per phase, store separately::
+
+        ic_preblocks   = build_preblocks(cfg, phase="ic_only")
+        step_preblocks = build_preblocks(cfg, phase="per_step")
+
+        # t=0: run both in sequence
+        ic_preprocessed    = apply_preblocks(ic_preblocks, batch, device=device)
+        preprocessed_batch = apply_preblocks(step_preblocks, ic_preprocessed, device=device)
+
+        # t>0: run per_step only
+        preprocessed_batch = apply_preblocks(step_preblocks, rollout_batch, device=device)
 
     Args:
-        preblock_cfg: the full preblocks dict from the config, e.g.:
-            {
-                'era5_log_transform': {'type': 'log_transform', 'args': {...}},
-                'era5_z_transform':   {'type': 'z_transform',   'args': {...}},
-            }
+        preblock_cfg: the full ``preblocks`` config dict (both sections).
+        phase: which section to build — ``"ic_only"`` or ``"per_step"``.
 
     Returns:
-        nn.ModuleDict of instantiated preblocks, ordered as in config.
+        ``nn.ModuleDict`` of instantiated blocks for the requested phase.
+
+    Raises:
+        ValueError: if the config contains keys other than ``"ic_only"`` / ``"per_step"``,
+            or if ``phase`` is not one of those values.
     """
-    return nn.ModuleDict(
-        {
-            name: PREBLOCK_REGISTRY[block_cfg["type"]](**(block_cfg.get("args") or {}))
-            for name, block_cfg in (preblock_cfg or {}).items()
-        }
-    )
+    cfg = preblock_cfg or {}
+    unknown = set(cfg) - _VALID_SECTIONS
+    if unknown:
+        raise ValueError(
+            f"build_preblocks: unexpected top-level keys {sorted(unknown)}. "
+            "Expected only 'ic_only' and/or 'per_step'. "
+            "If you are using the old flat preblock format, migrate to the two-section layout."
+        )
+    if phase not in _VALID_SECTIONS:
+        raise ValueError(f"build_preblocks: phase must be one of {sorted(_VALID_SECTIONS)}, got {phase!r}.")
+    return _build_preblock_section(cfg.get(phase) or {})
 
 
-def apply_preblocks(preblocks: nn.ModuleDict, batch: dict, device=None):
-    """Sequentially applies transform preblocks (dict→dict).
-
-    Returns a dict with keys:
-        "input"  — concatenated tensor (if concat preblock present) or nested batch dict
-        "meta"   — metadata dict (only present if concat preblock ran)
-        "target" — target tensor (only present if target data was in the batch)
-
-    Tensors in the output are moved to ``device`` unless the concat preblock was
-    configured with ``to_device: false``.
-    """
+def _run_preblock_group(group: nn.ModuleDict, batch: dict, device=None):
+    """Sequentially applies a group of preblocks, returning the transformed batch."""
     meta = None
     target = None
     to_device = True
     concat_ran = False
-    for preblock in preblocks.values():
+
+    for preblock in group.values():
         result = preblock(batch)
         if isinstance(result, tuple):
             if len(result) == 3:
@@ -94,3 +125,22 @@ def apply_preblocks(preblocks: nn.ModuleDict, batch: dict, device=None):
         out = {k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in out.items()}
 
     return out
+
+
+def apply_preblocks(
+    preblocks: nn.ModuleDict,
+    batch: dict,
+    device=None,
+) -> dict:
+    """Apply a preblock group built by ``build_preblocks``.
+
+    Args:
+        preblocks: ``nn.ModuleDict`` built by ``build_preblocks`` for a single phase.
+        batch: nested variable dict from the dataset (or a prior preblock pass).
+        device: move output tensors here after concat.
+
+    Returns:
+        When concat has run: ``{"input": tensor, "metadata": ..., "target": tensor}``.
+        Otherwise: the transformed nested batch dict.
+    """
+    return _run_preblock_group(preblocks, batch, device)

--- a/credit/preblock/concat.py
+++ b/credit/preblock/concat.py
@@ -133,6 +133,11 @@ class ConcatToTensor(BasePreblock):
         metadata["input"]["_channel_map"] = input_channel_map
         metadata["target"]["_channel_map"] = output_channel_map
 
+        # Normalize device: rollout batches mix CPU (dataloader) and accelerator
+        # (model output) tensors; torch.cat requires a uniform device.
+        accel = next((t.device for t in input_tensors if t.device.type != "cpu"), None)
+        if accel is not None:
+            input_tensors = [t.to(accel) for t in input_tensors]
         input_tensor = torch.cat(input_tensors, dim=1)
 
         if target_tensors:

--- a/credit/preblock/concat.py
+++ b/credit/preblock/concat.py
@@ -138,10 +138,10 @@ class ConcatToTensor(BasePreblock):
         accel = next((t.device for t in input_tensors if t.device.type != "cpu"), None)
         if accel is not None:
             input_tensors = [t.to(accel) for t in input_tensors]
-        input_tensor = torch.cat(input_tensors, dim=1)
+        input_tensor = torch.cat(input_tensors, dim=1).float()
 
         if target_tensors:
-            target_tensor = torch.cat(target_tensors, dim=1)
+            target_tensor = torch.cat(target_tensors, dim=1).float()
             return input_tensor, target_tensor, metadata
 
         return input_tensor, metadata

--- a/credit/trainers/__init__.py
+++ b/credit/trainers/__init__.py
@@ -4,7 +4,15 @@ import logging
 # Import trainer classes
 from credit.trainers.trainerERA5gen1 import TrainerERA5Gen1
 from credit.trainers.trainerERA5gen2 import TrainerERA5Gen2
-from credit.trainers.trainerERA5_Diffusion import TrainerERA5Diffusion
+from credit.trainers.trainerERA5gen2_legacy import TrainerERA5Gen2 as TrainerERA5Gen2Legacy
+
+try:
+    from credit.trainers.trainerERA5_Diffusion import TrainerERA5Diffusion
+
+    _DIFFUSION_AVAILABLE = True
+except (ImportError, Exception):
+    TrainerERA5Diffusion = None
+    _DIFFUSION_AVAILABLE = False
 from credit.trainers.trainerERA5_ensemble import TrainerERA5Ensemble
 from credit.trainers.trainer_downscaling import TrainerDownscaling
 
@@ -37,6 +45,10 @@ trainer_types = {
     "era5-gen2": (
         TrainerERA5Gen2,
         "ERA5 Gen 2 trainer for the new nested data schema with preblock-assembled batches. forecast_len=1 means 1 step.",
+    ),
+    "era5-gen2-legacy": (
+        TrainerERA5Gen2Legacy,
+        "ERA5 Gen 2 legacy trainer (update_x/build_channel_layout rollout, no postblocks). For comparison against era5-gen2.",
     ),
     "era5-diffusion": (
         TrainerERA5Diffusion,

--- a/credit/trainers/rollout_utils.py
+++ b/credit/trainers/rollout_utils.py
@@ -1,91 +1,98 @@
 """rollout_utils.py — utilities for autoregressive multi-step rollout."""
 
-import torch
+import logging
+
+logger = logging.getLogger(__name__)
 
 
-def build_rollout_input(
-    prev_full_dict: dict,
-    curr_dyn_input: torch.Tensor,
-    ic_channel_map: dict,
-) -> torch.Tensor:
-    """Build the next-step model input tensor using the IC channel map.
+def assemble_rollout_batch(
+    corrected_pred: dict,
+    ic_preprocessed: dict,
+    curr_batch: dict,
+) -> dict:
+    """Assemble a batch dict for the rollout preblock pass at autoregressive step t > 0.
 
-    Combines three sources:
-    - **Prognostic** channels: from ``prev_full_dict["predicted"]``.
-      Supports both a nested variable dict (after ``Reconstruct`` postblock)
-      and a raw flat tensor (when no postblocks are configured).
-    - **Dynamic forcing** channels: from ``curr_dyn_input`` (current dataloader
-      batch), written in the same relative order as the dynamic_forcing entries
-      in ``ic_channel_map``.
-    - **Static** (and any other) channels: copied as-is from the previous
-      input tensor.
+    Constructs a dataset-schema batch by routing each variable from the
+    appropriate source:
 
-    No full clone of the previous input is needed; only static channels are
-    copied, so peak extra memory is proportional to the static channel count
-    rather than the full tensor size.
+    - **prognostic / diagnostic** channels: from ``corrected_pred`` — the
+      postblock-corrected prediction in physical units from the previous step.
+    - **dynamic_forcing** channels: from ``curr_batch["input"]`` — the
+      current step's time-varying forcing loaded by the dataset.
+    - **static** (and any other non-predicted) channels: from
+      ``ic_preprocessed["input"]`` — the t=0 batch after IC-only preblocks
+      (e.g. regrid), so statics are already on the model grid.
+
+    The assembled dict is passed to ``apply_step_preblocks()``
+    which handles per-step operations (dynamic-forcing regrid, log_transform,
+    concat).  ``curr_batch["target"]`` is forwarded so preblocks normalize the
+    training target in the same pass.
 
     Args:
-        prev_full_dict: ``full_data_dict`` from the previous rollout step.
-            Must contain:
-              ``["preprocessed"]["input"]`` — previous full ``x`` tensor
-              ``["preprocessed"]["metadata"]["target"]["_channel_map"]`` — output
-              channel map used for the flat-tensor fallback path
-              ``["predicted"]`` — either a nested dict
-              ``{source: {var_key: tensor(B, n_lev, T, H, W)}}`` (after
-              ``Reconstruct``) or a raw flat tensor ``(B, C_pred, H, W)``.
-        curr_dyn_input: flat tensor ``(B, C_dyn, H, W)`` of dynamic_forcing
-            channels from the current dataloader batch.  Must be in the same
-            relative order as the dynamic_forcing entries in ``ic_channel_map``.
-        ic_channel_map: per-variable channel map cached from ``t=1``, covering
-            ALL input variable groups.  Keys are ``source/field_type/dim/varname``
-            strings; values are ``{"slice": slice, "orig_shape": (n_lev, T)}``.
+        corrected_pred: Nested ``{source: {var_key: tensor(B, n_lev, n_time, H, W)}}``
+            in physical units — output of the postblock chain at the previous
+            step.  Must be a dict; if postblocks are not configured, include at
+            least ``Reconstruct`` so this function receives the expected type.
+        ic_preprocessed: t=0 batch after IC-only preblocks.
+            Provides time-invariant static variables already mapped to the model
+            grid, and the authoritative list of all input variable keys.
+        curr_batch: Current step's raw batch from the dataset.  Provides the
+            dynamic forcing fields for this step and the training target.
 
     Returns:
-        Tensor ``(B, C_in, H, W)``: assembled input for the next forward pass.
+        dict with keys ``"input"`` (nested source→var dict) and ``"target"``
+        (from ``curr_batch``), ready for ``apply_step_preblocks()``.
+
+    Raises:
+        TypeError: if ``corrected_pred`` is not a dict, which usually means
+            ``Reconstruct`` was not included in the postblock chain.
     """
-    x_prev = prev_full_dict["preprocessed"]["input"]
-    prediction = prev_full_dict["predicted"]
+    if not isinstance(corrected_pred, dict):
+        raise TypeError(
+            "assemble_rollout_batch: corrected_pred must be a nested dict "
+            "{source: {var_key: tensor}}. "
+            "For multi-step rollout, 'Reconstruct' must be the first postblock. "
+            f"Got {type(corrected_pred).__name__}."
+        )
 
-    x_new = torch.empty_like(x_prev)
-    dyn_cursor = 0
+    assembled_input: dict = {}
 
-    for var_key, info in ic_channel_map.items():
-        sl = info["slice"]
-        n = sl.stop - sl.start
-        parts = var_key.split("/")
-        field_type = parts[1] if len(parts) > 1 else ""
+    for source, source_vars in ic_preprocessed["input"].items():
+        assembled_input[source] = {}
+        curr_source = curr_batch.get("input", {}).get(source, {})
+        pred_source = corrected_pred.get(source, {})
 
-        if field_type == "dynamic_forcing":
-            x_new[:, sl, ...] = curr_dyn_input[:, dyn_cursor : dyn_cursor + n, ...]
-            dyn_cursor += n
+        for var_key, ic_tensor in source_vars.items():
+            parts = var_key.split("/")
+            field_type = parts[1] if len(parts) > 1 else ""
 
-        elif field_type == "prognostic":
-            if isinstance(prediction, dict):
-                # After Reconstruct: nested dict {source: {var_key: (B, n_lev, T, H, W)}}
-                # Reconstruct always produces 5D var tensors.  If x_prev is 4D we need to
-                # flatten (n_lev, T) → n_lev*T; if x_prev is 5D assign directly.
-                source = parts[0]
-                if source in prediction and var_key in prediction[source]:
-                    var_tensor = prediction[source][var_key]  # (B, n_lev, T, H, W)
-                    if x_prev.dim() == 5:
-                        x_new[:, sl, ...] = var_tensor
-                    else:
-                        x_new[:, sl, ...] = var_tensor.flatten(1, 2)
+            if field_type in ("prognostic", "diagnostic"):
+                if var_key in pred_source:
+                    assembled_input[source][var_key] = pred_source[var_key]
                 else:
-                    x_new[:, sl, ...] = x_prev[:, sl, ...]
+                    logger.warning(
+                        "assemble_rollout_batch: '%s' not in corrected_pred; carrying forward from ic_preprocessed.",
+                        var_key,
+                    )
+                    assembled_input[source][var_key] = ic_tensor
+
+            elif field_type == "dynamic_forcing":
+                if var_key in curr_source:
+                    assembled_input[source][var_key] = curr_source[var_key]
+                else:
+                    logger.warning(
+                        "assemble_rollout_batch: dynamic_forcing '%s' not in curr_batch; "
+                        "carrying forward from ic_preprocessed.",
+                        var_key,
+                    )
+                    assembled_input[source][var_key] = ic_tensor
+
             else:
-                # Flat tensor fallback (no Reconstruct in postblocks).
-                # prediction has the same dimensionality as x_prev, so the slice
-                # naturally yields a compatible shape — no flatten needed.
-                output_map = prev_full_dict["preprocessed"]["metadata"]["target"]["_channel_map"]
-                if var_key in output_map:
-                    out_sl = output_map[var_key]["slice"]
-                    x_new[:, sl, ...] = prediction[:, out_sl, ...]
-                else:
-                    x_new[:, sl, ...] = x_prev[:, sl, ...]
+                # static and any other non-predicted field: carry forward from ic_preprocessed
+                # (already on the model grid after IC-only preblocks)
+                assembled_input[source][var_key] = ic_tensor
 
-        else:
-            # Static and any other non-updated channels: preserve from previous x.
-            x_new[:, sl, ...] = x_prev[:, sl, ...]
-
-    return x_new
+    return {
+        "input": assembled_input,
+        "target": curr_batch.get("target"),
+    }

--- a/credit/trainers/rollout_utils.py
+++ b/credit/trainers/rollout_utils.py
@@ -5,51 +5,48 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def assemble_rollout_batch(
-    corrected_pred: dict,
-    ic_preprocessed: dict,
-    curr_batch: dict,
-) -> dict:
+def assemble_rollout_batch(full_data_dict: dict, curr_batch: dict) -> dict:
     """Assemble a batch dict for the rollout preblock pass at autoregressive step t > 0.
 
     Constructs a dataset-schema batch by routing each variable from the
     appropriate source:
 
-    - **prognostic / diagnostic** channels: from ``corrected_pred`` — the
-      postblock-corrected prediction in physical units from the previous step.
+    - **prognostic / diagnostic** channels: from ``full_data_dict["y_processed"]`` —
+      the postblock-processed prediction from the previous step.
     - **dynamic_forcing** channels: from ``curr_batch["input"]`` — the
       current step's time-varying forcing loaded by the dataset.
     - **static** (and any other non-predicted) channels: from
-      ``ic_preprocessed["input"]`` — the t=0 batch after IC-only preblocks
-      (e.g. regrid), so statics are already on the model grid.
+      ``full_data_dict["ic_preprocessed"]["input"]`` — the t=0 raw batch after
+      IC-only preblocks, so statics are already on the model grid.
 
-    The assembled dict is passed to ``apply_step_preblocks()``
-    which handles per-step operations (dynamic-forcing regrid, log_transform,
-    concat).  ``curr_batch["target"]`` is forwarded so preblocks normalize the
-    training target in the same pass.
+    The assembled dict is passed to ``apply_preblocks(step_preblocks, ...)``
+    which handles per-step operations (log_transform, concat).
+    ``curr_batch["target"]`` is forwarded so preblocks normalize the training
+    target in the same pass.
 
     Args:
-        corrected_pred: Nested ``{source: {var_key: tensor(B, n_lev, n_time, H, W)}}``
-            in physical units — output of the postblock chain at the previous
-            step.  Must be a dict; if postblocks are not configured, include at
-            least ``Reconstruct`` so this function receives the expected type.
-        ic_preprocessed: t=0 batch after IC-only preblocks.
-            Provides time-invariant static variables already mapped to the model
-            grid, and the authoritative list of all input variable keys.
-        curr_batch: Current step's raw batch from the dataset.  Provides the
-            dynamic forcing fields for this step and the training target.
+        full_data_dict: the rollout state dict.  Must contain:
+            ``"y_processed"`` — nested ``{source: {var_key: tensor}}`` from the
+            previous step's postblock chain (output of ``Reconstruct`` + fixers).
+            ``"ic_preprocessed"`` — t=0 raw batch after IC-only preblocks,
+            providing the authoritative variable key list and static tensors.
+        curr_batch: current step's raw batch from the dataset.  Provides
+            dynamic forcing fields and the training target.
 
     Returns:
         dict with keys ``"input"`` (nested source→var dict) and ``"target"``
-        (from ``curr_batch``), ready for ``apply_step_preblocks()``.
+        (from ``curr_batch``), ready for ``apply_preblocks(step_preblocks, ...)``.
 
     Raises:
-        TypeError: if ``corrected_pred`` is not a dict, which usually means
-            ``Reconstruct`` was not included in the postblock chain.
+        TypeError: if ``full_data_dict["y_processed"]`` is not a dict, which
+            usually means ``Reconstruct`` was not included in the postblock chain.
     """
+    corrected_pred = full_data_dict["y_processed"]
+    ic_preprocessed = full_data_dict["ic_preprocessed"]
+
     if not isinstance(corrected_pred, dict):
         raise TypeError(
-            "assemble_rollout_batch: corrected_pred must be a nested dict "
+            "assemble_rollout_batch: full_data_dict['y_processed'] must be a nested dict "
             "{source: {var_key: tensor}}. "
             "For multi-step rollout, 'Reconstruct' must be the first postblock. "
             f"Got {type(corrected_pred).__name__}."
@@ -71,7 +68,7 @@ def assemble_rollout_batch(
                     assembled_input[source][var_key] = pred_source[var_key]
                 else:
                     logger.warning(
-                        "assemble_rollout_batch: '%s' not in corrected_pred; carrying forward from ic_preprocessed.",
+                        "assemble_rollout_batch: '%s' not in y_processed; carrying forward from ic_preprocessed.",
                         var_key,
                     )
                     assembled_input[source][var_key] = ic_tensor
@@ -89,7 +86,6 @@ def assemble_rollout_batch(
 
             else:
                 # static and any other non-predicted field: carry forward from ic_preprocessed
-                # (already on the model grid after IC-only preblocks)
                 assembled_input[source][var_key] = ic_tensor
 
     return {

--- a/credit/trainers/rollout_utils.py
+++ b/credit/trainers/rollout_utils.py
@@ -1,0 +1,91 @@
+"""rollout_utils.py — utilities for autoregressive multi-step rollout."""
+
+import torch
+
+
+def build_rollout_input(
+    prev_full_dict: dict,
+    curr_dyn_input: torch.Tensor,
+    ic_channel_map: dict,
+) -> torch.Tensor:
+    """Build the next-step model input tensor using the IC channel map.
+
+    Combines three sources:
+    - **Prognostic** channels: from ``prev_full_dict["predicted"]``.
+      Supports both a nested variable dict (after ``Reconstruct`` postblock)
+      and a raw flat tensor (when no postblocks are configured).
+    - **Dynamic forcing** channels: from ``curr_dyn_input`` (current dataloader
+      batch), written in the same relative order as the dynamic_forcing entries
+      in ``ic_channel_map``.
+    - **Static** (and any other) channels: copied as-is from the previous
+      input tensor.
+
+    No full clone of the previous input is needed; only static channels are
+    copied, so peak extra memory is proportional to the static channel count
+    rather than the full tensor size.
+
+    Args:
+        prev_full_dict: ``full_data_dict`` from the previous rollout step.
+            Must contain:
+              ``["preprocessed"]["input"]`` — previous full ``x`` tensor
+              ``["preprocessed"]["metadata"]["target"]["_channel_map"]`` — output
+              channel map used for the flat-tensor fallback path
+              ``["predicted"]`` — either a nested dict
+              ``{source: {var_key: tensor(B, n_lev, T, H, W)}}`` (after
+              ``Reconstruct``) or a raw flat tensor ``(B, C_pred, H, W)``.
+        curr_dyn_input: flat tensor ``(B, C_dyn, H, W)`` of dynamic_forcing
+            channels from the current dataloader batch.  Must be in the same
+            relative order as the dynamic_forcing entries in ``ic_channel_map``.
+        ic_channel_map: per-variable channel map cached from ``t=1``, covering
+            ALL input variable groups.  Keys are ``source/field_type/dim/varname``
+            strings; values are ``{"slice": slice, "orig_shape": (n_lev, T)}``.
+
+    Returns:
+        Tensor ``(B, C_in, H, W)``: assembled input for the next forward pass.
+    """
+    x_prev = prev_full_dict["preprocessed"]["input"]
+    prediction = prev_full_dict["predicted"]
+
+    x_new = torch.empty_like(x_prev)
+    dyn_cursor = 0
+
+    for var_key, info in ic_channel_map.items():
+        sl = info["slice"]
+        n = sl.stop - sl.start
+        parts = var_key.split("/")
+        field_type = parts[1] if len(parts) > 1 else ""
+
+        if field_type == "dynamic_forcing":
+            x_new[:, sl, ...] = curr_dyn_input[:, dyn_cursor : dyn_cursor + n, ...]
+            dyn_cursor += n
+
+        elif field_type == "prognostic":
+            if isinstance(prediction, dict):
+                # After Reconstruct: nested dict {source: {var_key: (B, n_lev, T, H, W)}}
+                # Reconstruct always produces 5D var tensors.  If x_prev is 4D we need to
+                # flatten (n_lev, T) → n_lev*T; if x_prev is 5D assign directly.
+                source = parts[0]
+                if source in prediction and var_key in prediction[source]:
+                    var_tensor = prediction[source][var_key]  # (B, n_lev, T, H, W)
+                    if x_prev.dim() == 5:
+                        x_new[:, sl, ...] = var_tensor
+                    else:
+                        x_new[:, sl, ...] = var_tensor.flatten(1, 2)
+                else:
+                    x_new[:, sl, ...] = x_prev[:, sl, ...]
+            else:
+                # Flat tensor fallback (no Reconstruct in postblocks).
+                # prediction has the same dimensionality as x_prev, so the slice
+                # naturally yields a compatible shape — no flatten needed.
+                output_map = prev_full_dict["preprocessed"]["metadata"]["target"]["_channel_map"]
+                if var_key in output_map:
+                    out_sl = output_map[var_key]["slice"]
+                    x_new[:, sl, ...] = prediction[:, out_sl, ...]
+                else:
+                    x_new[:, sl, ...] = x_prev[:, sl, ...]
+
+        else:
+            # Static and any other non-updated channels: preserve from previous x.
+            x_new[:, sl, ...] = x_prev[:, sl, ...]
+
+    return x_new

--- a/credit/trainers/trainerERA5gen2.py
+++ b/credit/trainers/trainerERA5gen2.py
@@ -100,7 +100,7 @@ class TrainerERA5Gen2(BaseTrainer):
              rollout preblocks normalize and concat.
           3. Forward pass → y_pred_flat (flat, normalized).
           4. Apply postblocks: Reconstruct → inverse scaler → physics fixers.
-             After this, full_data_dict["predicted"] is a nested physical-space dict.
+             After this, full_data_dict["y_processed"] is a nested dict split by Reconstruct.
           5. Compute loss on y_pred_flat vs the normalized target from preblocks.
 
         Args:
@@ -141,53 +141,44 @@ class TrainerERA5Gen2(BaseTrainer):
         for steps in range(batches_per_epoch):
             logs = {}
             loss = 0
-            y_pred_flat = None  # flat model output; used for loss, metrics, and rollout
-            y = None
+            full_data_dict = {}
 
             for t in range(1, self.forecast_len + 1):
                 batch = next(dl)
 
                 if t == 1:
-                    ic_preprocessed = apply_preblocks(self.ic_preblocks, batch, device=self.device)
-                    preprocessed_batch = apply_preblocks(self.step_preblocks, ic_preprocessed, device=self.device)
-                    x = preprocessed_batch["input"].float()
-                    if self.ensemble_size > 1:
-                        x = torch.repeat_interleave(x, self.ensemble_size, 0)
-                    full_data_dict = {
-                        "ic_preprocessed": ic_preprocessed,
-                        "metadata": preprocessed_batch["metadata"],
-                        "predicted": None,
-                    }
-                else:
-                    rollout_batch = assemble_rollout_batch(
-                        corrected_pred=full_data_dict["predicted"],
-                        ic_preprocessed=full_data_dict["ic_preprocessed"],
-                        curr_batch=batch,
+                    full_data_dict["ic_preprocessed"] = apply_preblocks(self.ic_preblocks, batch, device=self.device)
+                    full_data_dict.update(
+                        apply_preblocks(self.step_preblocks, full_data_dict["ic_preprocessed"], device=self.device)
                     )
-                    preprocessed_batch = apply_preblocks(self.step_preblocks, rollout_batch, device=self.device)
-                    x = preprocessed_batch["input"].float()
-                    if self.ensemble_size > 1:
-                        x = torch.repeat_interleave(x, self.ensemble_size, 0)
+                else:
+                    full_data_dict.update(
+                        apply_preblocks(
+                            self.step_preblocks, assemble_rollout_batch(full_data_dict, batch), device=self.device
+                        )
+                    )
+
+                if self.ensemble_size > 1:
+                    full_data_dict["x"] = torch.repeat_interleave(full_data_dict["x"], self.ensemble_size, 0)
 
                 if self.flag_clamp:
-                    x = torch.clamp(x, min=self.clamp_min, max=self.clamp_max)
+                    full_data_dict["x"] = torch.clamp(full_data_dict["x"], min=self.clamp_min, max=self.clamp_max)
 
                 with torch.autocast(device_type="cuda", enabled=self.amp):
-                    y_pred_flat = self.model(x)
+                    full_data_dict["y_pred"] = self.model(full_data_dict["x"])
 
-                # Postblocks first: Reconstruct splits y_pred_flat into a nested
-                # physical-space dict; subsequent blocks apply corrections in-place.
-                full_data_dict["predicted"] = y_pred_flat if self.retain_graph else y_pred_flat.detach()
                 full_data_dict = apply_postblocks(self.step_postblocks, full_data_dict)
 
-                # Loss on flat normalized prediction — y_pred_flat ref is still valid
-                # after postblocks replaced full_data_dict["predicted"].
                 if t in self.backprop_on_timestep:
-                    y = preprocessed_batch["target"].float()
                     if self.flag_clamp:
-                        y = torch.clamp(y, min=self.clamp_min, max=self.clamp_max)
+                        full_data_dict["y"] = torch.clamp(
+                            full_data_dict["y"].float(), min=self.clamp_min, max=self.clamp_max
+                        )
                     with torch.autocast(device_type="cuda", enabled=self.amp):
-                        loss = criterion(y.to(y_pred_flat.dtype), y_pred_flat).mean()
+                        loss = criterion(
+                            full_data_dict["y"].float().to(full_data_dict["y_pred"].dtype),
+                            full_data_dict["y_pred"],
+                        ).mean()
                     accum_log(logs, {"loss": loss.item()})
                     scaler.scale(loss).backward(retain_graph=self.retain_graph)
 
@@ -216,8 +207,8 @@ class TrainerERA5Gen2(BaseTrainer):
             if self.ema is not None:
                 self.ema.update(self.model)
 
-            if y_pred_flat is not None and y is not None:
-                metrics_dict = metrics(y_pred_flat, y)
+            if full_data_dict.get("y_pred") is not None and full_data_dict.get("y") is not None:
+                metrics_dict = metrics(full_data_dict["y_pred"], full_data_dict["y"])
                 for name, value in metrics_dict.items():
                     value = torch.Tensor([value]).to(self.device, non_blocking=True)
                     if self.distributed:
@@ -293,45 +284,44 @@ class TrainerERA5Gen2(BaseTrainer):
                 y = None
                 loss = 0
 
+                full_data_dict = {}
+
                 for t in range(1, self.valid_forecast_len + 1):
                     batch = next(dl)
 
                     if t == 1:
-                        ic_preprocessed = apply_preblocks(self.ic_preblocks, batch, device=self.device)
-                        preprocessed_batch = apply_preblocks(self.step_preblocks, ic_preprocessed, device=self.device)
-                        x = preprocessed_batch["input"].float()
-                        if self.ensemble_size > 1:
-                            x = torch.repeat_interleave(x, self.ensemble_size, 0)
-                        full_data_dict = {
-                            "ic_preprocessed": ic_preprocessed,
-                            "metadata": preprocessed_batch["metadata"],
-                            "predicted": None,
-                        }
-                    else:
-                        rollout_batch = assemble_rollout_batch(
-                            corrected_pred=full_data_dict["predicted"],
-                            ic_preprocessed=full_data_dict["ic_preprocessed"],
-                            curr_batch=batch,
+                        full_data_dict["ic_preprocessed"] = apply_preblocks(
+                            self.ic_preblocks, batch, device=self.device
                         )
-                        preprocessed_batch = apply_preblocks(self.step_preblocks, rollout_batch, device=self.device)
-                        x = preprocessed_batch["input"].float()
-                        if self.ensemble_size > 1:
-                            x = torch.repeat_interleave(x, self.ensemble_size, 0)
+                        full_data_dict.update(
+                            apply_preblocks(self.step_preblocks, full_data_dict["ic_preprocessed"], device=self.device)
+                        )
+                    else:
+                        full_data_dict.update(
+                            apply_preblocks(
+                                self.step_preblocks, assemble_rollout_batch(full_data_dict, batch), device=self.device
+                            )
+                        )
+
+                    if self.ensemble_size > 1:
+                        full_data_dict["x"] = torch.repeat_interleave(full_data_dict["x"], self.ensemble_size, 0)
 
                     if self.flag_clamp:
-                        x = torch.clamp(x, min=self.clamp_min, max=self.clamp_max)
+                        full_data_dict["x"] = torch.clamp(full_data_dict["x"], min=self.clamp_min, max=self.clamp_max)
 
-                    y_pred_flat = self.model(x.float())
-
-                    full_data_dict["predicted"] = y_pred_flat
+                    full_data_dict["y_pred"] = self.model(full_data_dict["x"])
                     full_data_dict = apply_postblocks(self.step_postblocks, full_data_dict)
 
                     if t == self.valid_forecast_len:
-                        y = preprocessed_batch["target"].float()
                         if self.flag_clamp:
-                            y = torch.clamp(y, min=self.clamp_min, max=self.clamp_max)
-                        loss = criterion(y.to(y_pred_flat.dtype), y_pred_flat).mean()
-                        metrics_dict = metrics(y_pred_flat.float(), y.float())
+                            full_data_dict["y"] = torch.clamp(
+                                full_data_dict["y"].float(), min=self.clamp_min, max=self.clamp_max
+                            )
+                        loss = criterion(
+                            full_data_dict["y"].float().to(full_data_dict["y_pred"].dtype),
+                            full_data_dict["y_pred"],
+                        ).mean()
+                        metrics_dict = metrics(full_data_dict["y_pred"].float(), full_data_dict["y"].float())
                         for name, value in metrics_dict.items():
                             value = torch.Tensor([value]).to(self.device, non_blocking=True)
                             if self.distributed:

--- a/credit/trainers/trainerERA5gen2.py
+++ b/credit/trainers/trainerERA5gen2.py
@@ -11,7 +11,7 @@ import optuna
 
 from credit.postblock import build_postblocks, apply_postblocks
 from credit.preblock import build_preblocks, apply_preblocks
-from credit.trainers.rollout_utils import build_rollout_input
+from credit.trainers.rollout_utils import assemble_rollout_batch
 from credit.scheduler import update_on_batch
 from credit.trainers.base_trainer import BaseTrainer
 from credit.trainers.utils import accum_log, cycle
@@ -30,8 +30,8 @@ class TrainerERA5Gen2(BaseTrainer):
           - forecast_len semantics: 1 = 1 step (Gen 1 used 0 = 1 step)
           - backprop_on_timestep: range(1, forecast_len+1) instead of range(0, forecast_len+2)
           - Validation config read from conf["validation_data"] if present, else conf["data"]
-          - Postblocks applied after model forward pass via apply_postblocks()
-          - Multi-step rollout uses build_rollout_input() driven by the t=1 channel map
+          - Postblocks applied after model forward pass via apply_postblocks(phase="per_step")
+          - Multi-step rollout uses assemble_rollout_batch() + apply_preblocks(phase="per_step") each step
 
         Args:
             model: The (possibly DDP/FSDP-wrapped) model.
@@ -41,12 +41,13 @@ class TrainerERA5Gen2(BaseTrainer):
         super().__init__(model, rank, conf)
         logger.info("Loading ERA5 Gen 2 trainer (new nested data schema, preblock-assembled batches)")
 
-        self.preblocks = build_preblocks(conf.get("preblocks", {}))
-        self.postblocks = build_postblocks(conf.get("postblocks", {}))
+        preblock_cfg = conf.get("preblocks", {})
+        self.ic_preblocks = build_preblocks(preblock_cfg, phase="ic_only")
+        self.step_preblocks = build_preblocks(preblock_cfg, phase="per_step")
 
-        # Cached from the first t=1 batch; covers ALL input variable groups.
-        # Used by build_rollout_input to assemble x at t > 1.
-        self.ic_channel_map = None
+        postblock_cfg = conf.get("postblocks", {})
+        self.step_postblocks = build_postblocks(postblock_cfg, phase="per_step")
+        self.rollout_postblocks = build_postblocks(postblock_cfg, phase="post_rollout")
 
         # ---- Data schema extraction (new nested schema) ----
         data_conf = conf["data"]
@@ -83,27 +84,6 @@ class TrainerERA5Gen2(BaseTrainer):
         self.skip_nan_prune = conf.get("trainer", {}).get("skip_nan_prune", False)
 
     # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    def _init_full_data_dict(self, batch: dict, _batch: dict, x: torch.Tensor) -> dict:
-        """Build the full_data_dict at t=1 from the raw batch and preblock output."""
-        return {
-            "raw": batch,
-            "preprocessed": {
-                "input": x,
-                "target": _batch.get("target"),
-                "metadata": _batch["metadata"],
-            },
-            "predicted": None,
-        }
-
-    def _update_full_data_dict(self, full_data_dict: dict, _batch: dict, x: torch.Tensor) -> None:
-        """Update preprocessed input/target in full_data_dict at t > 1 (in-place)."""
-        full_data_dict["preprocessed"]["input"] = x
-        full_data_dict["preprocessed"]["target"] = _batch.get("target")
-
-    # ------------------------------------------------------------------
     # Training loop
     # ------------------------------------------------------------------
 
@@ -112,12 +92,16 @@ class TrainerERA5Gen2(BaseTrainer):
         Train for one epoch.
 
         The inner loop iterates over forecast_len autoregressive steps. For each step:
-          1. Pull the next batch from the dataloader (contains per-field tensors).
-          2. Apply preblocks to assemble batch["preprocessed"]["input"] and ["target"].
-          3. At t=1: cache self.ic_channel_map and initialize full_data_dict.
-             At t>1: assemble x via build_rollout_input from the previous prediction.
-          4. Forward pass; compute loss on the flat (scaled) y_pred.
-          5. Apply postblocks (Reconstruct converts y_pred to nested variable dict).
+          1. Pull the next batch from the dataloader (raw, unnormalized).
+          2. At t=1: IC-only preblocks produce ic_preprocessed (regridded statics);
+             rollout preblocks produce the final normalized input x.
+             At t>1: assemble rollout batch from corrected_pred (prognostic),
+             ic_preprocessed (statics), and curr_batch (dynamic forcing);
+             rollout preblocks normalize and concat.
+          3. Forward pass → y_pred_flat (flat, normalized).
+          4. Apply postblocks: Reconstruct → inverse scaler → physics fixers.
+             After this, full_data_dict["predicted"] is a nested physical-space dict.
+          5. Compute loss on y_pred_flat vs the normalized target from preblocks.
 
         Args:
             epoch: Current epoch number.
@@ -159,36 +143,47 @@ class TrainerERA5Gen2(BaseTrainer):
             loss = 0
             y_pred_flat = None  # flat model output; used for loss, metrics, and rollout
             y = None
-            full_data_dict = None
 
             for t in range(1, self.forecast_len + 1):
                 batch = next(dl)
-                _batch = apply_preblocks(self.preblocks, batch, device=self.device)
 
                 if t == 1:
-                    self.ic_channel_map = _batch["metadata"]["input"]["_channel_map"]
-                    x = _batch["input"].float()
+                    ic_preprocessed = apply_preblocks(self.ic_preblocks, batch, device=self.device)
+                    preprocessed_batch = apply_preblocks(self.step_preblocks, ic_preprocessed, device=self.device)
+                    x = preprocessed_batch["input"].float()
                     if self.ensemble_size > 1:
                         x = torch.repeat_interleave(x, self.ensemble_size, 0)
-                    full_data_dict = self._init_full_data_dict(batch, _batch, x)
+                    full_data_dict = {
+                        "ic_preprocessed": ic_preprocessed,
+                        "metadata": preprocessed_batch["metadata"],
+                        "predicted": None,
+                    }
                 else:
-                    curr_dyn_input = _batch["input"].float()
+                    rollout_batch = assemble_rollout_batch(
+                        corrected_pred=full_data_dict["predicted"],
+                        ic_preprocessed=full_data_dict["ic_preprocessed"],
+                        curr_batch=batch,
+                    )
+                    preprocessed_batch = apply_preblocks(self.step_preblocks, rollout_batch, device=self.device)
+                    x = preprocessed_batch["input"].float()
                     if self.ensemble_size > 1:
-                        curr_dyn_input = torch.repeat_interleave(curr_dyn_input, self.ensemble_size, 0)
-                    x = build_rollout_input(full_data_dict, curr_dyn_input, self.ic_channel_map)
-                    self._update_full_data_dict(full_data_dict, _batch, x)
+                        x = torch.repeat_interleave(x, self.ensemble_size, 0)
 
                 if self.flag_clamp:
                     x = torch.clamp(x, min=self.clamp_min, max=self.clamp_max)
-                    full_data_dict["preprocessed"]["input"] = x
 
                 with torch.autocast(device_type="cuda", enabled=self.amp):
                     y_pred_flat = self.model(x)
 
-                # Loss on flat scaled prediction — computed before postblocks so
-                # the target and prediction are in the same (scaled) space.
+                # Postblocks first: Reconstruct splits y_pred_flat into a nested
+                # physical-space dict; subsequent blocks apply corrections in-place.
+                full_data_dict["predicted"] = y_pred_flat if self.retain_graph else y_pred_flat.detach()
+                full_data_dict = apply_postblocks(self.step_postblocks, full_data_dict)
+
+                # Loss on flat normalized prediction — y_pred_flat ref is still valid
+                # after postblocks replaced full_data_dict["predicted"].
                 if t in self.backprop_on_timestep:
-                    y = _batch["target"].float()
+                    y = preprocessed_batch["target"].float()
                     if self.flag_clamp:
                         y = torch.clamp(y, min=self.clamp_min, max=self.clamp_max)
                     with torch.autocast(device_type="cuda", enabled=self.amp):
@@ -196,14 +191,10 @@ class TrainerERA5Gen2(BaseTrainer):
                     accum_log(logs, {"loss": loss.item()})
                     scaler.scale(loss).backward(retain_graph=self.retain_graph)
 
-                # Postblocks — Reconstruct (if configured) splits y_pred_flat into
-                # a nested variable dict for the next rollout step.
-                full_data_dict["predicted"] = y_pred_flat if self.retain_graph else y_pred_flat.detach()
-                if self.postblocks:
-                    full_data_dict = apply_postblocks(self.postblocks, full_data_dict)
-
                 if self.distributed:
                     torch.distributed.barrier()
+
+            apply_postblocks(self.rollout_postblocks, full_data_dict)
 
             # optimizer step
             scaler.unscale_(optimizer)
@@ -301,37 +292,42 @@ class TrainerERA5Gen2(BaseTrainer):
                 y_pred_flat = None
                 y = None
                 loss = 0
-                full_data_dict = None
 
                 for t in range(1, self.valid_forecast_len + 1):
                     batch = next(dl)
-                    _batch = apply_preblocks(self.preblocks, batch, device=self.device)
 
                     if t == 1:
-                        self.ic_channel_map = _batch["metadata"]["input"]["_channel_map"]
-                        x = _batch["input"].float()
+                        ic_preprocessed = apply_preblocks(self.ic_preblocks, batch, device=self.device)
+                        preprocessed_batch = apply_preblocks(self.step_preblocks, ic_preprocessed, device=self.device)
+                        x = preprocessed_batch["input"].float()
                         if self.ensemble_size > 1:
                             x = torch.repeat_interleave(x, self.ensemble_size, 0)
-                        full_data_dict = self._init_full_data_dict(batch, _batch, x)
+                        full_data_dict = {
+                            "ic_preprocessed": ic_preprocessed,
+                            "metadata": preprocessed_batch["metadata"],
+                            "predicted": None,
+                        }
                     else:
-                        curr_dyn_input = _batch["input"].float()
+                        rollout_batch = assemble_rollout_batch(
+                            corrected_pred=full_data_dict["predicted"],
+                            ic_preprocessed=full_data_dict["ic_preprocessed"],
+                            curr_batch=batch,
+                        )
+                        preprocessed_batch = apply_preblocks(self.step_preblocks, rollout_batch, device=self.device)
+                        x = preprocessed_batch["input"].float()
                         if self.ensemble_size > 1:
-                            curr_dyn_input = torch.repeat_interleave(curr_dyn_input, self.ensemble_size, 0)
-                        x = build_rollout_input(full_data_dict, curr_dyn_input, self.ic_channel_map)
-                        self._update_full_data_dict(full_data_dict, _batch, x)
+                            x = torch.repeat_interleave(x, self.ensemble_size, 0)
 
                     if self.flag_clamp:
                         x = torch.clamp(x, min=self.clamp_min, max=self.clamp_max)
-                        full_data_dict["preprocessed"]["input"] = x
 
                     y_pred_flat = self.model(x.float())
 
                     full_data_dict["predicted"] = y_pred_flat
-                    if self.postblocks:
-                        full_data_dict = apply_postblocks(self.postblocks, full_data_dict)
+                    full_data_dict = apply_postblocks(self.step_postblocks, full_data_dict)
 
                     if t == self.valid_forecast_len:
-                        y = _batch["target"].float()
+                        y = preprocessed_batch["target"].float()
                         if self.flag_clamp:
                             y = torch.clamp(y, min=self.clamp_min, max=self.clamp_max)
                         loss = criterion(y.to(y_pred_flat.dtype), y_pred_flat).mean()
@@ -341,6 +337,8 @@ class TrainerERA5Gen2(BaseTrainer):
                             if self.distributed:
                                 dist.all_reduce(value, dist.ReduceOp.AVG, async_op=False)
                             results_dict[f"valid_{name}"].append(value[0].item())
+
+                apply_postblocks(self.rollout_postblocks, full_data_dict)
 
                 batch_loss = torch.Tensor([loss.item() if torch.is_tensor(loss) else loss]).to(self.device)
                 if self.distributed:

--- a/credit/trainers/trainerERA5gen2.py
+++ b/credit/trainers/trainerERA5gen2.py
@@ -9,9 +9,9 @@ import tqdm
 
 import optuna
 
-from credit.postblock.gen1 import GlobalMassFixer, GlobalWaterFixer, GlobalEnergyFixer
+from credit.postblock import build_postblocks, apply_postblocks
 from credit.preblock import build_preblocks, apply_preblocks
-from credit.datasets.channel_layout import build_channel_layout, update_x
+from credit.trainers.rollout_utils import build_rollout_input
 from credit.scheduler import update_on_batch
 from credit.trainers.base_trainer import BaseTrainer
 from credit.trainers.utils import accum_log, cycle
@@ -27,10 +27,11 @@ class TrainerERA5Gen2(BaseTrainer):
         Key differences from TrainerERA5Gen1:
           - Uses new nested data schema: conf["data"]["source"]["ERA5"]["variables"]
           - Applies preblocks to assemble batch tensors before the model forward pass
-            (no concat_and_reshape / reshape_only calls in the training loop)
           - forecast_len semantics: 1 = 1 step (Gen 1 used 0 = 1 step)
           - backprop_on_timestep: range(1, forecast_len+1) instead of range(0, forecast_len+2)
           - Validation config read from conf["validation_data"] if present, else conf["data"]
+          - Postblocks applied after model forward pass via apply_postblocks()
+          - Multi-step rollout uses build_rollout_input() driven by the t=1 channel map
 
         Args:
             model: The (possibly DDP/FSDP-wrapped) model.
@@ -40,42 +41,14 @@ class TrainerERA5Gen2(BaseTrainer):
         super().__init__(model, rank, conf)
         logger.info("Loading ERA5 Gen 2 trainer (new nested data schema, preblock-assembled batches)")
 
-        # ---- Preblock: config-driven transforms then auto-concat to tensors ----
         self.preblocks = build_preblocks(conf.get("preblocks", {}))
+        self.postblocks = build_postblocks(conf.get("postblocks", {}))
 
-        # ---- Postblock conservation fixers ----
-        post_conf = conf.get("model", {}).get("post_conf", {})
-        self.flag_mass_conserve = False
-        self.flag_water_conserve = False
-        self.flag_energy_conserve = False
-        self.opt_mass = None
-        self.opt_water = None
-        self.opt_energy = None
-
-        if post_conf.get("activate", False):
-            if post_conf.get("global_mass_fixer", {}).get("activate", False) and post_conf["global_mass_fixer"].get(
-                "activate_outside_model", False
-            ):
-                logger.info("Activate GlobalMassFixer outside of model")
-                self.flag_mass_conserve = True
-                self.opt_mass = GlobalMassFixer(post_conf)
-
-            if post_conf.get("global_water_fixer", {}).get("activate", False) and post_conf["global_water_fixer"].get(
-                "activate_outside_model", False
-            ):
-                logger.info("Activate GlobalWaterFixer outside of model")
-                self.flag_water_conserve = True
-                self.opt_water = GlobalWaterFixer(post_conf)
-
-            if post_conf.get("global_energy_fixer", {}).get("activate", False) and post_conf["global_energy_fixer"].get(
-                "activate_outside_model", False
-            ):
-                logger.info("Activate GlobalEnergyFixer outside of model")
-                self.flag_energy_conserve = True
-                self.opt_energy = GlobalEnergyFixer(post_conf)
+        # Cached from the first t=1 batch; covers ALL input variable groups.
+        # Used by build_rollout_input to assemble x at t > 1.
+        self.ic_channel_map = None
 
         # ---- Data schema extraction (new nested schema) ----
-        self.slices, _ = build_channel_layout(conf)
         data_conf = conf["data"]
         source = next(iter(data_conf["source"].values()))
         vars_conf = source["variables"]
@@ -107,8 +80,32 @@ class TrainerERA5Gen2(BaseTrainer):
         self.valid_forecast_len = data_valid.get("forecast_len", self.forecast_len)
 
         # If True, log a warning on NaN loss instead of raising TrialPruned.
-        # Useful for smoke tests with unnormalized data where NaN is expected.
         self.skip_nan_prune = conf.get("trainer", {}).get("skip_nan_prune", False)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _init_full_data_dict(self, batch: dict, _batch: dict, x: torch.Tensor) -> dict:
+        """Build the full_data_dict at t=1 from the raw batch and preblock output."""
+        return {
+            "raw": batch,
+            "preprocessed": {
+                "input": x,
+                "target": _batch.get("target"),
+                "metadata": _batch["metadata"],
+            },
+            "predicted": None,
+        }
+
+    def _update_full_data_dict(self, full_data_dict: dict, _batch: dict, x: torch.Tensor) -> None:
+        """Update preprocessed input/target in full_data_dict at t > 1 (in-place)."""
+        full_data_dict["preprocessed"]["input"] = x
+        full_data_dict["preprocessed"]["target"] = _batch.get("target")
+
+    # ------------------------------------------------------------------
+    # Training loop
+    # ------------------------------------------------------------------
 
     def train_one_epoch(self, epoch, trainloader, optimizer, criterion, scaler, scheduler, metrics):
         """
@@ -116,13 +113,14 @@ class TrainerERA5Gen2(BaseTrainer):
 
         The inner loop iterates over forecast_len autoregressive steps. For each step:
           1. Pull the next batch from the dataloader (contains per-field tensors).
-          2. Apply preblocks to assemble batch["x"] and batch["y"].
-          3. For t > 1, replace the prognostic channels of x with the previous y_pred.
-          4. Forward pass, optional postblock, loss and backprop on backprop_on_timestep.
+          2. Apply preblocks to assemble batch["preprocessed"]["input"] and ["target"].
+          3. At t=1: cache self.ic_channel_map and initialize full_data_dict.
+             At t>1: assemble x via build_rollout_input from the previous prediction.
+          4. Forward pass; compute loss on the flat (scaled) y_pred.
+          5. Apply postblocks (Reconstruct converts y_pred to nested variable dict).
 
         Args:
             epoch: Current epoch number.
-            conf: Full configuration dict.
             trainloader: DataLoader for training.
             optimizer, criterion, scaler, scheduler, metrics: Standard training objects.
 
@@ -133,11 +131,9 @@ class TrainerERA5Gen2(BaseTrainer):
             logger.info(f"ensemble training with ensemble_size {self.ensemble_size}")
         logger.info(f"Using grad-max-norm value: {self.grad_max_norm}")
 
-        # lambda scheduler steps once per epoch before batches
         if self.use_scheduler and self.scheduler_type == "lambda":
             scheduler.step()
 
-        # resolve effective batches_per_epoch
         from torch.utils.data import IterableDataset
 
         batches_per_epoch = self.batches_per_epoch
@@ -161,62 +157,50 @@ class TrainerERA5Gen2(BaseTrainer):
         for steps in range(batches_per_epoch):
             logs = {}
             loss = 0
-            x_init = None  # snapshot of x at step 1 for GlobalMassFixer
-            y_pred = None
+            y_pred_flat = None  # flat model output; used for loss, metrics, and rollout
             y = None
+            full_data_dict = None
 
             for t in range(1, self.forecast_len + 1):
                 batch = next(dl)
                 _batch = apply_preblocks(self.preblocks, batch, device=self.device)
-                x_raw, y_raw = _batch["input"], _batch["target"]
 
                 if t == 1:
-                    x = x_raw.float()
+                    self.ic_channel_map = _batch["metadata"]["input"]["_channel_map"]
+                    x = _batch["input"].float()
                     if self.ensemble_size > 1:
                         x = torch.repeat_interleave(x, self.ensemble_size, 0)
+                    full_data_dict = self._init_full_data_dict(batch, _batch, x)
                 else:
-                    # At t > 1 ERA5Dataset returns only dynamic_forcing channels.
-                    # update_x replaces dynfrc and prognostic slices; static stays.
-                    x_dynfrc = x_raw.float()
+                    curr_dyn_input = _batch["input"].float()
                     if self.ensemble_size > 1:
-                        x_dynfrc = torch.repeat_interleave(x_dynfrc, self.ensemble_size, 0)
-                    y_pred_in = y_pred if self.retain_graph else y_pred.detach()
-                    x = update_x(x, x_dynfrc, y_pred_in, self.slices)
+                        curr_dyn_input = torch.repeat_interleave(curr_dyn_input, self.ensemble_size, 0)
+                    x = build_rollout_input(full_data_dict, curr_dyn_input, self.ic_channel_map)
+                    self._update_full_data_dict(full_data_dict, _batch, x)
 
                 if self.flag_clamp:
                     x = torch.clamp(x, min=self.clamp_min, max=self.clamp_max)
+                    full_data_dict["preprocessed"]["input"] = x
 
                 with torch.autocast(device_type="cuda", enabled=self.amp):
-                    y_pred = self.model(x)
+                    y_pred_flat = self.model(x)
 
-                # postblock opts outside of model
-                if self.flag_mass_conserve:
-                    if t == 1:
-                        x_init = x.clone()
-                    input_dict = {"y_pred": y_pred, "x": x_init}
-                    input_dict = self.opt_mass(input_dict)
-                    y_pred = input_dict["y_pred"]
-
-                if self.flag_water_conserve:
-                    input_dict = {"y_pred": y_pred, "x": x}
-                    input_dict = self.opt_water(input_dict)
-                    y_pred = input_dict["y_pred"]
-
-                if self.flag_energy_conserve:
-                    input_dict = {"y_pred": y_pred, "x": x}
-                    input_dict = self.opt_energy(input_dict)
-                    y_pred = input_dict["y_pred"]
-
-                # backprop on specified timesteps
+                # Loss on flat scaled prediction — computed before postblocks so
+                # the target and prediction are in the same (scaled) space.
                 if t in self.backprop_on_timestep:
-                    y = y_raw.float()
+                    y = _batch["target"].float()
                     if self.flag_clamp:
                         y = torch.clamp(y, min=self.clamp_min, max=self.clamp_max)
-
                     with torch.autocast(device_type="cuda", enabled=self.amp):
-                        loss = criterion(y.to(y_pred.dtype), y_pred).mean()
+                        loss = criterion(y.to(y_pred_flat.dtype), y_pred_flat).mean()
                     accum_log(logs, {"loss": loss.item()})
                     scaler.scale(loss).backward(retain_graph=self.retain_graph)
+
+                # Postblocks — Reconstruct (if configured) splits y_pred_flat into
+                # a nested variable dict for the next rollout step.
+                full_data_dict["predicted"] = y_pred_flat if self.retain_graph else y_pred_flat.detach()
+                if self.postblocks:
+                    full_data_dict = apply_postblocks(self.postblocks, full_data_dict)
 
                 if self.distributed:
                     torch.distributed.barrier()
@@ -241,9 +225,8 @@ class TrainerERA5Gen2(BaseTrainer):
             if self.ema is not None:
                 self.ema.update(self.model)
 
-            # collect metrics
-            if y_pred is not None and y is not None:
-                metrics_dict = metrics(y_pred, y)
+            if y_pred_flat is not None and y is not None:
+                metrics_dict = metrics(y_pred_flat, y)
                 for name, value in metrics_dict.items():
                     value = torch.Tensor([value]).to(self.device, non_blocking=True)
                     if self.distributed:
@@ -274,16 +257,19 @@ class TrainerERA5Gen2(BaseTrainer):
 
         return results_dict
 
+    # ------------------------------------------------------------------
+    # Validation loop
+    # ------------------------------------------------------------------
+
     def validate(self, epoch, valid_loader, criterion, metrics):
         """
         Validate for one epoch.
 
         Runs self.valid_forecast_len autoregressive steps per sample.
-        Loss and metrics are computed only at the final step (t == self.valid_forecast_len).
+        Loss and metrics are computed only at the final step.
 
         Args:
             epoch: Current epoch number.
-            conf: Full configuration dict.
             valid_loader: DataLoader for validation.
             criterion, metrics: Loss and metric callables.
 
@@ -312,59 +298,44 @@ class TrainerERA5Gen2(BaseTrainer):
         dl = cycle(valid_loader)
         with torch.no_grad():
             for steps in range(valid_batches_per_epoch):
-                y_pred = None
+                y_pred_flat = None
                 y = None
                 loss = 0
-                x_init = None
+                full_data_dict = None
 
                 for t in range(1, self.valid_forecast_len + 1):
                     batch = next(dl)
                     _batch = apply_preblocks(self.preblocks, batch, device=self.device)
-                    x_raw, y_raw = _batch["input"], _batch["target"]
 
                     if t == 1:
-                        x = x_raw.float()
+                        self.ic_channel_map = _batch["metadata"]["input"]["_channel_map"]
+                        x = _batch["input"].float()
                         if self.ensemble_size > 1:
                             x = torch.repeat_interleave(x, self.ensemble_size, 0)
+                        full_data_dict = self._init_full_data_dict(batch, _batch, x)
                     else:
-                        # At t > 1 ERA5Dataset returns only dynamic_forcing channels.
-                        # update_x replaces dynfrc and prognostic slices; static stays.
-                        x_dynfrc = x_raw.float()
+                        curr_dyn_input = _batch["input"].float()
                         if self.ensemble_size > 1:
-                            x_dynfrc = torch.repeat_interleave(x_dynfrc, self.ensemble_size, 0)
-                        x = update_x(x, x_dynfrc, y_pred.detach(), self.slices)
+                            curr_dyn_input = torch.repeat_interleave(curr_dyn_input, self.ensemble_size, 0)
+                        x = build_rollout_input(full_data_dict, curr_dyn_input, self.ic_channel_map)
+                        self._update_full_data_dict(full_data_dict, _batch, x)
 
                     if self.flag_clamp:
                         x = torch.clamp(x, min=self.clamp_min, max=self.clamp_max)
+                        full_data_dict["preprocessed"]["input"] = x
 
-                    y_pred = self.model(x.float())
+                    y_pred_flat = self.model(x.float())
 
-                    # postblock opts outside of model
-                    if self.flag_mass_conserve:
-                        if t == 1:
-                            x_init = x.clone()
-                        input_dict = {"y_pred": y_pred, "x": x_init}
-                        input_dict = self.opt_mass(input_dict)
-                        y_pred = input_dict["y_pred"]
+                    full_data_dict["predicted"] = y_pred_flat
+                    if self.postblocks:
+                        full_data_dict = apply_postblocks(self.postblocks, full_data_dict)
 
-                    if self.flag_water_conserve:
-                        input_dict = {"y_pred": y_pred, "x": x}
-                        input_dict = self.opt_water(input_dict)
-                        y_pred = input_dict["y_pred"]
-
-                    if self.flag_energy_conserve:
-                        input_dict = {"y_pred": y_pred, "x": x}
-                        input_dict = self.opt_energy(input_dict)
-                        y_pred = input_dict["y_pred"]
-
-                    # compute loss and metrics only at the final rollout step
                     if t == self.valid_forecast_len:
-                        y = y_raw.float()
+                        y = _batch["target"].float()
                         if self.flag_clamp:
                             y = torch.clamp(y, min=self.clamp_min, max=self.clamp_max)
-
-                        loss = criterion(y.to(y_pred.dtype), y_pred).mean()
-                        metrics_dict = metrics(y_pred.float(), y.float())
+                        loss = criterion(y.to(y_pred_flat.dtype), y_pred_flat).mean()
+                        metrics_dict = metrics(y_pred_flat.float(), y.float())
                         for name, value in metrics_dict.items():
                             value = torch.Tensor([value]).to(self.device, non_blocking=True)
                             if self.distributed:

--- a/credit/trainers/trainerERA5gen2_legacy.py
+++ b/credit/trainers/trainerERA5gen2_legacy.py
@@ -1,0 +1,394 @@
+import gc
+import logging
+from collections import defaultdict
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import tqdm
+
+import optuna
+
+from credit.postblock.gen1 import GlobalMassFixer, GlobalWaterFixer, GlobalEnergyFixer
+from credit.preblock import build_preblocks, apply_preblocks
+from credit.datasets.channel_layout import build_channel_layout, update_x
+from credit.scheduler import update_on_batch
+from credit.trainers.base_trainer import BaseTrainer
+from credit.trainers.utils import accum_log, cycle
+
+logger = logging.getLogger(__name__)
+
+
+class TrainerERA5Gen2(BaseTrainer):
+    def __init__(self, model: torch.nn.Module, rank: int, conf: dict):
+        """
+        Gen 2 trainer for the ERA5 nested data schema.
+
+        Key differences from TrainerERA5Gen1:
+          - Uses new nested data schema: conf["data"]["source"]["ERA5"]["variables"]
+          - Applies preblocks to assemble batch tensors before the model forward pass
+            (no concat_and_reshape / reshape_only calls in the training loop)
+          - forecast_len semantics: 1 = 1 step (Gen 1 used 0 = 1 step)
+          - backprop_on_timestep: range(1, forecast_len+1) instead of range(0, forecast_len+2)
+          - Validation config read from conf["validation_data"] if present, else conf["data"]
+
+        Args:
+            model: The (possibly DDP/FSDP-wrapped) model.
+            rank: Global rank of this process.
+            conf: Full configuration dict.
+        """
+        super().__init__(model, rank, conf)
+        logger.info("Loading ERA5 Gen 2 trainer (new nested data schema, preblock-assembled batches)")
+
+        # ---- Preblock: config-driven transforms then auto-concat to tensors ----
+        self.preblocks = build_preblocks(conf.get("preblocks", {}))
+        #  TODO: Add build_postblocks()
+        # ---- Postblock conservation fixers ----
+        post_conf = conf.get("model", {}).get("post_conf", {})
+        self.flag_mass_conserve = False
+        self.flag_water_conserve = False
+        self.flag_energy_conserve = False
+        self.opt_mass = None
+        self.opt_water = None
+        self.opt_energy = None
+
+        if post_conf.get("activate", False):
+            if post_conf.get("global_mass_fixer", {}).get("activate", False) and post_conf["global_mass_fixer"].get(
+                "activate_outside_model", False
+            ):
+                logger.info("Activate GlobalMassFixer outside of model")
+                self.flag_mass_conserve = True
+                self.opt_mass = GlobalMassFixer(post_conf)
+
+            if post_conf.get("global_water_fixer", {}).get("activate", False) and post_conf["global_water_fixer"].get(
+                "activate_outside_model", False
+            ):
+                logger.info("Activate GlobalWaterFixer outside of model")
+                self.flag_water_conserve = True
+                self.opt_water = GlobalWaterFixer(post_conf)
+
+            if post_conf.get("global_energy_fixer", {}).get("activate", False) and post_conf["global_energy_fixer"].get(
+                "activate_outside_model", False
+            ):
+                logger.info("Activate GlobalEnergyFixer outside of model")
+                self.flag_energy_conserve = True
+                self.opt_energy = GlobalEnergyFixer(post_conf)
+
+        # ---- Data schema extraction (new nested schema) ----
+        self.slices, _ = build_channel_layout(conf)
+        data_conf = conf["data"]
+        source = next(iter(data_conf["source"].values()))
+        vars_conf = source["variables"]
+        diag = vars_conf.get("diagnostic") or {}
+        num_levels = len(source.get("levels", []))
+        self.varnum_diag = (len(diag.get("vars_3D", [])) * num_levels + len(diag.get("vars_2D", []))) if diag else 0
+
+        self.retain_graph = data_conf.get("retain_graph", False)
+
+        # forecast_len: 1 = 1 step (new semantics, unlike v1 where 0 = 1 step)
+        self.forecast_len = data_conf["forecast_len"]
+        trainer_conf = conf.get("trainer", {})
+        bpt = trainer_conf.get("backprop_on_timestep") or data_conf.get("backprop_on_timestep")
+        self.backprop_on_timestep = bpt if bpt is not None else list(range(1, self.forecast_len + 1))
+
+        data_clamp = data_conf.get("data_clamp")
+        if data_clamp is None:
+            self.flag_clamp = False
+            self.clamp_min = None
+            self.clamp_max = None
+        else:
+            self.flag_clamp = True
+            self.clamp_min = float(data_clamp[0])
+            self.clamp_max = float(data_clamp[1])
+
+        # Validation config: use validation_data block if present, else fall back to data
+        data_valid = conf.get("validation_data", data_conf)
+        self.valid_history_len = data_valid.get("history_len", data_conf.get("history_len", 1))
+        self.valid_forecast_len = data_valid.get("forecast_len", self.forecast_len)
+
+        # If True, log a warning on NaN loss instead of raising TrialPruned.
+        # Useful for smoke tests with unnormalized data where NaN is expected.
+        self.skip_nan_prune = conf.get("trainer", {}).get("skip_nan_prune", False)
+
+    def train_one_epoch(self, epoch, trainloader, optimizer, criterion, scaler, scheduler, metrics):
+        """
+        Train for one epoch.
+
+        The inner loop iterates over forecast_len autoregressive steps. For each step:
+          1. Pull the next batch from the dataloader (contains per-field tensors).
+          2. Apply preblocks to assemble batch["x"] and batch["y"].
+          3. For t > 1, replace the prognostic channels of x with the previous y_pred.
+          4. Forward pass, optional postblock, loss and backprop on backprop_on_timestep.
+
+        Args:
+            epoch: Current epoch number.
+            conf: Full configuration dict.
+            trainloader: DataLoader for training.
+            optimizer, criterion, scaler, scheduler, metrics: Standard training objects.
+
+        Returns:
+            dict: Training metrics for the epoch.
+        """
+        if self.ensemble_size > 1:
+            logger.info(f"ensemble training with ensemble_size {self.ensemble_size}")
+        logger.info(f"Using grad-max-norm value: {self.grad_max_norm}")
+
+        # lambda scheduler steps once per epoch before batches
+        if self.use_scheduler and self.scheduler_type == "lambda":
+            scheduler.step()
+
+        # resolve effective batches_per_epoch
+        from torch.utils.data import IterableDataset
+
+        batches_per_epoch = self.batches_per_epoch
+        if not isinstance(trainloader.dataset, IterableDataset):
+            if hasattr(trainloader.dataset, "batches_per_epoch"):
+                dataset_batches = trainloader.dataset.batches_per_epoch()
+            elif hasattr(trainloader.sampler, "batches_per_epoch"):
+                dataset_batches = trainloader.sampler.batches_per_epoch()
+            else:
+                dataset_batches = len(trainloader)
+            batches_per_epoch = (
+                self.batches_per_epoch if 0 < self.batches_per_epoch < dataset_batches else dataset_batches
+            )
+
+        batch_group_generator = tqdm.tqdm(range(batches_per_epoch), total=batches_per_epoch, leave=True)
+        self.model.train()
+
+        dl = cycle(trainloader)
+        results_dict = defaultdict(list)
+
+        for steps in range(batches_per_epoch):
+            logs = {}
+            loss = 0
+            x_init = None  # snapshot of x at step 1 for GlobalMassFixer
+            y_pred = None
+            y = None
+
+            for t in range(1, self.forecast_len + 1):
+                batch = next(dl)
+                _batch = apply_preblocks(self.preblocks, batch, device=self.device)
+                x_raw, y_raw = _batch["input"], _batch["target"]
+
+                if t == 1:
+                    x = x_raw.float()
+                    if self.ensemble_size > 1:
+                        x = torch.repeat_interleave(x, self.ensemble_size, 0)
+                else:
+                    # At t > 1 ERA5Dataset returns only dynamic_forcing channels.
+                    # update_x replaces dynfrc and prognostic slices; static stays.
+                    x_dynfrc = x_raw.float()
+                    if self.ensemble_size > 1:
+                        x_dynfrc = torch.repeat_interleave(x_dynfrc, self.ensemble_size, 0)
+                    y_pred_in = y_pred if self.retain_graph else y_pred.detach()
+                    x = update_x(x, x_dynfrc, y_pred_in, self.slices)
+
+                if self.flag_clamp:
+                    x = torch.clamp(x, min=self.clamp_min, max=self.clamp_max)
+
+                with torch.autocast(device_type="cuda", enabled=self.amp):
+                    y_pred = self.model(x)
+
+                # postblock opts outside of model
+                if self.flag_mass_conserve:
+                    if t == 1:
+                        x_init = x.clone()
+                    input_dict = {"y_pred": y_pred, "x": x_init}
+                    input_dict = self.opt_mass(input_dict)
+                    y_pred = input_dict["y_pred"]
+
+                if self.flag_water_conserve:
+                    input_dict = {"y_pred": y_pred, "x": x}
+                    input_dict = self.opt_water(input_dict)
+                    y_pred = input_dict["y_pred"]
+
+                if self.flag_energy_conserve:
+                    input_dict = {"y_pred": y_pred, "x": x}
+                    input_dict = self.opt_energy(input_dict)
+                    y_pred = input_dict["y_pred"]
+
+                # backprop on specified timesteps
+                if t in self.backprop_on_timestep:
+                    y = y_raw.float()
+                    if self.flag_clamp:
+                        y = torch.clamp(y, min=self.clamp_min, max=self.clamp_max)
+
+                    with torch.autocast(device_type="cuda", enabled=self.amp):
+                        loss = criterion(y.to(y_pred.dtype), y_pred).mean()
+                    accum_log(logs, {"loss": loss.item()})
+                    scaler.scale(loss).backward(retain_graph=self.retain_graph)
+
+                if self.distributed:
+                    torch.distributed.barrier()
+
+            # optimizer step
+            scaler.unscale_(optimizer)
+            if self.grad_max_norm == "dynamic":
+                local_norm = torch.norm(
+                    torch.stack([p.grad.detach().norm(2) for p in self.model.parameters() if p.grad is not None])
+                )
+                if self.distributed:
+                    dist.all_reduce(local_norm, op=dist.ReduceOp.SUM)
+                global_norm = local_norm.sqrt()
+                torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=global_norm)
+            elif self.grad_max_norm > 0.0:
+                torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=self.grad_max_norm)
+
+            scaler.step(optimizer)
+            scaler.update()
+            optimizer.zero_grad()
+
+            if self.ema is not None:
+                self.ema.update(self.model)
+
+            # collect metrics
+            if y_pred is not None and y is not None:
+                metrics_dict = metrics(y_pred, y)
+                for name, value in metrics_dict.items():
+                    value = torch.Tensor([value]).to(self.device, non_blocking=True)
+                    if self.distributed:
+                        dist.all_reduce(value, dist.ReduceOp.AVG, async_op=False)
+                    results_dict[f"train_{name}"].append(value[0].item())
+
+            batch_loss = torch.Tensor([logs.get("loss", 0.0)]).to(self.device)
+            if self.distributed:
+                dist.all_reduce(batch_loss, dist.ReduceOp.AVG, async_op=False)
+            results_dict["train_loss"].append(batch_loss[0].item())
+            results_dict["train_forecast_len"].append(self.forecast_len)
+
+            if not np.isfinite(np.mean(results_dict["train_loss"])):
+                print(results_dict["train_loss"])
+                if self.skip_nan_prune:
+                    logger.warning("NaN/Inf loss detected but skip_nan_prune=True; continuing.")
+                else:
+                    raise optuna.TrialPruned()
+
+            self._log_batch_progress(epoch, results_dict, optimizer, batch_group_generator, phase="train")
+
+            if self.use_scheduler and self.scheduler_type in update_on_batch:
+                scheduler.step()
+
+        batch_group_generator.close()
+        torch.cuda.empty_cache()
+        gc.collect()
+
+        return results_dict
+
+    def validate(self, epoch, valid_loader, criterion, metrics):
+        """
+        Validate for one epoch.
+
+        Runs self.valid_forecast_len autoregressive steps per sample.
+        Loss and metrics are computed only at the final step (t == self.valid_forecast_len).
+
+        Args:
+            epoch: Current epoch number.
+            conf: Full configuration dict.
+            valid_loader: DataLoader for validation.
+            criterion, metrics: Loss and metric callables.
+
+        Returns:
+            dict: Validation metrics for the epoch.
+        """
+        self.model.eval()
+
+        from torch.utils.data import IterableDataset
+
+        valid_batches_per_epoch = self.valid_batches_per_epoch
+        if not isinstance(valid_loader.dataset, IterableDataset):
+            if hasattr(valid_loader.dataset, "batches_per_epoch"):
+                dataset_batches = valid_loader.dataset.batches_per_epoch()
+            elif hasattr(valid_loader.sampler, "batches_per_epoch"):
+                dataset_batches = valid_loader.sampler.batches_per_epoch()
+            else:
+                dataset_batches = len(valid_loader)
+            valid_batches_per_epoch = (
+                self.valid_batches_per_epoch if 0 < self.valid_batches_per_epoch < dataset_batches else dataset_batches
+            )
+
+        results_dict = defaultdict(list)
+        batch_group_generator = tqdm.tqdm(range(valid_batches_per_epoch), total=valid_batches_per_epoch, leave=True)
+
+        dl = cycle(valid_loader)
+        with torch.no_grad():
+            for steps in range(valid_batches_per_epoch):
+                y_pred = None
+                y = None
+                loss = 0
+                x_init = None
+
+                for t in range(1, self.valid_forecast_len + 1):
+                    batch = next(dl)
+                    _batch = apply_preblocks(self.preblocks, batch, device=self.device)
+                    x_raw, y_raw = _batch["input"], _batch["target"]
+
+                    if t == 1:
+                        x = x_raw.float()
+                        if self.ensemble_size > 1:
+                            x = torch.repeat_interleave(x, self.ensemble_size, 0)
+                    else:
+                        # At t > 1 ERA5Dataset returns only dynamic_forcing channels.
+                        # update_x replaces dynfrc and prognostic slices; static stays.
+                        x_dynfrc = x_raw.float()
+                        if self.ensemble_size > 1:
+                            x_dynfrc = torch.repeat_interleave(x_dynfrc, self.ensemble_size, 0)
+                        x = update_x(x, x_dynfrc, y_pred.detach(), self.slices)
+
+                    if self.flag_clamp:
+                        x = torch.clamp(x, min=self.clamp_min, max=self.clamp_max)
+
+                    y_pred = self.model(x.float())
+
+                    # postblock opts outside of model
+                    if self.flag_mass_conserve:
+                        if t == 1:
+                            x_init = x.clone()
+                        input_dict = {"y_pred": y_pred, "x": x_init}
+                        input_dict = self.opt_mass(input_dict)
+                        y_pred = input_dict["y_pred"]
+
+                    if self.flag_water_conserve:
+                        input_dict = {"y_pred": y_pred, "x": x}
+                        input_dict = self.opt_water(input_dict)
+                        y_pred = input_dict["y_pred"]
+
+                    if self.flag_energy_conserve:
+                        input_dict = {"y_pred": y_pred, "x": x}
+                        input_dict = self.opt_energy(input_dict)
+                        y_pred = input_dict["y_pred"]
+
+                    # compute loss and metrics only at the final rollout step
+                    if t == self.valid_forecast_len:
+                        y = y_raw.float()
+                        if self.flag_clamp:
+                            y = torch.clamp(y, min=self.clamp_min, max=self.clamp_max)
+
+                        loss = criterion(y.to(y_pred.dtype), y_pred).mean()
+                        metrics_dict = metrics(y_pred.float(), y.float())
+                        for name, value in metrics_dict.items():
+                            value = torch.Tensor([value]).to(self.device, non_blocking=True)
+                            if self.distributed:
+                                dist.all_reduce(value, dist.ReduceOp.AVG, async_op=False)
+                            results_dict[f"valid_{name}"].append(value[0].item())
+
+                batch_loss = torch.Tensor([loss.item() if torch.is_tensor(loss) else loss]).to(self.device)
+                if self.distributed:
+                    torch.distributed.barrier()
+
+                results_dict["valid_loss"].append(batch_loss[0].item())
+                results_dict["valid_forecast_len"].append(self.valid_forecast_len)
+
+                self._log_batch_progress(epoch, results_dict, optimizer=None, pbar=batch_group_generator, phase="valid")
+
+        batch_group_generator.close()
+
+        if self.distributed:
+            torch.distributed.barrier()
+
+        torch.cuda.empty_cache()
+        gc.collect()
+
+        return results_dict
+
+
+Trainer = TrainerERA5Gen2  # canonical alias, matches other trainer modules

--- a/tests/test_era5gen2_equivalency.py
+++ b/tests/test_era5gen2_equivalency.py
@@ -1,0 +1,424 @@
+"""Equivalency tests: verify that trainerERA5gen2 (new) and trainerERA5gen2_legacy
+produce bit-identical flat y_pred tensors for the same model, batch, and config.
+
+Three assertions are verified:
+  1. y_pred at t=1 is identical (single-step and multi-step configs).
+  2. x fed to the model at t=2 is identical (multi-step rollout correctness).
+  3. The final training loss is identical.
+
+The new trainer uses build_rollout_input + postblocks; the legacy trainer uses
+update_x + build_channel_layout.  Both are exercised with and without Reconstruct
+to cover both code paths in build_rollout_input.
+"""
+
+import torch
+import torch.nn as nn
+import pytest
+
+try:
+    from credit.trainers.trainerERA5gen2_legacy import TrainerERA5Gen2 as LegacyTrainer
+    from credit.trainers.trainerERA5gen2 import TrainerERA5Gen2 as NewTrainer
+
+    _AVAILABLE = True
+except ImportError as e:
+    _AVAILABLE = False
+    _IMPORT_ERR = str(e)
+
+pytestmark = pytest.mark.skipif(not _AVAILABLE, reason=f"Trainers not importable: {locals().get('_IMPORT_ERR', '')}")
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+class _ScaleModel(nn.Module):
+    """Shape-preserving model: multiplies input by a learned scalar."""
+
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.ones(1))
+
+    def forward(self, x):
+        return x * self.w
+
+
+class _ProgOnlyModel(nn.Module):
+    """Returns only the first n_prog input channels, scaled by a learned scalar.
+
+    Simulates a realistic model that predicts only prognostic variables,
+    producing output shape (B, n_prog, H, W) regardless of input channel count.
+    """
+
+    def __init__(self, n_prog: int):
+        super().__init__()
+        self.n_prog = n_prog
+        self.w = nn.Parameter(torch.ones(1))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x[:, : self.n_prog, ...] * self.w
+
+
+class _RecordingModel(nn.Module):
+    """Wraps a model and records every (x, y_pred) pair seen during forward."""
+
+    def __init__(self, base: nn.Module):
+        super().__init__()
+        self.base = base
+        self.inputs: list[torch.Tensor] = []
+        self.outputs: list[torch.Tensor] = []
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.base(x)
+        self.inputs.append(x.detach().clone())
+        self.outputs.append(out.detach().clone())
+        return out
+
+
+class _FakeDataset:
+    pass
+
+
+class _FullLoader:
+    """Yields full batches (all variable groups) for every step."""
+
+    def __init__(self, B, C, H, W, n_batches, seed=0):
+        self.dataset = _FakeDataset()
+        self.sampler = None
+        self._B, self._C, self._H, self._W = B, C, H, W
+        self._n = n_batches
+        self._seed = seed
+
+    def __len__(self):
+        return self._n
+
+    def __iter__(self):
+        g = torch.Generator()
+        g.manual_seed(self._seed)
+        for _ in range(self._n):
+            input_vars = {
+                f"era5/prognostic/2d/v{i}": torch.randn(self._B, 1, 1, self._H, self._W, generator=g)
+                for i in range(self._C)
+            }
+            target_vars = {
+                f"era5/prognostic/2d/v{i}": torch.randn(self._B, 1, 1, self._H, self._W, generator=g)
+                for i in range(self._C)
+            }
+            yield {"input": {"era5": input_vars}, "target": {"era5": target_vars}}
+
+
+class _PartialLoader:
+    """Step 1: full batch (prog + static + dynfrc). Step 2+: dynfrc only.
+
+    Simulates the ERA5Dataset behaviour where t>1 batches contain only
+    dynamic_forcing channels.
+    """
+
+    N_PROG = 3
+    N_STATIC = 1
+    N_DYNFRC = 2
+
+    def __init__(self, B, H, W, forecast_len, seed=0):
+        self.dataset = _FakeDataset()
+        self.sampler = None
+        self._B, self._H, self._W = B, H, W
+        self._forecast_len = forecast_len
+        self._seed = seed
+
+    def __len__(self):
+        return self._forecast_len
+
+    def __iter__(self):
+        g = torch.Generator()
+        g.manual_seed(self._seed)
+
+        N_P, N_S, N_D = self.N_PROG, self.N_STATIC, self.N_DYNFRC
+        B, H, W = self._B, self._H, self._W
+
+        # t=1: full batch
+        full_input = {}
+        for i in range(N_P):
+            full_input[f"era5/prognostic/2d/p{i}"] = torch.randn(B, 1, 1, H, W, generator=g)
+        for i in range(N_S):
+            full_input[f"era5/static/2d/s{i}"] = torch.randn(B, 1, 1, H, W, generator=g)
+        for i in range(N_D):
+            full_input[f"era5/dynamic_forcing/2d/d{i}"] = torch.randn(B, 1, 1, H, W, generator=g)
+        target = {f"era5/prognostic/2d/p{i}": torch.randn(B, 1, 1, H, W, generator=g) for i in range(N_P)}
+        yield {"input": {"era5": full_input}, "target": {"era5": target}}
+
+        # t=2+: only dynfrc
+        for _ in range(1, self._forecast_len):
+            partial = {f"era5/dynamic_forcing/2d/d{i}": torch.randn(B, 1, 1, H, W, generator=g) for i in range(N_D)}
+            yield {"input": {"era5": partial}, "target": {"era5": target}}
+
+
+def _minimal_conf(tmp_path):
+    return {
+        "trainer": {
+            "mode": "none",
+            "start_epoch": 0,
+            "epochs": 1,
+            "num_epoch": 1,
+            "amp": False,
+            "use_scheduler": False,
+            "use_ema": False,
+            "use_tensorboard": False,
+            "skip_validation": False,
+            "train_batch_size": 1,
+            "batches_per_epoch": 1,
+            "valid_batches_per_epoch": 1,
+        },
+        "save_loc": str(tmp_path),
+    }
+
+
+def _gen2_conf_simple(tmp_path, forecast_len, C):
+    """Config where every variable is a 2D prognostic (simplest possible layout)."""
+    conf = _minimal_conf(tmp_path)
+    conf["data"] = {
+        "forecast_len": forecast_len,
+        "retain_graph": False,
+        "source": {
+            "ERA5": {
+                "levels": [],
+                "variables": {
+                    "prognostic": {"vars_3D": [], "vars_2D": [f"v{i}" for i in range(C)]},
+                    "diagnostic": {"vars_3D": [], "vars_2D": []},
+                    "dynamic_forcing": {"vars_2D": []},
+                    "static": {"vars_2D": []},
+                },
+            }
+        },
+    }
+    conf["preblocks"] = {"concat": {"type": "concat"}}
+    return conf
+
+
+def _gen2_conf_mixed(tmp_path, forecast_len):
+    """Config with prog + static + dynfrc variable groups (matches _PartialLoader)."""
+    conf = _minimal_conf(tmp_path)
+    N_P, N_S, N_D = _PartialLoader.N_PROG, _PartialLoader.N_STATIC, _PartialLoader.N_DYNFRC
+    conf["data"] = {
+        "forecast_len": forecast_len,
+        "retain_graph": False,
+        "source": {
+            "ERA5": {
+                "levels": [],
+                "variables": {
+                    "prognostic": {"vars_3D": [], "vars_2D": [f"p{i}" for i in range(N_P)]},
+                    "diagnostic": {"vars_3D": [], "vars_2D": []},
+                    "dynamic_forcing": {"vars_2D": [f"d{i}" for i in range(N_D)]},
+                    "static": {"vars_2D": [f"s{i}" for i in range(N_S)]},
+                },
+            }
+        },
+    }
+    conf["preblocks"] = {"concat": {"type": "concat"}}
+    return conf
+
+
+def _run_train(trainer_cls, model, conf, loader):
+    """Run one epoch with a recording model; return (recording_model, results)."""
+    rec = _RecordingModel(model)
+    trainer = trainer_cls(rec, rank=0, conf=conf)
+    optimizer = torch.optim.SGD(rec.parameters(), lr=1e-4)
+    criterion = nn.MSELoss()
+    scaler = torch.amp.GradScaler("cpu", enabled=False)
+    results = trainer.train_one_epoch(
+        epoch=0,
+        trainloader=loader,
+        optimizer=optimizer,
+        criterion=criterion,
+        scaler=scaler,
+        scheduler=None,
+        metrics=lambda p, y: {},
+    )
+    return rec, results
+
+
+# ---------------------------------------------------------------------------
+# Single-step equivalency: y_pred at t=1 is identical
+# ---------------------------------------------------------------------------
+
+
+class TestSingleStepEquivalency:
+    """forecast_len=1 — new and legacy trainers must produce identical y_pred."""
+
+    def test_y_pred_identical(self, tmp_path):
+        B, C, H, W = 1, 4, 4, 4
+        torch.manual_seed(42)
+        base = _ScaleModel()
+
+        model_legacy = _ScaleModel()
+        model_new = _ScaleModel()
+        model_new.load_state_dict(base.state_dict())
+        model_legacy.load_state_dict(base.state_dict())
+
+        conf_legacy = _gen2_conf_simple(tmp_path / "legacy", forecast_len=1, C=C)
+        conf_new = _gen2_conf_simple(tmp_path / "new", forecast_len=1, C=C)
+
+        loader_legacy = _FullLoader(B, C, H, W, n_batches=1, seed=7)
+        loader_new = _FullLoader(B, C, H, W, n_batches=1, seed=7)
+
+        rec_legacy, _ = _run_train(LegacyTrainer, model_legacy, conf_legacy, loader_legacy)
+        rec_new, _ = _run_train(NewTrainer, model_new, conf_new, loader_new)
+
+        assert len(rec_legacy.outputs) == 1 and len(rec_new.outputs) == 1
+        torch.testing.assert_close(rec_legacy.outputs[0], rec_new.outputs[0], atol=0, rtol=0)
+
+    def test_input_to_model_identical(self, tmp_path):
+        """x fed to the model at t=1 is the same in both trainers."""
+        B, C, H, W = 1, 4, 4, 4
+        torch.manual_seed(99)
+        base = _ScaleModel()
+
+        model_legacy, model_new = _ScaleModel(), _ScaleModel()
+        model_legacy.load_state_dict(base.state_dict())
+        model_new.load_state_dict(base.state_dict())
+
+        conf_legacy = _gen2_conf_simple(tmp_path / "legacy", forecast_len=1, C=C)
+        conf_new = _gen2_conf_simple(tmp_path / "new", forecast_len=1, C=C)
+
+        loader = _FullLoader(B, C, H, W, n_batches=1, seed=13)
+
+        rec_legacy, _ = _run_train(LegacyTrainer, model_legacy, conf_legacy, _FullLoader(B, C, H, W, 1, 13))
+        rec_new, _ = _run_train(NewTrainer, model_new, conf_new, _FullLoader(B, C, H, W, 1, 13))
+
+        torch.testing.assert_close(rec_legacy.inputs[0], rec_new.inputs[0], atol=0, rtol=0)
+
+    def test_loss_identical(self, tmp_path):
+        B, C, H, W = 1, 4, 4, 4
+        base = _ScaleModel()
+        model_legacy, model_new = _ScaleModel(), _ScaleModel()
+        model_legacy.load_state_dict(base.state_dict())
+        model_new.load_state_dict(base.state_dict())
+
+        conf_legacy = _gen2_conf_simple(tmp_path / "legacy", forecast_len=1, C=C)
+        conf_new = _gen2_conf_simple(tmp_path / "new", forecast_len=1, C=C)
+
+        _, res_legacy = _run_train(LegacyTrainer, model_legacy, conf_legacy, _FullLoader(B, C, H, W, 1, 55))
+        _, res_new = _run_train(NewTrainer, model_new, conf_new, _FullLoader(B, C, H, W, 1, 55))
+
+        assert abs(res_legacy["train_loss"][0] - res_new["train_loss"][0]) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Multi-step equivalency: x at t=2 and y_pred at t=2 are identical
+# ---------------------------------------------------------------------------
+
+
+class TestMultiStepEquivalencyNoPostblocks:
+    """forecast_len=2, postblocks={}.
+
+    build_rollout_input falls back to the flat-tensor path (no Reconstruct),
+    which should replicate update_x exactly.
+    """
+
+    def _models(self):
+        base = _ProgOnlyModel(_PartialLoader.N_PROG)
+        legacy = _ProgOnlyModel(_PartialLoader.N_PROG)
+        new = _ProgOnlyModel(_PartialLoader.N_PROG)
+        legacy.load_state_dict(base.state_dict())
+        new.load_state_dict(base.state_dict())
+        return legacy, new
+
+    def test_x_at_t2_identical(self, tmp_path):
+        B, H, W = 1, 4, 4
+        model_legacy, model_new = self._models()
+
+        conf_legacy = _gen2_conf_mixed(tmp_path / "legacy", forecast_len=2)
+        conf_new = _gen2_conf_mixed(tmp_path / "new", forecast_len=2)
+
+        seed = 21
+        rec_legacy, _ = _run_train(LegacyTrainer, model_legacy, conf_legacy, _PartialLoader(B, H, W, 2, seed))
+        rec_new, _ = _run_train(NewTrainer, model_new, conf_new, _PartialLoader(B, H, W, 2, seed))
+
+        assert len(rec_legacy.inputs) == 2 and len(rec_new.inputs) == 2
+        torch.testing.assert_close(rec_legacy.inputs[1], rec_new.inputs[1], atol=1e-6, rtol=1e-6)
+
+    def test_y_pred_at_t2_identical(self, tmp_path):
+        B, H, W = 1, 4, 4
+        model_legacy, model_new = self._models()
+
+        conf_legacy = _gen2_conf_mixed(tmp_path / "legacy", forecast_len=2)
+        conf_new = _gen2_conf_mixed(tmp_path / "new", forecast_len=2)
+
+        seed = 33
+        rec_legacy, _ = _run_train(LegacyTrainer, model_legacy, conf_legacy, _PartialLoader(B, H, W, 2, seed))
+        rec_new, _ = _run_train(NewTrainer, model_new, conf_new, _PartialLoader(B, H, W, 2, seed))
+
+        torch.testing.assert_close(rec_legacy.outputs[1], rec_new.outputs[1], atol=1e-6, rtol=1e-6)
+
+    def test_loss_identical(self, tmp_path):
+        B, H, W = 1, 4, 4
+        model_legacy, model_new = self._models()
+
+        conf_legacy = _gen2_conf_mixed(tmp_path / "legacy", forecast_len=2)
+        conf_new = _gen2_conf_mixed(tmp_path / "new", forecast_len=2)
+
+        seed = 77
+        _, res_legacy = _run_train(LegacyTrainer, model_legacy, conf_legacy, _PartialLoader(B, H, W, 2, seed))
+        _, res_new = _run_train(NewTrainer, model_new, conf_new, _PartialLoader(B, H, W, 2, seed))
+
+        assert abs(res_legacy["train_loss"][0] - res_new["train_loss"][0]) < 1e-6
+
+
+class TestMultiStepEquivalencyWithReconstruct:
+    """forecast_len=2 with Reconstruct in postblocks.
+
+    build_rollout_input uses the nested-dict path.  The result must still
+    be bit-identical to the legacy update_x path.
+    """
+
+    def _models(self):
+        base = _ProgOnlyModel(_PartialLoader.N_PROG)
+        legacy = _ProgOnlyModel(_PartialLoader.N_PROG)
+        new = _ProgOnlyModel(_PartialLoader.N_PROG)
+        legacy.load_state_dict(base.state_dict())
+        new.load_state_dict(base.state_dict())
+        return legacy, new
+
+    def _new_conf_with_reconstruct(self, tmp_path, forecast_len):
+        conf = _gen2_conf_mixed(tmp_path, forecast_len)
+        conf["postblocks"] = {"reconstruct": {"type": "reconstruct"}}
+        return conf
+
+    def test_x_at_t2_identical(self, tmp_path):
+        B, H, W = 1, 4, 4
+        model_legacy, model_new = self._models()
+
+        conf_legacy = _gen2_conf_mixed(tmp_path / "legacy", forecast_len=2)
+        conf_new = self._new_conf_with_reconstruct(tmp_path / "new", forecast_len=2)
+
+        seed = 44
+        rec_legacy, _ = _run_train(LegacyTrainer, model_legacy, conf_legacy, _PartialLoader(B, H, W, 2, seed))
+        rec_new, _ = _run_train(NewTrainer, model_new, conf_new, _PartialLoader(B, H, W, 2, seed))
+
+        assert len(rec_legacy.inputs) == 2 and len(rec_new.inputs) == 2
+        torch.testing.assert_close(rec_legacy.inputs[1], rec_new.inputs[1], atol=1e-6, rtol=1e-6)
+
+    def test_y_pred_at_t2_identical(self, tmp_path):
+        B, H, W = 1, 4, 4
+        model_legacy, model_new = self._models()
+
+        conf_legacy = _gen2_conf_mixed(tmp_path / "legacy", forecast_len=2)
+        conf_new = self._new_conf_with_reconstruct(tmp_path / "new", forecast_len=2)
+
+        seed = 66
+        rec_legacy, _ = _run_train(LegacyTrainer, model_legacy, conf_legacy, _PartialLoader(B, H, W, 2, seed))
+        rec_new, _ = _run_train(NewTrainer, model_new, conf_new, _PartialLoader(B, H, W, 2, seed))
+
+        torch.testing.assert_close(rec_legacy.outputs[1], rec_new.outputs[1], atol=1e-6, rtol=1e-6)
+
+    def test_loss_identical(self, tmp_path):
+        B, H, W = 1, 4, 4
+        model_legacy, model_new = self._models()
+
+        conf_legacy = _gen2_conf_mixed(tmp_path / "legacy", forecast_len=2)
+        conf_new = self._new_conf_with_reconstruct(tmp_path / "new", forecast_len=2)
+
+        seed = 88
+        _, res_legacy = _run_train(LegacyTrainer, model_legacy, conf_legacy, _PartialLoader(B, H, W, 2, seed))
+        _, res_new = _run_train(NewTrainer, model_new, conf_new, _PartialLoader(B, H, W, 2, seed))
+
+        assert abs(res_legacy["train_loss"][0] - res_new["train_loss"][0]) < 1e-6


### PR DESCRIPTION
### Description
This integrates the new postblock and data schema into `trainerERA5Gen2.py`. 

The new full data schema is a super dictionary that contains raw data from the loader, preprocessed data by the preblocks, and the model predictions, which is then fed to the postblocks. 

I have lightly tested it with using the reconstruct postblock, successfully. For now, I converted the original trainer into a legacy trainer module and implemented an equivalency test. We can remove the legacy trainer and this test once this is more throughly tested and approved. 

Once we settle on the details of how this operates, it should be relatively straight forward to implement into the other trainers and rollout scripts. 

I also had an LLM do a conversion of the `gen1.py` postblocks into their own modules to fit the new postblock scheme, but they are NOT ready yet and still need significant work. Once I work out a couple more details (and clean the conservation postblocks) I will convert this over from draft to a regular PR. That said, I still think it would be useful to get review feedback on this.  

Closes #374

### Checklist
- [ ] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date.
