### PR TITLE
Cbecker gen2

### DIFF
--- a/config/gen_2/examples/example-v2026.2.yml
+++ b/config/gen_2/examples/example-v2026.2.yml
@@ -29,19 +29,19 @@ data:
         prognostic:
           vars_3D: [ 'u_component_of_wind', 'v_component_of_wind', 'temperature', 'specific_total_water' ]
           vars_2D: [ 'SP', 'VAR_2T', 'VAR_10U', 'VAR_10V' ]
-          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h*'
+          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h_subset_%Y*'
 
         # Diagnostic: model predicts these but does not feed them back as input
         diagnostic:
           vars_2D: [ 'total_precipitation', 'evaporation', 'top_net_thermal_radiation', 'top_net_solar_radiation',
                      'surface_latent_heat_flux', 'surface_net_solar_radiation',
                      'surface_net_thermal_radiation', 'surface_sensible_heat_flux' ]
-          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h*'
+          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h_subset_%Y*'
 
         # Dynamic forcing: time-varying inputs (not predicted)
         dynamic_forcing:
           vars_2D: [ 'toa_incident_solar_radiation', 'land_sea_CI_mask' ]
-          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h*'
+          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h_subset_%Y*'
 
         # Static: time-invariant inputs (not predicted)
         static:

--- a/config/gen_2/examples/multi_source_data.yml
+++ b/config/gen_2/examples/multi_source_data.yml
@@ -46,21 +46,19 @@ data:
                 static: null
 
 preblocks:
-    per_step:
-        log_transform:
-            type: "log_transform"
-            args:
-                variables:
-                    - 'ERA5_LowerAir/prognostic/3d/Q'
-                    - 'ERA5_LowerAir/prognostic/2d/SP'
-                    - 'ERA5_LowerAir/dynamic_forcing/2d/tsi'
-                data_types:
-                    - 'input'
-                    - 'target'
-        concatenate:
-            type: "concat"
+    log_transform:
+      type: "log_transform"
+      args:
+          variables:
+                - 'ERA5_LowerAir/prognostic/3d/Q'
+                - 'ERA5_LowerAir/prognostic/2d/SP'
+                - 'ERA5_LowerAir/dynamic_forcing/2d/tsi'
+          data_types:
+            - 'input'
+            - 'target'
+    concatenate:
+      type: "concat"
 
 postblocks:
-    per_step:
-        reconstruct:
-            type: "reconstruct"
+  reconstruct:
+    type: "reconstruct"

--- a/config/gen_2/examples/multi_source_data.yml
+++ b/config/gen_2/examples/multi_source_data.yml
@@ -46,19 +46,21 @@ data:
                 static: null
 
 preblocks:
-    log_transform:
-      type: "log_transform"
-      args:
-          variables:
-                - 'ERA5_LowerAir/prognostic/3d/Q'
-                - 'ERA5_LowerAir/prognostic/2d/SP'
-                - 'ERA5_LowerAir/dynamic_forcing/2d/tsi'
-          data_types:
-            - 'input'
-            - 'target'
-    concatenate:
-      type: "concat"
+    per_step:
+        log_transform:
+            type: "log_transform"
+            args:
+                variables:
+                    - 'ERA5_LowerAir/prognostic/3d/Q'
+                    - 'ERA5_LowerAir/prognostic/2d/SP'
+                    - 'ERA5_LowerAir/dynamic_forcing/2d/tsi'
+                data_types:
+                    - 'input'
+                    - 'target'
+        concatenate:
+            type: "concat"
 
 postblocks:
-  reconstruct:
-    type: "reconstruct"
+    per_step:
+        reconstruct:
+            type: "reconstruct"

--- a/config/gen_2/examples/wxformer_era5_025deg_6hr.yml
+++ b/config/gen_2/examples/wxformer_era5_025deg_6hr.yml
@@ -20,17 +20,17 @@ data:
         prognostic:
           vars_3D: [ 'U', 'V', 'T', 'specific_total_water' ]
           vars_2D: [ 'SP', 'VAR_2T', 'VAR_10U', 'VAR_10V' ]
-          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/all_in_one/ERA5_plevel_6h_*.zarr'
+          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/all_in_one/ERA5_plevel_6h_%Y.zarr'
 
         diagnostic:
           vars_2D: [ 'total_precipitation', 'evaporation', 'top_net_thermal_radiation', 'top_net_solar_radiation',
                      'surface_latent_heat_flux', 'surface_net_solar_radiation',
                      'surface_net_thermal_radiation', 'surface_sensible_heat_flux' ]
-          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/all_in_one/ERA5_plevel_6h_*.zarr'
+          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/all_in_one/ERA5_plevel_6h_%Y*.zarr'
 
         dynamic_forcing:
           vars_2D: [ 'toa_incident_solar_radiation', 'land_sea_CI_mask' ]
-          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/all_in_one/ERA5_plevel_6h_*.zarr'
+          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/all_in_one/ERA5_plevel_6h_%Y*.zarr'
 
         static:
           vars_2D: [ 'z_norm', 'land_sea_mask' ]

--- a/config/gen_2/examples/wxformer_npj_era5_028deg.yml
+++ b/config/gen_2/examples/wxformer_npj_era5_028deg.yml
@@ -18,7 +18,7 @@ data:
         prognostic:
           vars_3D: ['U', 'V', 'T', 'Q']
           vars_2D: ['SP', 't2m', 'V500', 'U500', 'T500', 'Z500', 'Q500']
-          path: '/glade/campaign/cisl/aiml/wchapman/MLWPS/STAGING/y_TOTAL*'
+          path: '/glade/campaign/cisl/aiml/wchapman/MLWPS/STAGING/y_TOTAL_%Y-*.zarr'
 
         static:
           vars_2D: ['Z_GDS4_SFC', 'LSM']
@@ -26,7 +26,7 @@ data:
 
         dynamic_forcing:
           vars_2D: ['tsi']
-          path: '/glade/derecho/scratch/dgagne/credit_solar_nc_1h_0.25deg/*.nc'
+          path: '/glade/derecho/scratch/dgagne/credit_solar_nc_1h_0.25deg/solar_irradiance_%Y-*.nc'
 
         diagnostic: null
 

--- a/config/gen_2/smoke/smoke_gen2_casper.yml
+++ b/config/gen_2/smoke/smoke_gen2_casper.yml
@@ -16,12 +16,10 @@ data:
         prognostic:
           vars_3D: ["U", "V", "T", "Q"]
           vars_2D: ["SP", "t2m", "V500", "U500", "T500", "Z500", "Q500"]
-          path: "/glade/campaign/cisl/aiml/credit/era5_zarr/SixHourly_y_TOTAL*"
-          filename_time_format: "%Y"
+          path: "/glade/campaign/cisl/aiml/credit/era5_zarr/SixHourly_y_TOTAL_%Y-*"
         dynamic_forcing:
           vars_2D: ["tsi"]
-          path: "/glade/campaign/cisl/aiml/credit/credit_solar_nc_6h_0.25deg/*.nc"
-          filename_time_format: "%Y"
+          path: "/glade/campaign/cisl/aiml/credit/credit_solar_nc_6h_0.25deg/solar_irradiance_%Y*.nc"
         static:
           vars_2D: ["Z_GDS4_SFC", "LSM"]
           path: "/glade/campaign/cisl/aiml/credit/static_scalers/static_norm_old.nc"

--- a/config/gen_2/smoke/smoke_gen2_multistep_casper.yml
+++ b/config/gen_2/smoke/smoke_gen2_multistep_casper.yml
@@ -17,12 +17,10 @@ data:
         prognostic:
           vars_3D: ["u_component_of_wind", "v_component_of_wind", "temperature", "specific_total_water"]
           vars_2D: ["SP", "VAR_2T", "VAR_10U", "VAR_10V"]
-          path: "/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h_subset_*.zarr"
-          filename_time_format: "%Y"
+          path: "/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h_subset_%Y_*.zarr"
         dynamic_forcing:
           vars_2D: ["toa_incident_solar_radiation", "land_sea_CI_mask"]
-          path: "/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h_subset_*.zarr"
-          filename_time_format: "%Y"
+          path: "/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h_subset_%Y_*.zarr"
         static:
           vars_2D: ["z_norm", "land_sea_mask"]
           path: "/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/static/ERA5_mlevel_1deg_static_subset.zarr"

--- a/config/gen_2/smoke/smoke_v2branch_casper.yml
+++ b/config/gen_2/smoke/smoke_v2branch_casper.yml
@@ -8,13 +8,13 @@ seed: 1000
 
 data:
     variables: ['U', 'V', 'T', 'Q']
-    save_loc: '/glade/campaign/cisl/aiml/credit/era5_zarr/SixHourly_y_TOTAL*'
+    save_loc: '/glade/campaign/cisl/aiml/credit/era5_zarr/SixHourly_y_TOTAL_%Y_*.zarr'
 
     surface_variables: ['SP', 't2m', 'V500', 'U500', 'T500', 'Z500', 'Q500']
-    save_loc_surface: '/glade/campaign/cisl/aiml/credit/era5_zarr/SixHourly_y_TOTAL*'
+    save_loc_surface: '/glade/campaign/cisl/aiml/credit/era5_zarr/SixHourly_y_TOTAL_%Y_*.zarr'
 
     dynamic_forcing_variables: ['tsi']
-    save_loc_dynamic_forcing: '/glade/campaign/cisl/aiml/credit/credit_solar_nc_6h_0.25deg/*.nc'
+    save_loc_dynamic_forcing: '/glade/campaign/cisl/aiml/credit/credit_solar_nc_6h_0.25deg/solar_irradiance_%Y-*.nc'
 
     static_variables: ['Z_GDS4_SFC', 'LSM']
     save_loc_static: '/glade/campaign/cisl/aiml/credit/static_scalers/static_norm_old.nc'

--- a/credit/datasets/_utils.py
+++ b/credit/datasets/_utils.py
@@ -11,13 +11,27 @@ from __future__ import annotations
 
 import bisect
 import cftime
-import os
 import re
 from datetime import datetime as dt_cls
 
 import pandas as pd
 import s3fs
 
+
+# Set of all recognised strftime codes — used for path-template detection
+_STRFTIME_CODES: frozenset[str] = frozenset(
+    {
+        "%Y",
+        "%y",
+        "%m",
+        "%d",
+        "%H",
+        "%M",
+        "%S",
+        "%j",
+        "%f",
+    }
+)
 
 # Maps strftime format codes to non-capturing regex fragments
 _STRFTIME_TO_REGEX: dict[str, str] = {
@@ -41,6 +55,53 @@ _STRFTIME_TO_FREQ: list[tuple[str, str]] = [
     ("%d", "D"),
     ("%m", "M"),
 ]
+
+
+def _path_template_to_glob(template: str) -> str:
+    """Replace strftime codes in *template* with ``*`` to produce a glob pattern.
+
+    Args:
+        template: Path string that may contain strftime codes, e.g.
+            ``"/data/%Y/%m/era5_*.nc"``.
+
+    Returns:
+        Glob-compatible pattern, e.g. ``"/data/*/*/era5_*.nc"``.
+    """
+    result = template
+    for code in _STRFTIME_CODES:
+        result = result.replace(code, "*")
+    return result
+
+
+def _extract_time_fmt(template: str) -> str:
+    """Extract the strftime format substring from a path template.
+
+    Returns the slice of *template* from the first strftime code to the end of
+    the last one, preserving any literal characters between them.
+
+    Example::
+
+        _extract_time_fmt("/data/%Y/%m/era5_*.nc")  # "%Y/%m"
+        _extract_time_fmt("/data/era5_%Y%m%d.nc")   # "%Y%m%d"
+
+    Args:
+        template: Path template containing at least one strftime code.
+
+    Returns:
+        The strftime format string (suitable for ``strptime``).
+    """
+    first_pos = len(template)
+    last_pos = 0
+    for code in _STRFTIME_CODES:
+        idx = 0
+        while True:
+            pos = template.find(code, idx)
+            if pos == -1:
+                break
+            first_pos = min(first_pos, pos)
+            last_pos = max(last_pos, pos + len(code))
+            idx = pos + 1
+    return template[first_pos:last_pos] if last_pos > 0 else template
 
 
 def _strftime_to_regex(fmt: str) -> re.Pattern:
@@ -90,14 +151,15 @@ def _map_files(
 
     Args:
         file_list: Sorted list of file paths returned by glob.
-        time_fmt: strftime format string, e.g. ``"%Y"``, ``"%Y%m%d-%H%M%S"``.
+        time_fmt: strftime format string extracted from the path template,
+            e.g. ``"%Y"``, ``"%Y/%m"``.  The regex is searched against the
+            full file path so date components in directory names are matched.
 
     Returns:
         List of ``(start, end, path)`` tuples sorted by start time.
 
     Raises:
-        ValueError: If *time_fmt* does not match the basename of any file
-            in *file_list*.
+        ValueError: If *time_fmt* does not match any file in *file_list*.
     """
     if len(file_list) == 1:
         return [(pd.Timestamp.min, pd.Timestamp.max, file_list[0])]
@@ -107,13 +169,11 @@ def _map_files(
 
     intervals: list[tuple[pd.Timestamp, pd.Timestamp, str]] = []
     for f in file_list:
-        basename = os.path.basename(f)
-        m = pattern.search(basename)
+        m = pattern.search(f)
         if m is None:
             raise ValueError(
-                f"filename_time_format '{time_fmt}' did not match "
-                f"filename '{basename}'. Verify that the format matches "
-                "the date portion of your filenames."
+                f"Time format '{time_fmt}' did not match path '{f}'. "
+                "Verify that your path contains strftime codes covering the date portion."
             )
         parsed = dt_cls.strptime(m.group(0), time_fmt)
         period = pd.Period(parsed, freq)

--- a/credit/datasets/base_dataset.py
+++ b/credit/datasets/base_dataset.py
@@ -18,7 +18,7 @@ import pandas as pd
 from torch.utils.data import Dataset
 import torch
 
-from credit.datasets._utils import _map_files  # pyright: ignore[reportPrivateUsage]
+from credit.datasets._utils import _map_files, _path_template_to_glob, _extract_time_fmt  # pyright: ignore[reportPrivateUsage]
 
 # Expected types of fields
 # * ``prognostic``      — input at step 0 and target (autoregressive rollout)
@@ -665,9 +665,9 @@ class BaseDataset(AbstractBaseDataset):
                 The expected return type should be consistent within a dataset class.
         """
         if self.mode == "local":
-            files = sorted(glob(field_config.get("path", "")))
-            time_fmt: str = field_config.get("filename_time_format", "%Y")
-            return _map_files(files, time_fmt) if files else None
+            path_template: str = field_config.get("path", "")
+            files = sorted(glob(_path_template_to_glob(path_template)))
+            return _map_files(files, _extract_time_fmt(path_template)) if files else None
         elif self.mode == "remote":
             return True
         else:

--- a/credit/datasets/mrms.py
+++ b/credit/datasets/mrms.py
@@ -51,14 +51,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from glob import glob
 import gzip
 
 import pandas as pd
 import torch
 import xarray as xr
 
-from credit.datasets._utils import _find_file, _map_files, _start_s3_fs
+from credit.datasets._utils import _find_file, _start_s3_fs
 from credit.datasets.base_dataset import BaseDataset
 
 
@@ -169,32 +168,6 @@ class MRMSDataset(BaseDataset):
 
         # Initialize the s3fs on the first call to _extract_field within __getitem__
         self._fs = None
-
-    def _get_file_source(
-        self,
-        field_config: dict[str, Any],
-    ) -> list[tuple[pd.Timestamp, pd.Timestamp, str]] | bool | None:
-        """Return the file source for a field. Override in subclasses for different modes/backends.
-
-        Args:
-            field_config (dict[str, Any]): Validated field-type config dict.
-
-        Raises:
-            ValueError: If ``self.mode`` is not a recognised mode.
-
-        Returns:
-            list[tuple[pd.Timestamp, pd.Timestamp, str]] | bool | None: Depending on the mode and field type,
-                this method may return a list of (start_time, end_time, file_path) tuples produced by _map_files,
-                a boolean indicating the presence of the field (e.g., for remote data), or None if the field is disabled.
-                The expected return type should be consistent within a dataset class.
-        """
-        if self.mode == "local":
-            files = sorted(glob(field_config.get("path", "")))
-            time_fmt: str = field_config.get("filename_time_format", "%Y%m%d-%H%M%S")
-            return _map_files(files, time_fmt) if files else None
-        else:
-            # Remote mode: S3 path is constructed at runtime from the timestamp
-            return True
 
     def _extract_field(
         self,

--- a/credit/postblock/reconstruct.py
+++ b/credit/postblock/reconstruct.py
@@ -39,7 +39,7 @@ class Reconstruct(BasePostblock):
     """
 
     def forward(self, batch_dict: dict) -> dict:
-        y_pred = batch_dict["y_pred"]
+        y_pred = batch_dict["prediction"]
         output_map = batch_dict["metadata"]["target"]["_channel_map"]
 
         # Flatten time dim if y_pred arrived as 5D (B, C, T, H, W) — unflatten needs 4D input

--- a/credit/postblock/reconstruct.py
+++ b/credit/postblock/reconstruct.py
@@ -39,7 +39,7 @@ class Reconstruct(BasePostblock):
     """
 
     def forward(self, batch_dict: dict) -> dict:
-        y_pred = batch_dict["prediction"]
+        y_pred = batch_dict["y_pred"]
         output_map = batch_dict["metadata"]["target"]["_channel_map"]
 
         # Flatten time dim if y_pred arrived as 5D (B, C, T, H, W) — unflatten needs 4D input

--- a/scripts/multi_source_example.py
+++ b/scripts/multi_source_example.py
@@ -28,22 +28,20 @@ print(sample["input"]["ERA5_UpperAir"].keys())
 preblocks = build_preblocks(config["preblocks"])
 batch = apply_preblocks(preblocks, sample)
 print("BATCH KEYS:", batch.keys())
-print("Input shape:", batch["input"].shape)
-print("Target shape:", batch["target"].shape)
-target_shape = batch["target"].shape
+print("Input shape:", batch["x"].shape)
+print("Target shape:", batch["y"].shape)
+target_shape = batch["y"].shape
 
 print("METADATA KEYS:", batch["metadata"].keys())
 print("METADATA KEYS:", batch["metadata"]["input"].keys())
 print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"].keys())
 print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"]["datetime"])
-# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['target']['_channel_map']['ERA5_LowerAir/prognostic/3d/V'].keys())
-# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['input']['_channel_map']['ERA5_LowerAir/prognostic/3d/V']['slice'])
 
 fake_prediction = torch.tensor(np.random.normal(0, 1, target_shape))
-batch["prediction"] = fake_prediction
-sample["prediction"] = fake_prediction
+batch["y_pred"] = fake_prediction
+sample["y_pred"] = fake_prediction
 
 postblocks = build_postblocks(config["postblocks"])
 postbatch = apply_postblocks(postblocks, batch)
 print("POSTBATCH KEYS:", postbatch.keys())
-print(postbatch["prediction"]["ERA5_UpperAir"].keys())
+print(postbatch["y_pred"].shape)

--- a/scripts/multi_source_example.py
+++ b/scripts/multi_source_example.py
@@ -28,16 +28,16 @@ print(sample["input"]["ERA5_UpperAir"].keys())
 preblocks = build_preblocks(config["preblocks"])
 batch = apply_preblocks(preblocks, sample)
 print("BATCH KEYS:", batch.keys())
-print("Input shape:", batch["input"].shape)
-print("Target shape:", batch["target"].shape)
-target_shape = batch["target"].shape
+print("Input shape:", batch["x"].shape)
+print("Target shape:", batch["y"].shape)
+target_shape = batch["y"].shape
 
 print("METADATA KEYS:", batch["metadata"].keys())
 print("METADATA KEYS:", batch["metadata"]["input"].keys())
 print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"].keys())
 print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"]["datetime"])
-# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['target']['_channel_map']['ERA5_LowerAir/prognostic/3d/V'].keys())
-# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['input']['_channel_map']['ERA5_LowerAir/prognostic/3d/V']['slice'])
+# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['y']['_channel_map']['ERA5_LowerAir/prognostic/3d/V'].keys())
+# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['x']['_channel_map']['ERA5_LowerAir/prognostic/3d/V']['slice'])
 
 fake_prediction = torch.tensor(np.random.normal(0, 1, target_shape))
 batch["prediction"] = fake_prediction
@@ -46,4 +46,4 @@ sample["prediction"] = fake_prediction
 postblocks = build_postblocks(config["postblocks"])
 postbatch = apply_postblocks(postblocks, batch)
 print("POSTBATCH KEYS:", postbatch.keys())
-print(postbatch["prediction"]["ERA5_UpperAir"].keys())
+print(postbatch["prediction"].shape)

--- a/scripts/multi_source_example.py
+++ b/scripts/multi_source_example.py
@@ -28,16 +28,16 @@ print(sample["input"]["ERA5_UpperAir"].keys())
 preblocks = build_preblocks(config["preblocks"])
 batch = apply_preblocks(preblocks, sample)
 print("BATCH KEYS:", batch.keys())
-print("Input shape:", batch["x"].shape)
-print("Target shape:", batch["y"].shape)
-target_shape = batch["y"].shape
+print("Input shape:", batch["input"].shape)
+print("Target shape:", batch["target"].shape)
+target_shape = batch["target"].shape
 
 print("METADATA KEYS:", batch["metadata"].keys())
 print("METADATA KEYS:", batch["metadata"]["input"].keys())
 print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"].keys())
 print("METADATA KEYS:", batch["metadata"]["input"]["ERA5_LowerAir"]["datetime"])
-# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['y']['_channel_map']['ERA5_LowerAir/prognostic/3d/V'].keys())
-# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['x']['_channel_map']['ERA5_LowerAir/prognostic/3d/V']['slice'])
+# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['target']['_channel_map']['ERA5_LowerAir/prognostic/3d/V'].keys())
+# print("METADATA CHANNEL_MAP KEYS:", batch['metadata']['input']['_channel_map']['ERA5_LowerAir/prognostic/3d/V']['slice'])
 
 fake_prediction = torch.tensor(np.random.normal(0, 1, target_shape))
 batch["prediction"] = fake_prediction
@@ -46,4 +46,4 @@ sample["prediction"] = fake_prediction
 postblocks = build_postblocks(config["postblocks"])
 postbatch = apply_postblocks(postblocks, batch)
 print("POSTBATCH KEYS:", postbatch.keys())
-print(postbatch["prediction"].shape)
+print(postbatch["prediction"]["ERA5_UpperAir"].keys())

--- a/tests/era5_dataset_test.py
+++ b/tests/era5_dataset_test.py
@@ -89,7 +89,7 @@ def patch_era5_io_multiyear(
     """
 
     def fake_glob(pattern: str) -> list[str]:
-        if pattern == "/fake/*.zarr":
+        if pattern == "/fake/era5_*.zarr":
             return ["/fake/era5_2022.zarr", "/fake/era5_2023.zarr"]
         raise ValueError(f"Unexpected glob pattern: {pattern}")
 
@@ -115,7 +115,7 @@ def patch_refactor_io_multiyear(
     """
 
     def fake_glob(pattern: str) -> list[str]:
-        if pattern == "/fake/*.zarr":
+        if pattern == "/fake/era5_*.zarr":
             return ["/fake/era5_2022.zarr", "/fake/era5_2023.zarr"]
         raise ValueError(f"Unexpected glob pattern: {pattern}")
 
@@ -148,19 +148,19 @@ def minimal_config() -> dict[str, Any]:
                     "prognostic": {
                         "vars_3D": ["T", "U"],
                         "vars_2D": ["SP"],
-                        "path": "/fake/*.zarr",
+                        "path": "/fake/era5_%Y.zarr",
                     },
                     "dynamic_forcing": {
                         "vars_2D": ["tsi"],
-                        "path": "/fake/*.zarr",
+                        "path": "/fake/era5_%Y.zarr",
                     },
                     "static": {
                         "vars_2D": ["LSM"],
-                        "path": "/fake/*.zarr",
+                        "path": "/fake/era5_%Y.zarr",
                     },
                     "diagnostic": {
                         "vars_2D": ["TP"],
-                        "path": "/fake/*.zarr",
+                        "path": "/fake/era5_%Y.zarr",
                     },
                 },
             }

--- a/tests/mrms_dataset_test.py
+++ b/tests/mrms_dataset_test.py
@@ -66,9 +66,8 @@ def mrms_xr_dataset():
 @pytest.fixture
 def patch_mrms_io(monkeypatch, mrms_xr_dataset):
     """Patch glob + xr.open_dataset so MRMSDataset loads from the fake dataset."""
-    MRMS_MODULE = "credit.datasets.mrms"
     monkeypatch.setattr(
-        f"{MRMS_MODULE}.glob",
+        "credit.datasets.base_dataset.glob",
         lambda pattern: ["/fake/MRMS_20240601-000000.nc"],
     )
     monkeypatch.setattr(xr, "open_dataset", lambda path, **kw: mrms_xr_dataset)

--- a/tests/sampler_test.py
+++ b/tests/sampler_test.py
@@ -90,19 +90,19 @@ def minimal_config() -> dict[str, Any]:
                     "prognostic": {
                         "vars_3D": ["T", "U"],
                         "vars_2D": ["SP"],
-                        "path": "/fake/era5_%Y.zarr",
+                        "path": "/fake/*.zarr",
                     },
                     "dynamic_forcing": {
                         "vars_2D": ["tsi"],
-                        "path": "/fake/era5_%Y.zarr",
+                        "path": "/fake/*.zarr",
                     },
                     "static": {
                         "vars_2D": ["LSM"],
-                        "path": "/fake/era5_%Y.zarr",
+                        "path": "/fake/*.zarr",
                     },
                     "diagnostic": {
                         "vars_2D": ["TP"],
-                        "path": "/fake/era5_%Y.zarr",
+                        "path": "/fake/*.zarr",
                     },
                 },
             }

--- a/tests/sampler_test.py
+++ b/tests/sampler_test.py
@@ -90,19 +90,19 @@ def minimal_config() -> dict[str, Any]:
                     "prognostic": {
                         "vars_3D": ["T", "U"],
                         "vars_2D": ["SP"],
-                        "path": "/fake/*.zarr",
+                        "path": "/fake/era5_%Y.zarr",
                     },
                     "dynamic_forcing": {
                         "vars_2D": ["tsi"],
-                        "path": "/fake/*.zarr",
+                        "path": "/fake/era5_%Y.zarr",
                     },
                     "static": {
                         "vars_2D": ["LSM"],
-                        "path": "/fake/*.zarr",
+                        "path": "/fake/era5_%Y.zarr",
                     },
                     "diagnostic": {
                         "vars_2D": ["TP"],
-                        "path": "/fake/*.zarr",
+                        "path": "/fake/era5_%Y.zarr",
                     },
                 },
             }


### PR DESCRIPTION
### Description
This allows recursive directory and file matching using the `LocalDataset` and `MRMSDataset` (which can fetch data locally) by removing the `filename_time_format:` key in the config and substituting the string formatted time `strftime` conventions directly in the `path:` key in the config.

#### old (did not work with nested directories)
`path: /path_to_data/data_*.nc`
`filename_time_format: %Y`

#### new (same files in one directory)
`path: /path_to_data/data_%Y*.nc`

#### new using nested directories
`path: /path_to_data/%Y/%m/data_%d_*.nc`

The gen 2 configs were updated to reflect this. 

Closes #383 

### Checklist
- [x] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date.
