### PR TITLE
CREDIT preprocess app and bridgescaler fitting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@ to be under active development. Please contact [the MILES group](mailto:milescor
 
 `credit ask` is a unified AI assistant — it automatically runs in agent mode (reads your
 files, runs shell commands, iterates until it has a confident answer) when an Anthropic key
-is available, or falls back to simple chat (Groq/Gemini/OpenAI) otherwise.
+is available, or falls back to simple chat (Groq, OpenRouter, Gemini, or OpenAI) otherwise.
 
 ```bash
 pip install "miles-credit[ask]"
 
-# Free — no card needed
-export GROQ_API_KEY=gsk_...        # https://console.groq.com
+# Free — no card needed (pick either)
+export GROQ_API_KEY=gsk_...          # https://console.groq.com
+export OPENROUTER_API_KEY=sk-or-...  # https://openrouter.ai
 
 # Or use your own Anthropic key for full agent mode (~$0.01–0.05/session)
 export ANTHROPIC_API_KEY=sk-ant-...  # https://console.anthropic.com
@@ -36,6 +37,16 @@ export ANTHROPIC_API_KEY=sk-ant-...  # https://console.anthropic.com
 credit ask "why is my loss not decreasing?"
 credit ask -c my_run.yml "why did my training run crash?"
 ```
+
+The assistant picks the first provider with an available API key. Supported keys:
+
+| Env var | Provider / model | Mode |
+|---------|------------------|------|
+| `ANTHROPIC_API_KEY` | Anthropic (Claude) | full agent mode |
+| `GROQ_API_KEY` | Groq (Llama 3, free) | simple chat |
+| `OPENROUTER_API_KEY` | OpenRouter (Qwen3-Next-80B, free) | simple chat |
+| `GOOGLE_API_KEY` | Google (Gemini) | simple chat |
+| `OPENAI_API_KEY` | OpenAI (GPT-4o) | simple chat |
 
 See the [AI Assistant documentation](https://miles-credit.readthedocs.io/en/latest/agent.html) for the full reference.
 

--- a/config/gen_2/examples/example-v2026.2.yml
+++ b/config/gen_2/examples/example-v2026.2.yml
@@ -229,9 +229,9 @@ model:
   attn_dropout: 0.
   ff_dropout: 0.
 
-  interp: False
+  interp: True                      # final bilinear resize to grid; mild low-pass, suppresses residual checkerboard
   use_spectral_norm: True
-  upsample_with_ps: True            # Upsample with pixel shuffle
+  upsample_with_ps: True            # pixel-shuffle (ICNR-initialized) decoder avoids checkerboard artifacts
 
   padding_conf:
     activate: True
@@ -244,7 +244,7 @@ model:
 loss:
   training_loss: "mse"
 
-  use_power_loss: False
+  use_power_loss: True              # penalize spurious high-wavenumber content (anti-checkerboard); set False to disable
   use_spectral_loss: False
 
   use_latitude_weights: True

--- a/config/gen_2/examples/weatherbench2_era5_wxformer.yml
+++ b/config/gen_2/examples/weatherbench2_era5_wxformer.yml
@@ -38,7 +38,7 @@ preblocks:
     args:
       variables:
         - 'WBERA5/prognostic/3d/specific_humidity'
-        - "WBERA5/prognostic/3d/surface_pressure"
+        - "WBERA5/prognostic/2d/surface_pressure"
         - "WBERA5/diagnostic/2d/total_precipitation_6hr"
       data_types:
         - 'input'

--- a/config/gen_2/examples/weatherbench2_era5_wxformer.yml
+++ b/config/gen_2/examples/weatherbench2_era5_wxformer.yml
@@ -46,6 +46,7 @@ preblocks:
   scaler:
     type: "bridgescaler_transformer"
     args:
+      variables: []
       scaler_path: "/Users/dgagne/data/weatherbench2/scaler.json"
       scaler_type: "standard"
 

--- a/config/gen_2/examples/weatherbench2_era5_wxformer.yml
+++ b/config/gen_2/examples/weatherbench2_era5_wxformer.yml
@@ -1,4 +1,5 @@
-save_loc: '/glade/derecho/scratch/$USER/CREDIT/weatherbench2'
+save_loc: '/Users/dgagne/data/weatherbench2'
+#save_loc: '/glade/derecho/scratch/$USER/CREDIT/weatherbench2'
 seed: 31415
 
 data:
@@ -42,12 +43,29 @@ preblocks:
       data_types:
         - 'input'
         - 'target'
+  scaler:
+    type: "bridgescaler_transformer"
+    args:
+      scaler_path: "/Users/dgagne/data/weatherbench2/scaler.json"
+      scaler_type: "standard"
+
   vars_concat:
     type: "concat"
 
 postblocks:
   reconstruct:
     type: "reconstruct"
+
+trainer:
+  type: era5-gen2           # use the v2 trainer (new nested data schema)
+
+  mode: ddp
+  epochs: 100
+  train_batch_size: 32
+  batches_per_epoch: 100
+  thread_workers: 2
+  valid_thread_workers: 2
+  prefetch_factor: 2
 
 
 

--- a/config/gen_2/examples/weatherbench2_era5_wxformer.yml
+++ b/config/gen_2/examples/weatherbench2_era5_wxformer.yml
@@ -1,0 +1,54 @@
+save_loc: '/glade/derecho/scratch/$USER/CREDIT/weatherbench2'
+seed: 31415
+
+data:
+  source:
+    WBERA5:
+      dataset_type: "weatherbench2_era5"
+      resolution: "240x121"   # optional; overridden by the resolution kwarg
+      level_coord: "level"
+      levels: [ 50, 100, 150, 200, 250,  300, 400, 500, 600, 700, 850, 925, 1000 ]
+      variables:
+        prognostic:
+          vars_3D: ["u_component_of_wind", "v_component_of_wind", "temperature", "specific_humidity", "geopotential"]
+          vars_2D: ["surface_pressure", "2m_temperature", '2m_dewpoint_temperature',
+                    '10m_u_component_of_wind', '10m_v_component_of_wind']
+        diagnostic:
+          vars_2D: ['total_precipitation_6hr', 'total_cloud_cover', 'sea_ice_cover',
+                    'mean_surface_sensible_heat_flux', 'mean_surface_latent_heat_flux',
+                    'mean_surface_net_short_wave_radiation_flux', 'mean_surface_net_long_wave_radiation_flux',
+                     'mean_top_net_long_wave_radiation_flux', 'mean_top_net_short_wave_radiation_flux']
+        dynamic_forcing:
+          vars_2D: ["sea_surface_temperature", 'mean_top_downward_short_wave_radiation_flux',
+                    'low_vegetation_cover', 'high_vegetation_cover',
+                    'leaf_area_index_high_vegetation', 'leaf_area_index_low_vegetation']
+        static:
+          vars_2D: ["land_sea_mask", "geopotential_at_surface", 'lake_cover']
+  start_datetime: "1979-01-01"
+  end_datetime: "2017-12-31 18:00:00"
+  timestep: "6h"
+
+  history_len: 1
+  forecast_len: 1
+
+preblocks:
+  log_transform:
+    type: "log_transform"
+    args:
+      variables:
+        - 'WBERA5/prognostic/3d/specific_humidity'
+        - "WBERA5/prognostic/3d/surface_pressure"
+        - "WBERA5/diagnostic/2d/total_precipitation_6hr"
+      data_types:
+        - 'input'
+        - 'target'
+  vars_concat:
+    type: "concat"
+
+postblocks:
+  reconstruct:
+    type: "reconstruct"
+
+
+
+

--- a/config/gen_2/examples/weatherbench2_era5_wxformer.yml
+++ b/config/gen_2/examples/weatherbench2_era5_wxformer.yml
@@ -1,5 +1,4 @@
-save_loc: '/Users/dgagne/data/weatherbench2'
-#save_loc: '/glade/derecho/scratch/$USER/CREDIT/weatherbench2'
+save_loc: '/glade/derecho/scratch/$USER/CREDIT/weatherbench2'
 seed: 31415
 
 data:
@@ -26,34 +25,35 @@ data:
         static:
           vars_2D: ["land_sea_mask", "geopotential_at_surface", 'lake_cover']
   start_datetime: "1979-01-01"
-  end_datetime: "2017-12-31 18:00:00"
+  end_datetime: "2017-01-31 18:00:00"
   timestep: "6h"
 
   history_len: 1
   forecast_len: 1
 
 preblocks:
-  log_transform:
-    type: "log_transform"
-    args:
-      variables:
-        - 'WBERA5/prognostic/3d/specific_humidity'
-        - "WBERA5/prognostic/2d/surface_pressure"
-        - "WBERA5/diagnostic/2d/total_precipitation_6hr"
-      data_types:
-        - 'input'
-        - 'target'
-  scaler:
-    type: "bridgescaler_transformer"
-    args:
-      variables: []
-      scaler_path: "/Users/dgagne/data/weatherbench2/scaler.json"
-      scaler_type: "standard"
-      scaler_params:
-        channels_last: False
+  per_step:
+    log_transform:
+      type: "log_transform"
+      args:
+        variables:
+          - 'WBERA5/prognostic/3d/specific_humidity'
+          - "WBERA5/prognostic/2d/surface_pressure"
+          - "WBERA5/diagnostic/2d/total_precipitation_6hr"
+        data_types:
+          - 'input'
+          - 'target'
+    scaler:
+      type: "bridgescaler_transformer"
+      args:
+        variables: []
+        scaler_path: "/glade/derecho/scratch/$USER/CREDIT/weatherbench2/scaler_quantile.json"
+        scaler_type: "quantile"
+        scaler_params:
+          channels_last: False
 
-  vars_concat:
-    type: "concat"
+    vars_concat:
+      type: "concat"
 
 postblocks:
   reconstruct:
@@ -63,13 +63,14 @@ trainer:
   type: era5-gen2           # use the v2 trainer (new nested data schema)
 
   mode: ddp
-  epochs: 100
-  train_batch_size: 32
+  epochs: 1
+  train_batch_size: 8
   batches_per_epoch: 100
-  thread_workers: 2
+  thread_workers: 8
   valid_thread_workers: 2
   prefetch_factor: 2
 
-
+pbs:
+  walltime: "01:00:00"
 
 

--- a/config/gen_2/examples/weatherbench2_era5_wxformer_tiny.yml
+++ b/config/gen_2/examples/weatherbench2_era5_wxformer_tiny.yml
@@ -16,7 +16,7 @@ data:
         diagnostic:
           vars_2D: ['total_precipitation_6hr']
         dynamic_forcing:
-          vars_2D: ["sea_surface_temperature", 'mean_top_downward_short_wave_radiation_flux']
+          vars_2D: ["sea_surface_temperature"]
         static:
           vars_2D: ["land_sea_mask", "geopotential_at_surface"]
   start_datetime: "1979-01-01"
@@ -37,14 +37,22 @@ preblocks:
       data_types:
         - 'input'
         - 'target'
+  fill_nan:
+    type: "fill_nan"
+    args:
+      variables: []
+      data_types:
+        - 'input'
+        - 'target'
   scaler:
     type: "bridgescaler_transformer"
     args:
       variables: []
       scaler_path: "/Users/dgagne/data/weatherbench2/scaler.json"
-      scaler_type: "standard"
+      scaler_type: "quantile"
       scaler_params:
         channels_last: False
+        compression: 500
 
   vars_concat:
     type: "concat"

--- a/config/gen_2/examples/weatherbench2_era5_wxformer_tiny.yml
+++ b/config/gen_2/examples/weatherbench2_era5_wxformer_tiny.yml
@@ -27,35 +27,36 @@ data:
   forecast_len: 1
 
 preblocks:
-  log_transform:
-    type: "log_transform"
-    args:
-      variables:
-        - 'WBERA5/prognostic/3d/specific_humidity'
-        - "WBERA5/prognostic/3d/surface_pressure"
-        - "WBERA5/diagnostic/2d/total_precipitation_6hr"
-      data_types:
-        - 'input'
-        - 'target'
-  fill_nan:
-    type: "fill_nan"
-    args:
-      variables: []
-      data_types:
-        - 'input'
-        - 'target'
-  scaler:
-    type: "bridgescaler_transformer"
-    args:
-      variables: []
-      scaler_path: "/Users/dgagne/data/weatherbench2/scaler.json"
-      scaler_type: "quantile"
-      scaler_params:
-        channels_last: False
-        compression: 500
+  per_step:
+    log_transform:
+      type: "log_transform"
+      args:
+        variables:
+          - 'WBERA5/prognostic/3d/specific_humidity'
+          - "WBERA5/prognostic/2d/surface_pressure"
+          - "WBERA5/diagnostic/2d/total_precipitation_6hr"
+        data_types:
+          - 'input'
+          - 'target'
+    fill_nan:
+      type: "fill_nan"
+      args:
+        variables: []
+        data_types:
+          - 'input'
+          - 'target'
+    scaler:
+      type: "bridgescaler_transformer"
+      args:
+        variables: []
+        scaler_path: "/Users/dgagne/data/weatherbench2/scaler.json"
+        scaler_type: "quantile"
+        scaler_params:
+          channels_last: False
+          compression: 500
 
-  vars_concat:
-    type: "concat"
+    vars_concat:
+      type: "concat"
 
 postblocks:
   reconstruct:

--- a/config/gen_2/examples/weatherbench2_era5_wxformer_tiny.yml
+++ b/config/gen_2/examples/weatherbench2_era5_wxformer_tiny.yml
@@ -8,23 +8,17 @@ data:
       dataset_type: "weatherbench2_era5"
       resolution: "240x121"   # optional; overridden by the resolution kwarg
       level_coord: "level"
-      levels: [ 50, 100, 150, 200, 250,  300, 400, 500, 600, 700, 850, 925, 1000 ]
+      levels: [500, 850]
       variables:
         prognostic:
-          vars_3D: ["u_component_of_wind", "v_component_of_wind", "temperature", "specific_humidity", "geopotential"]
-          vars_2D: ["surface_pressure", "2m_temperature", '2m_dewpoint_temperature',
-                    '10m_u_component_of_wind', '10m_v_component_of_wind']
+          vars_3D: ["temperature", "specific_humidity"]
+          vars_2D: ["surface_pressure", "2m_temperature"]
         diagnostic:
-          vars_2D: ['total_precipitation_6hr', 'total_cloud_cover', 'sea_ice_cover',
-                    'mean_surface_sensible_heat_flux', 'mean_surface_latent_heat_flux',
-                    'mean_surface_net_short_wave_radiation_flux', 'mean_surface_net_long_wave_radiation_flux',
-                     'mean_top_net_long_wave_radiation_flux', 'mean_top_net_short_wave_radiation_flux']
+          vars_2D: ['total_precipitation_6hr']
         dynamic_forcing:
-          vars_2D: ["sea_surface_temperature", 'mean_top_downward_short_wave_radiation_flux',
-                    'low_vegetation_cover', 'high_vegetation_cover',
-                    'leaf_area_index_high_vegetation', 'leaf_area_index_low_vegetation']
+          vars_2D: ["sea_surface_temperature", 'mean_top_downward_short_wave_radiation_flux']
         static:
-          vars_2D: ["land_sea_mask", "geopotential_at_surface", 'lake_cover']
+          vars_2D: ["land_sea_mask", "geopotential_at_surface"]
   start_datetime: "1979-01-01"
   end_datetime: "2017-12-31 18:00:00"
   timestep: "6h"
@@ -62,11 +56,11 @@ postblocks:
 trainer:
   type: era5-gen2           # use the v2 trainer (new nested data schema)
 
-  mode: ddp
-  epochs: 100
-  train_batch_size: 32
-  batches_per_epoch: 100
-  thread_workers: 2
+  mode: none
+  epochs: 1
+  train_batch_size: 2
+  batches_per_epoch: 3
+  thread_workers: 4
   valid_thread_workers: 2
   prefetch_factor: 2
 

--- a/credit/applications/preprocess.py
+++ b/credit/applications/preprocess.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import warnings
 
 from bridgescaler import save_scaler_dict
 
@@ -18,11 +19,102 @@ import torch.distributed as dist
 from torch.distributed import gather_object, barrier
 
 
+def _scaler_probe_range(scaler):
+    """Return ``(lo, hi, label)`` normalized probe endpoints for a fitted scaler.
+
+    The endpoints span the range of normalized values the scaler typically
+    produces, so an inverse transform reveals what physical values each scaler
+    maps that range to:
+
+      - minmax    -> ``[0, 1]``
+      - standard  -> ``[-4, 4]`` (±4 standard deviations)
+      - quantile  -> ``[0, 1]`` for a uniform output distribution, otherwise
+                     ``[-4, 4]`` (e.g. normal/logistic)
+    """
+    cls = type(scaler).__name__
+    if "MinMax" in cls:
+        return 0.0, 1.0, "minmax [0, 1]"
+    if "Quantile" in cls:
+        distribution = getattr(scaler, "distribution", "uniform")
+        if distribution == "uniform":
+            return 0.0, 1.0, f"quantile-{distribution} [0, 1]"
+        return -4.0, 4.0, f"quantile-{distribution} [-4, 4]"
+    return -4.0, 4.0, "standard [-4, 4]"
+
+
+def _scaler_device(scaler):
+    """Best-effort lookup of the torch device holding a scaler's fitted stats."""
+    for attr in ("mean_x_", "var_x_", "min_x_", "max_x_", "min_tensor", "max_tensor"):
+        t = getattr(scaler, attr, None)
+        if torch.is_tensor(t):
+            return t.device
+        if isinstance(t, dict):
+            for v in t.values():
+                if torch.is_tensor(v):
+                    return v.device
+    return torch.device("cpu")
+
+
+def _log_single_scaler(scaler, name, logger):
+    """Log the fitted parameters of one leaf scaler, one line per channel/level."""
+    columns = list(getattr(scaler, "x_columns_", []) or [])
+    cls = type(scaler).__name__
+    lo, hi, label = _scaler_probe_range(scaler)
+    logger.info("Scaler '%s' [%s] — %d channel(s), probe range %s", name, cls, len(columns), label)
+
+    mean = getattr(scaler, "mean_x_", None)
+    var = getattr(scaler, "var_x_", None)
+    vmin = getattr(scaler, "min_x_", None)
+    vmax = getattr(scaler, "max_x_", None)
+
+    # Inverse-transform the normalized probe endpoints to physical units. A
+    # (2, n_channels) probe tensor works for both channels-first and
+    # channels-last scalers (the channel dim is dim 1 either way).
+    inv = None
+    if columns:
+        try:
+            device = _scaler_device(scaler)
+            probe = torch.tensor([[lo] * len(columns), [hi] * len(columns)], dtype=torch.float32, device=device)
+            with torch.no_grad():
+                inv = scaler.inverse_transform(probe).detach().cpu()
+        except Exception as exc:  # noqa: BLE001 - logging-only, never fail preprocessing
+            logger.warning("  could not inverse-transform probe for '%s': %s", name, exc)
+
+    for i, col in enumerate(columns):
+        parts = []
+        if mean is not None and var is not None:
+            parts.append(f"mean={float(mean[i]):.4g} var={float(var[i]):.4g}")
+        if vmin is not None and vmax is not None:
+            parts.append(f"min={float(vmin[i]):.4g} max={float(vmax[i]):.4g}")
+        if inv is not None:
+            parts.append(f"inv[{lo:g} -> {hi:g}]=[{float(inv[0, i]):.4g}, {float(inv[1, i]):.4g}]")
+        logger.info("    %s: %s", col, "  ".join(parts) if parts else "(no stats available)")
+
+
+def log_fitted_scalers(scaler_dict, logger, path=()):
+    """Recursively log every fitted scaler in a nested ``scaler[data_type][source][var]`` dict."""
+    for key, value in scaler_dict.items():
+        if isinstance(value, dict):
+            log_fitted_scalers(value, logger, path + (key,))
+        else:
+            _log_single_scaler(value, "/".join(path + (key,)), logger)
+
+
 def main():
+    # gcsfs/aiohttp leave their async SSL transports open until garbage collection,
+    # which triggers a benign "unclosed transport" ResourceWarning from asyncio at
+    # teardown (after the scalers have already been fitted and saved). Silence it.
+    warnings.filterwarnings("ignore", category=ResourceWarning)
+    warnings.filterwarnings("ignore", category=UserWarning, module="bridgescaler")
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config", dest="model_config", required=True, type=str, help="Path to config file")
     parser.add_argument(
-        "--backend", type=str, default="nccl", choices=["nccl", "gloo", "mpi"], help="Backend for distributed training."
+        "-b",
+        "--backend",
+        type=str,
+        default="nccl",
+        choices=["nccl", "gloo", "mpi"],
+        help="Backend for distributed training.",
     )
     args = parser.parse_args()
     config = args.model_config
@@ -89,6 +181,9 @@ def main():
         root.info("Combining scalers.")
         combined_scaler = combine_scaler_dicts(all_scalers)
         save_scaler_dict(combined_scaler, scaler_block.scaler_path)
+        root.info("Saved fitted scaler to %s", scaler_block.scaler_path)
+        root.info("Fitted scaler values by variable:")
+        log_fitted_scalers(combined_scaler, root)
     return
 
 

--- a/credit/applications/preprocess.py
+++ b/credit/applications/preprocess.py
@@ -10,18 +10,17 @@ import os
 import torch
 import yaml
 import sys
-from pathlib import Path
-from credit.pbs import launch_script, launch_script_mpi
 import shutil
 from credit.preblock import build_preblocks, apply_preblocks_before_scaler, BridgeScalerTransformer
+from credit.preblock.scaler import combine_scaler_dicts
 from credit.trainers.utils import cycle, load_dataset, load_dataloader
+import torch.distributed as dist
 from torch.distributed import gather_object, barrier
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config", dest="model_config", required=True, type=str, help="Path to config file")
-    parser.add_argument("-l", dest="launch", type=int, default=0, help="Submit workers to PBS.")
     parser.add_argument(
         "--backend", type=str, default="nccl", choices=["nccl", "gloo", "mpi"], help="Backend for distributed training."
     )
@@ -46,16 +45,6 @@ def main():
     os.makedirs(save_loc, exist_ok=True)
     if not os.path.exists(os.path.join(save_loc, "model.yml")):
         shutil.copy(config, os.path.join(save_loc, "model.yml"))
-
-    if launch:
-        script_path = Path(__file__).absolute()
-        if conf["pbs"]["queue"] == "casper":
-            logging.info("Launching to PBS on Casper")
-            launch_script(config, script_path)
-        else:
-            logging.info("Launching to PBS on Derecho")
-            launch_script_mpi(config, script_path)
-        sys.exit()
 
     if conf["trainer"]["mode"] in ["fsdp", "ddp", "domain_parallel", "fsdp+domain_parallel"]:
         setup(rank, world_size, conf["trainer"]["mode"], backend)
@@ -87,16 +76,20 @@ def main():
         batch = next(dl)
         processed_batch = apply_preblocks_before_scaler(preblocks, batch, device)
         preblocks[scaler_block_key].fit_scaler_batch(processed_batch)
-    barrier()
-    if rank == 0:
-        all_scalers = []
+
+    scaler_block = preblocks[scaler_block_key]
+    # Gather the per-rank fitted scaler dicts onto rank 0 (or run single-process).
+    if dist.is_initialized() and world_size > 1:
+        barrier()
+        all_scalers = [None] * world_size if rank == 0 else None
+        gather_object(scaler_block.scaler, all_scalers, dst=0)
     else:
-        all_scalers = []
-    gather_object(preblocks[scaler_block_key].scaler, all_scalers, dst=0)
+        all_scalers = [scaler_block.scaler]
+
     if rank == 0:
         root.info("Combining scalers.")
-        combined_scaler = sum(all_scalers)
-        save_scaler_dict(combined_scaler, preblocks.scaler_path)
+        combined_scaler = combine_scaler_dicts(all_scalers)
+        save_scaler_dict(combined_scaler, scaler_block.scaler_path)
     return
 
 

--- a/credit/applications/preprocess.py
+++ b/credit/applications/preprocess.py
@@ -26,7 +26,6 @@ def main():
     )
     args = parser.parse_args()
     config = args.model_config
-    launch = int(args.launch)
     backend = args.backend
     root = logging.getLogger()
     root.setLevel(logging.DEBUG)

--- a/credit/applications/preprocess.py
+++ b/credit/applications/preprocess.py
@@ -1,0 +1,91 @@
+import argparse
+import logging
+from credit.distributed import get_rank_info, setup
+from credit.seed import seed_everything
+from os.path import expandvars
+import os
+import torch
+import yaml
+import sys
+from pathlib import Path
+from credit.pbs import launch_script, launch_script_mpi
+from credit.datasets.load_dataset_and_dataloader import load_dataset, load_dataloader
+import shutil
+from credit.preblock import build_preblocks, apply_preblocks_before_scaler
+from credit.trainers.utils import cycle
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--config", dest="model_config", required=True, type=str, help="Path to config file")
+    parser.add_argument("-l", dest="launch", type=int, default=0, help="Submit workers to PBS.")
+    parser.add_argument(
+        "--backend", type=str, default="nccl", choices=["nccl", "gloo", "mpi"], help="Backend for distributed training."
+    )
+    args = parser.parse_args()
+    config = args.model_config
+    launch = int(args.launch)
+    backend = args.backend
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+    ch = logging.StreamHandler()
+    gettrace = getattr(sys, "gettrace", None)
+    ch.setLevel(logging.DEBUG if gettrace and gettrace() else logging.INFO)
+    ch.setFormatter(formatter)
+    root.addHandler(ch)
+
+    with open(args.config) as config_file:
+        conf = yaml.safe_load(config_file)
+    local_rank, world_rank, world_size = get_rank_info(conf["trainer"]["mode"])
+    rank = world_rank
+    save_loc = expandvars(conf["save_loc"])
+    os.makedirs(save_loc, exist_ok=True)
+    if not os.path.exists(os.path.join(save_loc, "model.yml")):
+        shutil.copy(config, os.path.join(save_loc, "model.yml"))
+
+    if launch:
+        script_path = Path(__file__).absolute()
+        if conf["pbs"]["queue"] == "casper":
+            logging.info("Launching to PBS on Casper")
+            launch_script(config, script_path)
+        else:
+            logging.info("Launching to PBS on Derecho")
+            launch_script_mpi(config, script_path)
+        sys.exit()
+
+    if conf["trainer"]["mode"] in ["fsdp", "ddp", "domain_parallel", "fsdp+domain_parallel"]:
+        setup(rank, world_size, conf["trainer"]["mode"], backend)
+
+    if torch.cuda.is_available():
+        device = torch.device(f"cuda:{local_rank % torch.cuda.device_count()}")
+        torch.cuda.set_device(local_rank % torch.cuda.device_count())
+        torch.backends.cudnn.benchmark = True
+    else:
+        device = torch.device("cpu")
+
+    trainer_conf = conf["trainer"]
+    train_dataset = load_dataset(conf, is_train=True)
+    train_loader = load_dataloader(conf, train_dataset, rank=rank, world_size=world_size, is_train=True)
+    seed = conf.get("seed", 42) + rank
+    seed_everything(seed)
+    preblocks = build_preblocks(conf["preblocks"])
+    scaler_block_key = None
+    for k, v in preblocks.items():
+        if v["type"] == "bridgescaler_transform":
+            scaler_block_key = k
+            break
+    if scaler_block_key is None:
+        raise ValueError("BridgeScalerTransformer not found in preblocks.")
+    batches_per_epoch = trainer_conf.get("batches_per_epoch", 1)
+    dl = cycle(train_loader)
+    for i in range(batches_per_epoch):
+        batch = next(dl)
+        processed_batch = apply_preblocks_before_scaler(preblocks, batch, device)
+        preblocks[scaler_block_key].fit_scaler_batch(processed_batch)
+
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/credit/applications/preprocess.py
+++ b/credit/applications/preprocess.py
@@ -1,5 +1,8 @@
 import argparse
 import logging
+
+from bridgescaler import save_scaler_dict
+
 from credit.distributed import get_rank_info, setup
 from credit.seed import seed_everything
 from os.path import expandvars
@@ -9,10 +12,10 @@ import yaml
 import sys
 from pathlib import Path
 from credit.pbs import launch_script, launch_script_mpi
-from credit.datasets.load_dataset_and_dataloader import load_dataset, load_dataloader
 import shutil
-from credit.preblock import build_preblocks, apply_preblocks_before_scaler
-from credit.trainers.utils import cycle
+from credit.preblock import build_preblocks, apply_preblocks_before_scaler, BridgeScalerTransformer
+from credit.trainers.utils import cycle, load_dataset, load_dataloader
+from torch.distributed import gather_object, barrier
 
 
 def main():
@@ -34,8 +37,8 @@ def main():
     ch.setLevel(logging.DEBUG if gettrace and gettrace() else logging.INFO)
     ch.setFormatter(formatter)
     root.addHandler(ch)
-
-    with open(args.config) as config_file:
+    root.info("Loading Config file")
+    with open(args.model_config) as config_file:
         conf = yaml.safe_load(config_file)
     local_rank, world_rank, world_size = get_rank_info(conf["trainer"]["mode"])
     rank = world_rank
@@ -72,7 +75,7 @@ def main():
     preblocks = build_preblocks(conf["preblocks"])
     scaler_block_key = None
     for k, v in preblocks.items():
-        if v["type"] == "bridgescaler_transform":
+        if isinstance(v, BridgeScalerTransformer):
             scaler_block_key = k
             break
     if scaler_block_key is None:
@@ -80,10 +83,20 @@ def main():
     batches_per_epoch = trainer_conf.get("batches_per_epoch", 1)
     dl = cycle(train_loader)
     for i in range(batches_per_epoch):
+        root.info(f"Worker {rank}: Processing batch {i} of {batches_per_epoch}.")
         batch = next(dl)
         processed_batch = apply_preblocks_before_scaler(preblocks, batch, device)
         preblocks[scaler_block_key].fit_scaler_batch(processed_batch)
-
+    barrier()
+    if rank == 0:
+        all_scalers = []
+    else:
+        all_scalers = []
+    gather_object(preblocks[scaler_block_key].scaler, all_scalers, dst=0)
+    if rank == 0:
+        root.info("Combining scalers.")
+        combined_scaler = sum(all_scalers)
+        save_scaler_dict(combined_scaler, preblocks.scaler_path)
     return
 
 

--- a/credit/applications/preprocess.py
+++ b/credit/applications/preprocess.py
@@ -153,6 +153,7 @@ def main():
     seed = conf.get("seed", 42) + rank
     seed_everything(seed)
     preblocks = build_preblocks(conf["preblocks"])
+    print(preblocks)
     scaler_block_key = None
     for k, v in preblocks.items():
         if isinstance(v, BridgeScalerTransformer):
@@ -160,7 +161,14 @@ def main():
             break
     if scaler_block_key is None:
         raise ValueError("BridgeScalerTransformer not found in preblocks.")
-    batches_per_epoch = trainer_conf.get("batches_per_epoch", 1)
+    _bpe = trainer_conf.get("batches_per_epoch", 0) or 0
+    if hasattr(train_loader.sampler, "batches_per_epoch"):
+        dataset_batches = train_loader.sampler.batches_per_epoch()
+    elif hasattr(train_loader.dataset, "batches_per_epoch"):
+        dataset_batches = train_loader.dataset.batches_per_epoch()
+    else:
+        dataset_batches = len(train_loader)
+    batches_per_epoch = _bpe if 0 < _bpe < dataset_batches else dataset_batches
     dl = cycle(train_loader)
     for i in range(batches_per_epoch):
         root.info(f"Worker {rank}: Processing batch {i} of {batches_per_epoch}.")

--- a/credit/cli/_parser.py
+++ b/credit/cli/_parser.py
@@ -8,7 +8,7 @@ from ._ask import _ask
 from ._common import _setup_logging
 from ._convert import _convert, _init
 from ._plot import _metrics, _plot
-from ._submit import _realtime, _rollout, _rollout_ensemble, _submit, _train
+from ._submit import _preprocess, _realtime, _rollout, _rollout_ensemble, _submit, _train
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -18,8 +18,9 @@ def _build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=textwrap.dedent("""\
             Examples:
-              credit init     --grid 0.25deg -o my_config.yml
-              credit train    -c config.yml
+              credit init       --grid 0.25deg -o my_config.yml
+              credit preprocess -c config.yml
+              credit train      -c config.yml
               credit realtime -c config.yml --init-time 2024-01-15T00 --steps 40
               credit rollout  -c config.yml
               credit submit   --cluster casper  -c config.yml --gpus 1
@@ -45,6 +46,13 @@ def _build_parser() -> argparse.ArgumentParser:
         "-o", "--output", default="config.yml", metavar="FILE", help="Output file path (default: config.yml)"
     )
     p.add_argument("--force", action="store_true", help="Overwrite existing output file")
+
+    # ---- preprocess ----
+    p = sub.add_parser("preprocess", help="Fit preprocessing scalers (BridgeScaler) over the training data")
+    p.add_argument("-c", "--config", required=True, metavar="CONFIG", help="Path to YAML config")
+    p.add_argument(
+        "--backend", default="nccl", choices=["nccl", "gloo", "mpi"], help="Distributed backend (default: nccl)"
+    )
 
     # ---- train ----
     p = sub.add_parser("train", help="Train a CREDIT v2 model")
@@ -115,18 +123,20 @@ def _build_parser() -> argparse.ArgumentParser:
             Use --dry-run to inspect the script before submitting.
 
             Modes:
-              train     (default) Submit a training job.  Use --reload / --chain for
-                        resuming and chaining multiple epochs across jobs.
-              rollout   Submit N parallel PBS rollout jobs covering all init times.
-                        Use --jobs N to set parallelism.  No afterok chain.
-              realtime  Submit a single realtime forecast job.
-                        Requires --init-time and --steps.
+              train      (default) Submit a training job.  Use --reload / --chain for
+                         resuming and chaining multiple epochs across jobs.
+              preprocess Submit a single job to fit preprocessing scalers.
+              rollout    Submit N parallel PBS rollout jobs covering all init times.
+                         Use --jobs N to set parallelism.  No afterok chain.
+              realtime   Submit a single realtime forecast job.
+                         Requires --init-time and --steps.
 
             Examples:
               credit submit --cluster casper  -c config.yml --gpus 1 --walltime 04:00:00
               credit submit --cluster derecho -c config.yml --gpus 4 --nodes 2 --dry-run
               credit submit --cluster casper  -c config.yml --mode train --reload
               credit submit --cluster derecho -c config.yml --mode train --chain 10
+              credit submit --cluster casper  -c config.yml --mode preprocess
               credit submit --cluster casper  -c config.yml --mode rollout --jobs 10
               credit submit --cluster casper  -c config.yml --mode realtime --init-time 2024-01-15T00 --steps 40
         """),
@@ -137,8 +147,8 @@ def _build_parser() -> argparse.ArgumentParser:
         "--mode",
         dest="submit_mode",
         default="train",
-        choices=["train", "rollout", "realtime"],
-        help="Submission mode: train (default), rollout, or realtime",
+        choices=["train", "preprocess", "rollout", "realtime"],
+        help="Submission mode: train (default), preprocess, rollout, or realtime",
     )
     p.add_argument("--gpus", type=int, default=None, metavar="N", help="GPUs per node")
     p.add_argument("--nodes", type=int, default=None, metavar="N", help="Number of nodes, derecho only")
@@ -307,6 +317,7 @@ def main() -> None:
 
     dispatch = {
         "init": _init,
+        "preprocess": _preprocess,
         "train": _train,
         "rollout": _rollout,
         "rollout-ensemble": _rollout_ensemble,

--- a/credit/cli/_submit.py
+++ b/credit/cli/_submit.py
@@ -21,6 +21,13 @@ def _train(args: argparse.Namespace) -> None:
     main_cli()
 
 
+def _preprocess(args: argparse.Namespace) -> None:
+    from credit.applications.preprocess import main
+
+    sys.argv = ["credit-preprocess", "-c", args.config, "--backend", args.backend]
+    main()
+
+
 def _rollout(args: argparse.Namespace) -> None:
     from credit.applications.rollout_to_netcdf_gen2 import main
 
@@ -401,6 +408,128 @@ def _build_realtime_pbs_script(
         """)
 
 
+def _build_preprocess_pbs_script(
+    args: argparse.Namespace,
+    config: str,
+    repo: str,
+    save_loc: str = None,
+) -> str:
+    """Return a PBS script that runs the preprocessing / scaler-fitting job."""
+    if save_loc:
+        logs_dir = os.path.join(os.path.expandvars(save_loc), "logs")
+        os.makedirs(logs_dir, exist_ok=True)
+        output_line = f"#PBS -o {logs_dir}"
+    else:
+        output_line = ""
+
+    job_name = getattr(args, "job_name", "credit_preprocess")
+
+    if args.cluster == "casper":
+        return textwrap.dedent(f"""\
+            #!/bin/bash -l
+            #PBS -N {job_name}
+            #PBS -l select=1:ncpus={args.cpus}:ngpus={args.gpus}:mem={args.mem}:gpu_type={args.gpu_type}
+            #PBS -l walltime={args.walltime}
+            #PBS -A {args.account}
+            #PBS -q {args.queue}
+            #PBS -j oe
+            #PBS -k eod
+            {output_line}
+
+            module load conda/latest
+
+            conda activate {args.conda_env}
+
+            REPO={repo}
+            CONFIG={config}
+            NGPUS={args.gpus}
+            TORCHRUN=$(which torchrun)
+
+            echo "Preprocessing — scaler fitting"
+            echo "Config  : ${{CONFIG}}"
+            echo "Node    : $(hostname)"
+            echo "GPUs    : ${{NGPUS}}"
+
+            ${{TORCHRUN}} --standalone --nnodes=1 --nproc-per-node=${{NGPUS}} \\
+                ${{REPO}}/credit/applications/preprocess.py -c ${{CONFIG}}
+        """)
+
+    else:  # derecho
+        return textwrap.dedent(f"""\
+            #!/bin/bash
+            #PBS -A {args.account}
+            #PBS -N {job_name}
+            #PBS -l walltime={args.walltime}
+            #PBS -l select=1:ncpus={args.cpus}:ngpus={args.gpus}:mem={args.mem}
+            #PBS -q {args.queue}
+            #PBS -j oe
+            #PBS -k eod
+            #PBS -r n
+            {output_line}
+
+            module load ncarenv/24.12 gcc/12.4.0 ncarcompilers craype cray-mpich/8.1.29 \\
+                        cuda/12.3.2 conda/latest
+
+            conda activate {args.conda_env}
+
+            REPO={repo}
+            CONFIG={config}
+            TORCHRUN={args.conda_env + "/bin/torchrun" if (args.conda_env and os.path.isdir(args.conda_env)) else _find_torchrun()}
+
+            echo "Preprocessing — scaler fitting"
+            echo "Config  : ${{CONFIG}}"
+
+            ${{TORCHRUN}} --standalone --nnodes=1 --nproc-per-node={args.gpus} \\
+                ${{REPO}}/credit/applications/preprocess.py -c ${{CONFIG}}
+        """)
+
+
+def _do_submit_preprocess(args: argparse.Namespace) -> None:
+    """Submit a single PBS job for preprocessing / scaler fitting."""
+    repo = _repo_root()
+    pbs_cfg = _load_pbs_config(args.config)
+
+    if not hasattr(args, "nodes"):
+        args.nodes = None
+    if not hasattr(args, "torchrun"):
+        args.torchrun = None
+
+    args = _resolve_pbs_opts(args, pbs_cfg)
+
+    with open(args.config) as f:
+        conf = yaml.safe_load(f)
+    save_loc = os.path.expandvars(conf.get("save_loc", "."))
+    config_abs = os.path.abspath(args.config)
+
+    sep = "=" * 52
+    logger.info(
+        "\n%s\n  Preprocess job plan\n%s\n"
+        "  Cluster   : %s\n"
+        "  Account   : %s\n"
+        "  Config    : %s\n"
+        "  GPUs      : %s\n"
+        "  Walltime  : %s\n"
+        "%s",
+        sep,
+        sep,
+        args.cluster,
+        args.account,
+        args.config,
+        args.gpus,
+        args.walltime,
+        sep,
+    )
+
+    script = _build_preprocess_pbs_script(args, config_abs, repo, save_loc=save_loc)
+
+    if args.dry_run:
+        print(script)
+        return
+
+    job_id = _qsub(script, save_loc=save_loc)
+    logger.info("Submitted: %s", job_id)
+
+
 def _do_submit_realtime(args: argparse.Namespace) -> None:
     """Submit a single PBS job for a realtime forecast."""
     repo = _repo_root()
@@ -457,6 +586,9 @@ def _do_submit_realtime(args: argparse.Namespace) -> None:
 def _submit(args: argparse.Namespace) -> None:
     """Generate and optionally submit PBS batch scripts, with optional chaining."""
     mode = getattr(args, "submit_mode", "train")
+    if mode == "preprocess":
+        _do_submit_preprocess(args)
+        return
     if mode == "rollout":
         _do_submit_rollout(args)
         return

--- a/credit/datasets/era5.py
+++ b/credit/datasets/era5.py
@@ -373,8 +373,8 @@ class WeatherBench2ERA5Dataset(BaseDataset):
     def __init__(
         self,
         data_config: dict,
-        resolution: str = "1440x721",
         return_target: bool = False,
+        resolution: str = "1440x721",
     ) -> None:
         super().__init__(data_config, return_target)
         assert self.curr_source_cfg["dataset_type"] == "weatherbench2_era5", (

--- a/credit/datasets/multi_source.py
+++ b/credit/datasets/multi_source.py
@@ -55,7 +55,7 @@ _SOURCE_REGISTRY: dict[str, tuple[str, str]] = {
     "BASE": ("credit.datasets.base_dataset", "BaseDataset"),  # placeholders / testing
     "LOCAL": ("credit.datasets.local", "LocalDataset"),
     "ARCO_ERA5": ("credit.datasets.era5", "ARCOERA5Dataset"),
-    "WeatherBench2_ERA5": ("credit.datasets.era5", "WeatherBench2ERA5Dataset"),
+    "WEATHERBENCH2_ERA5": ("credit.datasets.era5", "WeatherBench2ERA5Dataset"),
     "MRMS": ("credit.datasets.mrms", "MRMSDataset"),
     "GOES": ("credit.datasets.goes", "GOESDataset"),
     "HRRR": ("credit.datasets.hrrr", "HRRRDataset"),

--- a/credit/datasets/multi_source.py
+++ b/credit/datasets/multi_source.py
@@ -147,7 +147,7 @@ class MultiSourceDataset(AbstractBaseDataset):
             sub_config = make_single_source_subconfig(config, user_dataset_name)
             # Route to the appropriate dataset class based on the "dataset_name" field in the sub-config
             cls = route_to_dataset_class(sub_config["source"][user_dataset_name])
-            self.datasets[user_dataset_name] = cls(sub_config, return_target)
+            self.datasets[user_dataset_name] = cls(sub_config, return_target=return_target)
             logger.info(f"MultiSourceDataset: registered dataset '{user_dataset_name}' with class '{cls.__name__}'")
 
         self.datetimes: pd.DatetimeIndex = self._build_master_clock(config)

--- a/credit/distributed.py
+++ b/credit/distributed.py
@@ -41,6 +41,90 @@ def setup(rank, world_size, mode, backend="nccl"):
     dist.init_process_group(backend, rank=rank, world_size=world_size)
 
 
+# torch's conventional default rendezvous port; used as a deterministic
+# fallback when no MPI broadcast is available to agree on a random port.
+DEFAULT_MASTER_PORT = 29500
+
+
+def resolve_master_addr():
+    """Resolve a routable (non-loopback) IP address for the current host.
+
+    ``socket.gethostbyname(socket.gethostname())`` frequently returns a
+    loopback address (``127.0.0.1``) on HPC nodes whose hostname maps to
+    localhost in ``/etc/hosts``, which makes it unusable as a rendezvous
+    address. This prefers a non-loopback result from hostname resolution, and
+    otherwise discovers the outbound-interface IP by opening a dummy UDP
+    socket (no packets are actually sent).
+
+    Returns:
+        str: A best-effort non-loopback IPv4 address, falling back to
+            ``127.0.0.1`` if none can be determined.
+    """
+    try:
+        addr = socket.gethostbyname(socket.gethostname())
+        if not addr.startswith("127."):
+            return addr
+    except OSError:
+        pass
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        # Connecting a UDP socket only sets the kernel's chosen source address;
+        # it does not send any traffic. The destination need not be reachable.
+        sock.connect(("8.8.8.8", 80))
+        return sock.getsockname()[0]
+    except OSError:
+        return "127.0.0.1"
+    finally:
+        sock.close()
+
+
+def resolve_socket_ifname():
+    """Return the network interface name owning this host's routable address.
+
+    Used to set ``GLOO_SOCKET_IFNAME`` so Gloo binds to a real (non-loopback)
+    interface instead of falling back to ``127.0.0.1``.
+
+    Returns:
+        str | None: The matching interface name, or ``None`` if it cannot be
+            determined (no routable address, ``psutil`` unavailable, or no
+            matching interface), in which case the caller should leave
+            ``GLOO_SOCKET_IFNAME`` unset.
+    """
+    addr = resolve_master_addr()
+    if addr.startswith("127."):
+        return None
+    try:
+        import psutil
+    except ImportError:
+        return None
+    for ifname, addrs in psutil.net_if_addrs().items():
+        for snic in addrs:
+            if snic.family == socket.AF_INET and snic.address == addr:
+                return ifname
+    return None
+
+
+def configure_gloo_ifname():
+    """Bind Gloo to a routable interface when ``GLOO_SOCKET_IFNAME`` is unset.
+
+    PyTorch's Gloo backend (used for CPU-side collectives even in NCCL runs)
+    binds to loopback when it cannot resolve the hostname to a local address,
+    which breaks those collectives across nodes. This sets
+    ``GLOO_SOCKET_IFNAME`` to the interface owning this host's routable address
+    as a best-effort default. It is a no-op if the variable is already set or
+    no interface can be determined, and it intentionally leaves
+    ``NCCL_SOCKET_IFNAME`` alone so NCCL is free to auto-select the
+    high-speed interconnect.
+    """
+    if "GLOO_SOCKET_IFNAME" in os.environ:
+        return
+    ifname = resolve_socket_ifname()
+    if ifname is not None:
+        os.environ["GLOO_SOCKET_IFNAME"] = ifname
+        logging.info("Set GLOO_SOCKET_IFNAME=%s for Gloo CPU collectives", ifname)
+
+
 def get_rank_info(trainer_mode):
     """Gets rank and size information for distributed training.
 
@@ -58,6 +142,7 @@ def get_rank_info(trainer_mode):
                 WORLD_SIZE = int(os.environ["WORLD_SIZE"])
                 WORLD_RANK = int(os.environ["RANK"])
             else:
+                logging.info("Using MPI for distributed training.")
                 from mpi4py import MPI
 
                 comm = MPI.COMM_WORLD
@@ -66,14 +151,23 @@ def get_rank_info(trainer_mode):
                 LOCAL_RANK = shmem_comm.Get_rank()
                 WORLD_SIZE = comm.Get_size()
                 WORLD_RANK = comm.Get_rank()
-
-                # Set MASTER_ADDR and MASTER_PORT if not already set.
-                # (broadcast these from rank 0 - they must be consistent on every node)
-                if "MASTER_ADDR" not in os.environ:
-                    os.environ["MASTER_ADDR"] = comm.bcast(socket.gethostbyname(socket.gethostname()), root=0)
-                if "MASTER_PORT" not in os.environ:
-                    os.environ["MASTER_PORT"] = comm.bcast(str(np.random.randint(1000, 8000)), root=0)
-
+                print("MASTER_ADDR: ", os.environ.get("MASTER_ADDR", "Not set"))
+                # Set MASTER_ADDR and MASTER_PORT consistently on every rank.
+                # bcast is a collective: every rank must call it, in the same order.
+                # Rank 0 picks the values (honoring any pre-set env vars) and broadcasts
+                # them so all workers agree, rather than each rank reading its own env.
+                if WORLD_RANK == 0:
+                    master_addr = os.environ.get("MASTER_ADDR", resolve_master_addr())
+                    master_port = os.environ.get("MASTER_PORT", str(np.random.randint(20000, 30000)))
+                else:
+                    master_addr = None
+                    master_port = None
+                os.environ["MASTER_ADDR"] = comm.bcast(master_addr, root=0)
+                os.environ["MASTER_PORT"] = comm.bcast(master_port, root=0)
+                comm.barrier()
+                print("MASTER_ADDR: ", os.environ.get("MASTER_ADDR", "Still Not set"))
+                logging.info("Using MASTER_ADDR={}".format(os.environ["MASTER_ADDR"]))
+                logging.info("Using MASTER_PORT={}".format(os.environ["MASTER_PORT"]))
                 if 0 == WORLD_RANK:
                     logging.info("Using MASTER_ADDR={}".format(os.environ["MASTER_ADDR"]))
                     logging.info("Using MASTER_PORT={}".format(os.environ["MASTER_PORT"]))
@@ -101,6 +195,29 @@ def get_rank_info(trainer_mode):
                     "Can't find the environment variables for local rank. "
                     "If you are on casper you'll want to use torchrun for now."
                 )
+
+            # The MPI broadcast path above is unavailable here, so we cannot
+            # guarantee these agree across nodes. Set sane defaults only if the
+            # launcher hasn't already provided them, and warn that multi-node
+            # jobs must export MASTER_ADDR/MASTER_PORT explicitly to be safe.
+            if "MASTER_ADDR" not in os.environ:
+                os.environ["MASTER_ADDR"] = resolve_master_addr()
+                logging.warning(
+                    "MASTER_ADDR was not set and could not be broadcast via MPI; "
+                    "defaulting to %s. For multi-node jobs, export MASTER_ADDR "
+                    "explicitly so all nodes agree on the rendezvous address.",
+                    os.environ["MASTER_ADDR"],
+                )
+            if "MASTER_PORT" not in os.environ:
+                os.environ["MASTER_PORT"] = str(DEFAULT_MASTER_PORT)
+                logging.warning(
+                    "MASTER_PORT was not set; defaulting to %s.",
+                    os.environ["MASTER_PORT"],
+                )
+
+        # Point Gloo at a routable interface so its CPU-side collectives don't
+        # fall back to loopback (runs for both the MPI and fallback branches).
+        configure_gloo_ifname()
 
     else:
         LOCAL_RANK = 0

--- a/credit/models/wxformer/crossformer.py
+++ b/credit/models/wxformer/crossformer.py
@@ -66,6 +66,29 @@ class CubeEmbedding(nn.Module):
         return x
 
 
+def icnr_init_(weight, scale, init=nn.init.kaiming_normal_):
+    """ICNR init for a sub-pixel conv feeding nn.PixelShuffle (Aitken et al. 2017).
+
+    Initializes the conv weight so that, immediately after PixelShuffle(scale), the
+    output equals a nearest-neighbor upsample of a single initialized sub-kernel.
+    All scale**2 sub-pixel channels start identical, which removes the checkerboard
+    grid pattern present at initialization with default init.
+
+    Args:
+        weight: conv weight of shape (out_ch * scale**2, in_ch, kh, kw).
+        scale: PixelShuffle upscale factor.
+        init: in-place initializer applied to the sub-kernel.
+    """
+    out_ch = weight.shape[0] // (scale**2)
+    sub = torch.zeros(out_ch, *weight.shape[1:], device=weight.device, dtype=weight.dtype)
+    init(sub)
+    # PixelShuffle consumes channels in contiguous (r**2) blocks per output channel,
+    # so each sub-kernel must be repeated contiguously along the channel dim.
+    sub = sub.repeat_interleave(scale**2, dim=0)
+    with torch.no_grad():
+        weight.copy_(sub)
+
+
 class UpBlock(nn.Module):
     def __init__(
         self,
@@ -110,8 +133,10 @@ class UpBlock(nn.Module):
 class UpBlockPS(nn.Module):
     def __init__(self, in_ch, out_ch, num_groups, scale=2, num_residuals=2):
         super().__init__()
-        # sub-pixel conv at low res
+        # sub-pixel conv at low res (ICNR init removes checkerboard at initialization)
         self.conv = nn.Conv2d(in_ch, out_ch * scale**2, 3, stride=1, padding=1)
+        icnr_init_(self.conv.weight, scale)
+        nn.init.zeros_(self.conv.bias)
         self.ps = nn.PixelShuffle(scale)
         # sharpening branch (identity init)
         self.sharp = nn.Conv2d(out_ch, out_ch, 3, padding=1)
@@ -580,14 +605,17 @@ class CrossFormer(BaseModel):
             self.up_block2 = UpBlockPS(2 * (last_dim // 2), last_dim // 4, dim[0])
             self.up_block3 = UpBlockPS(2 * (last_dim // 4), last_dim // 8, dim[0])
             scale = 2
+            ps_conv = nn.Conv2d(
+                2 * (last_dim // 8),  # in_channels
+                self.output_channels * (scale**2),  # conv_out = target_channels * 4
+                kernel_size=3,
+                stride=1,
+                padding=1,
+            )
+            icnr_init_(ps_conv.weight, scale)  # checkerboard-free sub-pixel init
+            nn.init.zeros_(ps_conv.bias)
             self.up_block4 = nn.Sequential(
-                nn.Conv2d(
-                    2 * (last_dim // 8),  # in_channels
-                    self.output_channels * (scale**2),  # conv_out = target_channels * 4
-                    kernel_size=3,
-                    stride=1,
-                    padding=1,
-                ),
+                ps_conv,
                 nn.PixelShuffle(upscale_factor=scale),  # now (target_channels, H*2, W*2),
                 nn.Conv2d(self.output_channels, self.output_channels, 3, padding=1),
             )

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -6,6 +6,7 @@ from credit.preblock.sqrt import SqrtTransform
 from credit.preblock.regrid import Regridder
 from credit.preblock.concat import ConcatToTensor
 from credit.preblock.norm import ERA5Normalizer
+from credit.preblock.nan import FillNan
 from credit.preblock.scaler import BridgeScalerTransformer
 
 
@@ -15,6 +16,7 @@ PREBLOCK_REGISTRY = {
     "regrid": Regridder,
     "concat": ConcatToTensor,
     "era5_normalizer": ERA5Normalizer,
+    "fill_nan": FillNan,
     "bridgescaler_transformer": BridgeScalerTransformer,
 }
 

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -1,5 +1,3 @@
-import logging
-
 import torch
 import torch.nn as nn
 
@@ -8,16 +6,8 @@ from credit.preblock.sqrt import SqrtTransform
 from credit.preblock.regrid import Regridder
 from credit.preblock.concat import ConcatToTensor
 from credit.preblock.norm import ERA5Normalizer
+from credit.preblock.scaler import BridgeScalerTransformer
 
-# bridgescaler is an optional dependency; guard against environments without it
-try:
-    from credit.preblock.scaler import BridgeScalerTransformer
-
-    _BRIDGESCALER_AVAILABLE = True
-except (ImportError, Exception) as _e:
-    logging.warning(f"BridgeScalerTransformer unavailable (numba/NumPy conflict): {_e}")
-    BridgeScalerTransformer = None
-    _BRIDGESCALER_AVAILABLE = False
 
 PREBLOCK_REGISTRY = {
     "log_transform": LogTransform,
@@ -25,10 +15,8 @@ PREBLOCK_REGISTRY = {
     "regrid": Regridder,
     "concat": ConcatToTensor,
     "era5_normalizer": ERA5Normalizer,
+    "bridgescaler_transform": BridgeScalerTransformer,
 }
-
-if _BRIDGESCALER_AVAILABLE:
-    PREBLOCK_REGISTRY["bridgescaler_transform"] = BridgeScalerTransformer
 
 
 def build_preblocks(preblock_cfg: dict | None = None) -> nn.ModuleDict:
@@ -94,3 +82,18 @@ def apply_preblocks(preblocks: nn.ModuleDict, batch: dict, device=None):
         out = {k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in out.items()}
 
     return out
+
+
+def apply_preblocks_before_scaler(preblocks: nn.ModuleDict, batch: dict, device=None):
+    for preblock in preblocks.values():
+        if isinstance(preblock, BridgeScalerTransformer):
+            break
+        result = preblock(batch)
+        if isinstance(result, tuple):
+            if len(result) == 3:
+                batch, target, meta = result
+            else:
+                batch, meta = result
+        else:
+            batch = result
+    return batch

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -15,7 +15,7 @@ PREBLOCK_REGISTRY = {
     "regrid": Regridder,
     "concat": ConcatToTensor,
     "era5_normalizer": ERA5Normalizer,
-    "bridgescaler_transform": BridgeScalerTransformer,
+    "bridgescaler_transformer": BridgeScalerTransformer,
 }
 
 

--- a/credit/preblock/_utils.py
+++ b/credit/preblock/_utils.py
@@ -1,5 +1,45 @@
-def _parse_variable_selection(variable_list, state_dict):
+def _parse_variable_selection(variable_list: list, state_dict: dict, data_types: list = None) -> list:
     """
-    The goal of this function is to
+    The goal of this function is to expand partial variables in `variable_list` based on the keys in `state_dict`.
+    For example, if `variable_list` contains "ERA5/prognostic/3d", then this function should expand that partial name
+    to include every variable in `state_dict` that has the matching partial name.
+
+    Args:
+        variable_list (list): A list of partial or full variable names. An empty list means that all variables should be used.
+        state_dict (dict): A dictionary of the data state following the CREDIT convention, nested as
+        `state_dict[data_type][source][var_name]`. The data types (input, target, prediction) are the
+        highest level key, then the source (e.g. "era5"), then the full variable names
+        (e.g. `"era5/prognostic/3d/temperature"`).
+        data_types (list): A list of data types to include. If None, all data types will be included.
+
+    Returns:
+        list: The full variable names from `state_dict` matched by `variable_list`, with duplicates
+        removed and order preserved.
     """
-    return
+    # Default to every data type present in the state.
+    if data_types is None:
+        data_types = list(state_dict.keys())
+
+    # Collect every full variable name across the selected data types and sources,
+    # preserving first-seen order and dropping duplicates (the same variable may
+    # appear under more than one data type).
+    all_variables = []
+    for data_type in data_types:
+        for source in state_dict.get(data_type, {}).values():
+            for var_name in source:
+                if var_name not in all_variables:
+                    all_variables.append(var_name)
+
+    # An empty selection means "use everything".
+    if not variable_list:
+        return all_variables
+
+    # Expand each (possibly partial) name: a variable matches if it equals the
+    # entry or sits beneath it in the "/"-delimited hierarchy.
+    selected = []
+    for partial in variable_list:
+        for var_name in all_variables:
+            if var_name == partial or var_name.startswith(partial + "/"):
+                if var_name not in selected:
+                    selected.append(var_name)
+    return selected

--- a/credit/preblock/_utils.py
+++ b/credit/preblock/_utils.py
@@ -1,0 +1,5 @@
+def _parse_variable_selection(variable_list, state_dict):
+    """
+    The goal of this function is to
+    """
+    return

--- a/credit/preblock/nan.py
+++ b/credit/preblock/nan.py
@@ -1,0 +1,73 @@
+import torch
+
+from credit.preblock.base import BasePreblock
+from ._utils import _parse_variable_selection
+
+
+class FillNan(BasePreblock):
+    """Replace NaN values with a constant fill value for selected variables.
+
+    Walks a nested batch dict of the form ``batch[data_type][source][var_key]``
+    and replaces any NaN entries with ``fill_value`` for the selected variables.
+    Only NaNs are touched; ``+/-inf`` and finite values are left unchanged.
+
+    ``variables`` may contain full or partial names (e.g. ``"era5/prognostic/3d"``
+    expands to every variable beneath it) and is expanded against the first batch
+    via :func:`credit.preblock._utils._parse_variable_selection`. An empty or
+    omitted ``variables`` list means "every variable". Specifying a subset lets
+    several ``FillNan`` preblocks coexist, each filling different variables with a
+    different value.
+
+    Config example::
+
+        type: "fill_nan"
+        args:
+            variables:                  # optional, defaults to all variables
+                - "era5/prognostic/3d/Q"
+            data_types:                 # optional, defaults to ['input', 'target']
+                - "input"
+                - "target"
+            fill_value: 0.0             # optional, default 0.0
+    """
+
+    def __init__(
+        self,
+        variables: list[str] = None,
+        data_types: list[str] = None,
+        fill_value: float = 0.0,
+    ):
+        super().__init__()
+        self.variables = variables or []
+        self.variables_expanded = False
+        self.data_types = data_types or ["input", "target"]
+        self.fill_value = fill_value
+
+        # Validate data_types at init
+        invalid = set(self.data_types) - set(self.VALID_DATA_TYPES)
+        if invalid:
+            raise ValueError(f"Invalid data_types {invalid}. Valid options are {self.VALID_DATA_TYPES}. ")
+
+    def forward(self, batch: dict) -> dict:
+        if not self.variables_expanded:
+            self.variables = _parse_variable_selection(self.variables, batch, self.data_types)
+            self.variables_expanded = True
+
+        for var_key in self.variables:
+            source = var_key.split("/")[0]
+
+            for data_type in self.data_types:
+                if data_type not in batch:
+                    continue
+                if source not in batch[data_type]:
+                    continue
+                if var_key not in batch[data_type][source]:
+                    continue
+
+                x = batch[data_type][source][var_key]
+                batch[data_type][source][var_key] = torch.where(
+                    torch.isnan(x),
+                    torch.tensor(self.fill_value, dtype=x.dtype, device=x.device),
+                    x,
+                )
+
+        return batch

--- a/credit/preblock/scaler.py
+++ b/credit/preblock/scaler.py
@@ -3,7 +3,7 @@ from bridgescaler.distributed_tensor import DStandardScalerTensor, DQuantileScal
 from credit.preblock.base import BasePreblock
 from os.path import exists, expandvars
 from os import makedirs
-
+from ._utils import _parse_variable_selection
 
 _SCALER_REGISTRY = {
     "standard": DStandardScalerTensor,
@@ -12,14 +12,42 @@ _SCALER_REGISTRY = {
 }
 
 
+def _combine_scaler_dicts(a, b):
+    """Recursively merge two nested scaler dicts by summing matching leaf scalers.
+
+    bridgescaler distributed scalers implement ``__add__`` as a running merge of
+    fitted statistics, so summing per-batch (or per-rank) fits yields the combined
+    fit over all the underlying data.
+    """
+    if isinstance(a, dict):
+        return {k: _combine_scaler_dicts(a[k], b[k]) for k in a}
+    return a + b
+
+
+def combine_scaler_dicts(scaler_dicts):
+    """Combine a list of nested scaler dicts into a single merged scaler dict.
+
+    Args:
+        scaler_dicts (list): Nested scaler dicts with identical structure, e.g. the
+            per-rank results gathered in ``credit.applications.preprocess``.
+
+    Returns:
+        dict: A single nested scaler dict merging the statistics of every input.
+    """
+    combined = scaler_dicts[0]
+    for scaler_dict in scaler_dicts[1:]:
+        combined = _combine_scaler_dicts(combined, scaler_dict)
+    return combined
+
+
 class BridgeScalerTransformer(BasePreblock):
-    """Scaling preblock using a fitted bridgescaler dict.
+    """Scaling preblock using a dictionary of bridgescaler scalers to fit and transform CREDIT state dictionaries.
 
     Applies per-variable z-score scaling (or its inverse) to tensors in a
-    nested batch dict of the form ``batch[source][data_type][var_key]``.
+    nested batch dict of the form `batch[data_type][source][var_key]`.
 
-    The scaler dict must have been fit with ``bridgescaler.scale_var_dict``
-    using the same nested structure and saved with ``bridgescaler.save_scaler_dict``.
+    The scaler dict must have been fit with `bridgescaler.scale_var_dict`
+    using the same nested structure and saved with `bridgescaler.save_scaler_dict`.
 
     Example config::
 
@@ -42,20 +70,52 @@ class BridgeScalerTransformer(BasePreblock):
     ):
         super().__init__()
         self.variables = variables
+        self.variables_expanded = False
         self.method = method
         self.scaler_path = expandvars(scaler_path)
         if scaler_params is None:
             scaler_params = {}
         self.scaler_params = scaler_params
+        # ``scaler`` holds the nested dict of fitted scalers used for transform /
+        # inverse_transform (loaded from disk, or accumulated by fit_scaler_batch).
+        # ``scaler_template`` is the single unfitted prototype used to fit new data.
         if exists(expandvars(self.scaler_path)):
             self.scaler = load_scaler_dict(scaler_path)
+            self.scaler_template = None
         else:
             full_scaler_path = expandvars(self.scaler_path)
             makedirs(full_scaler_path.rsplit("/", 1)[0], exist_ok=True)
-            self.scaler = _SCALER_REGISTRY[scaler_type](**scaler_params)
+            self.scaler = None
+            self.scaler_template = _SCALER_REGISTRY[scaler_type](**scaler_params)
 
     def forward(self, batch: dict) -> dict:
+        if not self.variables_expanded:
+            self.variables = _parse_variable_selection(self.variables, batch)
+            self.variables_expanded = True
         return scale_var_dict(batch, self.scaler, self.method, self.variables)
 
     def fit_scaler_batch(self, batch: dict) -> dict:
-        return scale_var_dict(batch, self.scaler, "fit", self.variables)
+        """
+        Fit the scaler dictionary to a batch of data. This will usually be called with `credit preprocess`. Repeated
+        calls to fit_scaler_batch will perform a running average of the scaler parameters.
+
+        Args:
+            batch (dict): state dictionary
+
+        Returns:
+            dict: The accumulated nested dict of fitted scalers
+            (`scaler[data_type][source][var_key]`) merged across every call so far.
+            The same dict is stored on `self.scaler`.
+        """
+        if self.scaler_template is None:
+            raise ValueError(
+                f"Cannot fit: a scaler already exists at '{self.scaler_path}'. Remove it to refit from scratch."
+            )
+        if not self.variables_expanded:
+            self.variables = _parse_variable_selection(self.variables, batch)
+            self.variables_expanded = True
+        fitted = scale_var_dict(batch, self.scaler_template, "fit", self.variables)
+        # Merge this batch's fit into the running accumulation (running average of
+        # the scaler statistics across batches).
+        self.scaler = fitted if self.scaler is None else _combine_scaler_dicts(self.scaler, fitted)
+        return self.scaler

--- a/credit/preblock/scaler.py
+++ b/credit/preblock/scaler.py
@@ -1,5 +1,14 @@
 from bridgescaler import load_scaler_dict, scale_var_dict
+from bridgescaler.distributed_tensor import DStandardScalerTensor, DQuantileScalerTensor, DMinMaxScalerTensor
 from credit.preblock.base import BasePreblock
+from os.path import exists, expandvars
+from os import makedirs
+
+_SCALER_REGISTRY = {
+    "standard": DStandardScalerTensor,
+    "quantile": DQuantileScalerTensor,
+    "minmax": DMinMaxScalerTensor,
+}
 
 
 class BridgeScalerTransformer(BasePreblock):
@@ -22,12 +31,25 @@ class BridgeScalerTransformer(BasePreblock):
             method: "transform"
     """
 
-    def __init__(self, scaler_path: str, variables: list[str], method: str):
+    def __init__(
+        self, scaler_path: str, variables: list[str], method: str, scaler_type: str = "standard", scaler_params=None
+    ):
         super().__init__()
         self.variables = variables
         self.method = method
         self.scaler_path = scaler_path
-        self.scaler = load_scaler_dict(scaler_path)
+        if scaler_params is None:
+            scaler_params = {}
+        self.scaler_params = scaler_params
+        if exists(expandvars(self.scaler_path)):
+            self.scaler = load_scaler_dict(scaler_path)
+        else:
+            full_scaler_path = expandvars(self.scaler_path)
+            makedirs(full_scaler_path.rsplit("/", 1)[0], exist_ok=True)
+            self.scaler = _SCALER_REGISTRY[scaler_type](**scaler_params)
 
     def forward(self, batch: dict) -> dict:
         return scale_var_dict(batch, self.scaler, self.method, self.variables)
+
+    def fit_scaler_batch(self, batch: dict) -> dict:
+        return scale_var_dict(batch, self.scaler, "fit", self.variables)

--- a/credit/preblock/scaler.py
+++ b/credit/preblock/scaler.py
@@ -4,6 +4,7 @@ from credit.preblock.base import BasePreblock
 from os.path import exists, expandvars
 from os import makedirs
 
+
 _SCALER_REGISTRY = {
     "standard": DStandardScalerTensor,
     "quantile": DQuantileScalerTensor,
@@ -32,12 +33,17 @@ class BridgeScalerTransformer(BasePreblock):
     """
 
     def __init__(
-        self, scaler_path: str, variables: list[str], method: str, scaler_type: str = "standard", scaler_params=None
+        self,
+        scaler_path: str,
+        variables: list[str],
+        method: str = "transform",
+        scaler_type: str = "standard",
+        scaler_params=None,
     ):
         super().__init__()
         self.variables = variables
         self.method = method
-        self.scaler_path = scaler_path
+        self.scaler_path = expandvars(scaler_path)
         if scaler_params is None:
             scaler_params = {}
         self.scaler_params = scaler_params

--- a/tests/test_downscaling_dataset.py
+++ b/tests/test_downscaling_dataset.py
@@ -8,10 +8,31 @@ from credit.datasets.downscaling_dataset import DownscalingDataset
 
 @pytest.fixture
 def config():
-    """Load test configuration from YAML."""
-    config_path = Path("tests/data/downscaling/dataset.yml")
+    """Load test configuration from YAML.
+
+    Paths in the YAML (``rootpath``) are written relative to the repository
+    root, so they are resolved to absolute paths here. This lets the tests run
+    regardless of the directory pytest is invoked from.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    config_path = Path(__file__).parent / "data" / "downscaling" / "dataset.yml"
     with open(config_path) as f:
-        return yaml.safe_load(f)
+        conf = yaml.safe_load(f)
+
+    def _absolutize_rootpaths(node):
+        """Recursively rewrite relative ``rootpath`` values to absolute paths."""
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "rootpath" and isinstance(value, str) and not Path(value).is_absolute():
+                    node[key] = str(repo_root / value)
+                else:
+                    _absolutize_rootpaths(value)
+        elif isinstance(node, list):
+            for item in node:
+                _absolutize_rootpaths(item)
+
+    _absolutize_rootpaths(conf["data"])
+    return conf
 
 
 @pytest.fixture

--- a/tests/test_preblock.py
+++ b/tests/test_preblock.py
@@ -15,6 +15,7 @@ except (ImportError, Exception):
     _BRIDGESCALER_AVAILABLE = False
 
 from credit.preblock.regrid import Regridder
+from credit.preblock._utils import _parse_variable_selection
 
 
 def create_synthetic_data() -> dict:
@@ -216,3 +217,132 @@ def test_scaler_round_trip(scaler_file):
     data = fwd(data)
     data = inv(data)
     assert torch.allclose(data["input"]["Test_ERA5"][var].float(), original.float(), atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# _parse_variable_selection
+# ---------------------------------------------------------------------------
+def _selection_state() -> dict:
+    """A state dict following the CREDIT convention: state[data_type][source][var_name].
+
+    var_name uses the canonical `source/field_type/dim/varname` layout, and the
+    source key (e.g. "era5") matches the first segment of each variable name.
+    """
+    return {
+        "input": {
+            "era5": {
+                "era5/prognostic/3d/T": object(),
+                "era5/prognostic/3d/U": object(),
+                "era5/prognostic/2d/SP": object(),
+                "era5/static/2d/Z": object(),
+            },
+        },
+        "target": {
+            "era5": {
+                "era5/prognostic/3d/T": object(),
+                "era5/diagnostic/2d/precip": object(),
+            },
+        },
+        "prediction": {
+            "era5": {
+                "era5/prognostic/3d/T": object(),
+            },
+        },
+    }
+
+
+def test_parse_variable_selection_expands_partial():
+    """A partial name expands to every variable beneath it in the hierarchy."""
+    state = _selection_state()
+    result = _parse_variable_selection(["era5/prognostic/3d"], state)
+    assert result == ["era5/prognostic/3d/T", "era5/prognostic/3d/U"]
+
+
+def test_parse_variable_selection_full_name_matches_only_itself():
+    """A full variable name matches exactly and does not pull in siblings."""
+    state = _selection_state()
+    result = _parse_variable_selection(["era5/prognostic/3d/T"], state)
+    assert result == ["era5/prognostic/3d/T"]
+
+
+def test_parse_variable_selection_empty_list_returns_all():
+    """An empty selection returns every variable across all data types (deduped)."""
+    state = _selection_state()
+    result = _parse_variable_selection([], state)
+    assert result == [
+        "era5/prognostic/3d/T",
+        "era5/prognostic/3d/U",
+        "era5/prognostic/2d/SP",
+        "era5/static/2d/Z",
+        "era5/diagnostic/2d/precip",
+    ]
+
+
+def test_parse_variable_selection_dedupes_across_data_types():
+    """A variable present in multiple data types appears only once."""
+    state = _selection_state()
+    result = _parse_variable_selection(["era5/prognostic/3d/T"], state)
+    assert result == ["era5/prognostic/3d/T"]
+
+
+def test_parse_variable_selection_data_types_filter():
+    """Only the requested data types contribute candidate variables."""
+    state = _selection_state()
+    result = _parse_variable_selection([], state, data_types=["prediction"])
+    assert result == ["era5/prognostic/3d/T"]
+
+    result = _parse_variable_selection(["era5"], state, data_types=["target"])
+    assert result == ["era5/prognostic/3d/T", "era5/diagnostic/2d/precip"]
+
+
+def test_parse_variable_selection_missing_data_type_ignored():
+    """A requested data type that is absent from the state is skipped, not an error."""
+    state = _selection_state()
+    result = _parse_variable_selection([], state, data_types=["prediction", "nonexistent"])
+    assert result == ["era5/prognostic/3d/T"]
+
+
+def test_parse_variable_selection_prefix_boundary():
+    """Matching respects '/' boundaries: a prefix that is not a full path segment
+    does not match."""
+    state = _selection_state()
+    # "era5/prognostic/3" is a string prefix of "era5/prognostic/3d/..." but not a
+    # hierarchy ancestor, so nothing should match.
+    result = _parse_variable_selection(["era5/prognostic/3"], state)
+    assert result == []
+
+
+def test_parse_variable_selection_preserves_selection_order():
+    """Multiple partials expand in the order they are listed."""
+    state = _selection_state()
+    result = _parse_variable_selection(["era5/static", "era5/prognostic/2d"], state)
+    assert result == ["era5/static/2d/Z", "era5/prognostic/2d/SP"]
+
+
+def test_parse_variable_selection_multiple_sources():
+    """Variables are collected across all sources within a data type, and a
+    source-level partial selects only that source's variables."""
+    state = {
+        "input": {
+            "era5": {
+                "era5/prognostic/3d/T": object(),
+                "era5/prognostic/2d/SP": object(),
+            },
+            "gfs": {
+                "gfs/prognostic/3d/T": object(),
+                "gfs/static/2d/Z": object(),
+            },
+        },
+    }
+    # Empty list pulls in every variable from every source.
+    assert _parse_variable_selection([], state) == [
+        "era5/prognostic/3d/T",
+        "era5/prognostic/2d/SP",
+        "gfs/prognostic/3d/T",
+        "gfs/static/2d/Z",
+    ]
+    # A source-rooted partial selects only that source's variables.
+    assert _parse_variable_selection(["gfs"], state) == [
+        "gfs/prognostic/3d/T",
+        "gfs/static/2d/Z",
+    ]

--- a/tests/test_preblock_nan.py
+++ b/tests/test_preblock_nan.py
@@ -1,0 +1,167 @@
+"""test_preblock_nan.py — unit tests for credit.preblock.nan.FillNan."""
+
+import math
+
+import pytest
+import torch
+
+from credit.preblock import PREBLOCK_REGISTRY, build_preblocks
+from credit.preblock.nan import FillNan
+
+
+def create_nan_data() -> dict:
+    """Nested CREDIT-convention batch dict with NaNs (and an inf) sprinkled in.
+
+    Structure: data[data_type][source][var_name], tensor shape (2, 3, 1, 4, 4).
+    Each variable gets a couple of NaN entries; T also gets an inf so we can
+    assert infs are left untouched.
+    """
+    shape = (2, 3, 1, 4, 4)
+    var_names = [
+        "Test_ERA5/prognostic/3d/T",
+        "Test_ERA5/prognostic/3d/U",
+        "Test_ERA5/prognostic/2d/SP",
+    ]
+
+    def _make():
+        out = {}
+        for var in var_names:
+            t = torch.randn(*shape)
+            t[0, 0, 0, 0, 0] = float("nan")
+            t[1, 1, 0, 1, 1] = float("nan")
+            if var.endswith("/T"):
+                t[0, 1, 0, 0, 0] = float("inf")
+            out[var] = t
+        return out
+
+    return {split: {"Test_ERA5": _make()} for split in ("input", "target")}
+
+
+def _all_vars(batch, data_type="input", source="Test_ERA5"):
+    return batch[data_type][source]
+
+
+# ---------------------------------------------------------------------------
+# Default behaviour: fill every NaN with 0.0 across all variables / data types
+# ---------------------------------------------------------------------------
+
+
+def test_fill_nan_default_fills_all():
+    """With no variables specified, every NaN in every variable is replaced by 0."""
+    batch = create_nan_data()
+    result = FillNan()(batch)
+    for data_type in ("input", "target"):
+        for var, tensor in _all_vars(result, data_type).items():
+            assert not torch.isnan(tensor).any(), f"NaNs remain in {data_type}/{var}"
+
+
+def test_fill_nan_replaces_with_zero_at_known_positions():
+    """The exact NaN positions become the fill value, finite values are unchanged."""
+    batch = create_nan_data()
+    original = batch["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/U"].clone()
+    result = FillNan()(batch)
+    out = result["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/U"]
+    assert out[0, 0, 0, 0, 0] == 0.0
+    assert out[1, 1, 0, 1, 1] == 0.0
+    # A finite location is left exactly as it was.
+    assert out[0, 2, 0, 2, 2] == original[0, 2, 0, 2, 2]
+
+
+def test_fill_nan_preserves_inf_and_finite():
+    """Only NaNs are touched; +/-inf and finite values are preserved."""
+    batch = create_nan_data()
+    result = FillNan()(batch)
+    t = result["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/T"]
+    assert math.isinf(t[0, 1, 0, 0, 0].item())
+    assert not torch.isnan(t).any()
+
+
+def test_fill_nan_custom_value():
+    """A custom fill_value is used in place of the default 0."""
+    batch = create_nan_data()
+    result = FillNan(fill_value=-999.0)(batch)
+    t = result["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/U"]
+    assert t[0, 0, 0, 0, 0] == -999.0
+    assert t[1, 1, 0, 1, 1] == -999.0
+
+
+# ---------------------------------------------------------------------------
+# Variable subset selection
+# ---------------------------------------------------------------------------
+
+
+def test_fill_nan_variable_subset_full_name():
+    """Only the selected variable is filled; others keep their NaNs."""
+    batch = create_nan_data()
+    result = FillNan(variables=["Test_ERA5/prognostic/3d/U"])(batch)
+    filled = result["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/U"]
+    untouched = result["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/T"]
+    assert not torch.isnan(filled).any()
+    assert torch.isnan(untouched).any()
+
+
+def test_fill_nan_variable_subset_partial_name_expands():
+    """A partial name expands to every variable beneath it (via _parse_variable_selection)."""
+    batch = create_nan_data()
+    fn = FillNan(variables=["Test_ERA5/prognostic/3d"])
+    result = fn(batch)
+    # Both 3d variables should have been expanded and filled.
+    assert sorted(fn.variables) == [
+        "Test_ERA5/prognostic/3d/T",
+        "Test_ERA5/prognostic/3d/U",
+    ]
+    assert not torch.isnan(result["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/T"]).any()
+    assert not torch.isnan(result["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/U"]).any()
+    # The 2d variable was not selected, so its NaNs remain.
+    assert torch.isnan(result["input"]["Test_ERA5"]["Test_ERA5/prognostic/2d/SP"]).any()
+
+
+def test_fill_nan_data_types_scope():
+    """Restricting data_types fills only those splits."""
+    batch = create_nan_data()
+    result = FillNan(data_types=["input"])(batch)
+    assert not torch.isnan(result["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/T"]).any()
+    # target was not in scope, so its NaNs are untouched.
+    assert torch.isnan(result["target"]["Test_ERA5"]["Test_ERA5/prognostic/3d/T"]).any()
+
+
+# ---------------------------------------------------------------------------
+# Invariants
+# ---------------------------------------------------------------------------
+
+
+def test_fill_nan_preserves_shape_and_dtype():
+    """Output tensors keep their shape and dtype."""
+    batch = create_nan_data()
+    var = "Test_ERA5/prognostic/3d/T"
+    original = batch["input"]["Test_ERA5"][var]
+    shape, dtype = original.shape, original.dtype
+    result = FillNan()(batch)
+    out = result["input"]["Test_ERA5"][var]
+    assert out.shape == shape
+    assert out.dtype == dtype
+
+
+def test_fill_nan_invalid_data_type_raises():
+    """An unsupported data_type is rejected at construction time."""
+    with pytest.raises(ValueError):
+        FillNan(data_types=["prediction"])
+
+
+# ---------------------------------------------------------------------------
+# Registry / config construction
+# ---------------------------------------------------------------------------
+
+
+def test_fill_nan_registered():
+    """FillNan is registered under the 'fill_nan' key."""
+    assert PREBLOCK_REGISTRY["fill_nan"] is FillNan
+
+
+def test_fill_nan_built_from_config():
+    """build_preblocks instantiates FillNan from a config dict and it works."""
+    blocks = build_preblocks({"fill": {"type": "fill_nan", "args": {"fill_value": 5.0}}})
+    result = blocks["fill"](create_nan_data())
+    t = result["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/U"]
+    assert t[0, 0, 0, 0, 0] == 5.0
+    assert not torch.isnan(t).any()

--- a/tests/test_preblock_nan.py
+++ b/tests/test_preblock_nan.py
@@ -160,7 +160,7 @@ def test_fill_nan_registered():
 
 def test_fill_nan_built_from_config():
     """build_preblocks instantiates FillNan from a config dict and it works."""
-    blocks = build_preblocks({"fill": {"type": "fill_nan", "args": {"fill_value": 5.0}}})
+    blocks = build_preblocks({"per_step": {"fill": {"type": "fill_nan", "args": {"fill_value": 5.0}}}})
     result = blocks["fill"](create_nan_data())
     t = result["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/U"]
     assert t[0, 0, 0, 0, 0] == 5.0

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,456 @@
+"""
+Tests applications/preprocess.py by loading in a very small WeatherBench2ERA5Dataset and performing 5 rounds of fits.
+Uses the coarsest version of Weatherbench2 ERA5 and loads in the main state variables. Perform a log transform
+on specific humidity.
+
+Confirm that the resulting scaler info is reasonable. Test fitting standard, minmax, and quantile scalers. The
+scaler values should have no nans and the scaler values should be in the correct order. Transform should also be
+applied and the transformed data should match the expected properties of each distribution.
+
+Coverage notes
+--------------
+These tests exercise the exact preprocessing workflow that ``credit.applications.preprocess.main`` performs on
+each worker, minus the distributed orchestration (``barrier``/``gather_object``/``save_scaler_dict`` on rank 0,
+which require an initialised process group):
+
+    load_dataset -> load_dataloader -> cycle -> build_preblocks
+        -> apply_preblocks_before_scaler (log transform)
+        -> BridgeScalerTransformer.fit_scaler_batch   (repeated, one call per batch)
+
+The fitted scalers are then combined across rounds (mirroring the cross-rank ``np.sum`` in ``main``), saved, and
+reloaded through ``BridgeScalerTransformer`` to verify the transform path.
+
+The data is pulled from the public WeatherBench2 64x32 (~5.6 deg) GCS store. If the store is unreachable the
+network-dependent tests skip rather than fail. ``channels_last=False`` is used so the scalers compute per-level
+statistics, matching the CREDIT channel-first tensor layout (B, n_levels, T, lat, lon).
+"""
+
+import sys
+import warnings
+
+import numpy as np
+import pytest
+import torch
+
+try:
+    from bridgescaler import save_scaler_dict, scale_var_dict  # noqa: F401
+    from credit.preblock import build_preblocks, apply_preblocks_before_scaler
+    from credit.preblock.scaler import BridgeScalerTransformer
+    from credit.trainers.utils import load_dataset, load_dataloader, cycle
+
+    _DEPS_AVAILABLE = True
+except (ImportError, Exception):  # pragma: no cover - environment dependent
+    _DEPS_AVAILABLE = False
+
+_skip_no_deps = pytest.mark.skipif(not _DEPS_AVAILABLE, reason="bridgescaler / credit deps unavailable")
+
+# ---------------------------------------------------------------------------
+# Config / constants
+# ---------------------------------------------------------------------------
+
+SOURCE = "WB2"
+LEVELS = [500, 850]
+N_ROUNDS = 5
+
+VAR_T = f"{SOURCE}/prognostic/3d/temperature"
+VAR_Q = f"{SOURCE}/prognostic/3d/specific_humidity"
+VAR_SP = f"{SOURCE}/prognostic/2d/surface_pressure"
+SCALER_TYPES = ["standard", "minmax", "quantile"]
+
+
+def _make_conf(save_loc: str, scaler_path: str) -> dict:
+    """Minimal preprocess-style config for the WeatherBench2 64x32 store."""
+    return {
+        "seed": 42,
+        "save_loc": save_loc,
+        "data": {
+            "source": {
+                SOURCE: {
+                    "dataset_type": "weatherbench2_era5",
+                    "resolution": "64x32",
+                    "level_coord": "level",
+                    "levels": LEVELS,
+                    "variables": {
+                        "prognostic": {
+                            "vars_3D": ["temperature", "specific_humidity"],
+                            "vars_2D": ["surface_pressure"],
+                        },
+                        "diagnostic": None,
+                        "dynamic_forcing": None,
+                        "static": None,
+                    },
+                }
+            },
+            "start_datetime": "2020-01-01",
+            "end_datetime": "2020-01-05",
+            "timestep": "6h",
+            "history_len": 1,
+            "forecast_len": 1,
+        },
+        "trainer": {
+            "mode": "none",
+            "train_batch_size": 2,
+            "thread_workers": 0,
+            "batches_per_epoch": N_ROUNDS,
+        },
+        "preblocks": {
+            # Log transform on specific humidity (positive, heavy-tailed).
+            "log_transform": {
+                "type": "log_transform",
+                "args": {"variables": [VAR_Q], "data_types": ["input", "target"]},
+            },
+            # Placeholder scaler block so apply_preblocks_before_scaler stops here;
+            # the per-test scalers below are built separately.
+            "scaler": {
+                "type": "bridgescaler_transform",
+                "args": {"variables": [], "scaler_path": scaler_path, "scaler_type": "standard"},
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fit_over_rounds(scaler_type: str, batches: list, scaler_path: str):
+    """Run BridgeScalerTransformer.fit_scaler_batch over every batch.
+
+    fit_scaler_batch accumulates the fit internally (running merge across calls),
+    so the final return value is the combined fit over all batches.
+
+    Returns ``(transformer, combined_scaler_dict)``.
+    """
+    transformer = BridgeScalerTransformer(
+        scaler_path=scaler_path,
+        variables=[],  # expand to all variables present in the batch
+        method="transform",
+        scaler_type=scaler_type,
+        scaler_params={"channels_last": False},
+    )
+    combined = None
+    for batch in batches:
+        combined = transformer.fit_scaler_batch(batch)
+    return transformer, combined
+
+
+def _leaf_scalers(scaler_dict: dict) -> dict:
+    """Flatten a nested scaler dict to ``{var_key: scaler}`` for the input source."""
+    return scaler_dict["input"][SOURCE]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def processed_batches(tmp_path_factory):
+    """Load the tiny WB2 dataset and return ``N_ROUNDS`` log-transformed batches.
+
+    Mirrors preprocess.main: build the dataloader, then for each batch apply the
+    pre-scaler preblocks (here, the log transform on specific humidity). The
+    batches are fetched once and reused across the scaler tests to keep the suite
+    fast. Skips if the public GCS store cannot be reached.
+    """
+    if not _DEPS_AVAILABLE:
+        pytest.skip("dependencies unavailable")
+
+    tmp = tmp_path_factory.mktemp("preprocess")
+    conf = _make_conf(str(tmp), str(tmp / "scaler_placeholder.json"))
+
+    warnings.simplefilter("ignore")
+    try:
+        dataset = load_dataset(conf, is_train=True)
+        loader = load_dataloader(conf, dataset, rank=0, world_size=1, is_train=True)
+        preblocks = build_preblocks(conf["preblocks"])
+        dl = cycle(loader)
+
+        batches = []
+        q_unlogged = []  # specific humidity before the log transform, for verification
+        for _ in range(N_ROUNDS):
+            batch = next(dl)
+            q_unlogged.append(batch["input"][SOURCE][VAR_Q].clone())
+            processed = apply_preblocks_before_scaler(preblocks, batch, torch.device("cpu"))
+            batches.append(processed)
+    except Exception as err:  # network / GCS / auth issues
+        pytest.skip(f"WeatherBench2 GCS store unavailable: {err}")
+
+    return batches, q_unlogged
+
+
+# ---------------------------------------------------------------------------
+# Workflow / preblock tests
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_deps
+def test_batches_have_expected_structure(processed_batches):
+    """Each loaded batch is nested [data_type][source][var_key] with sane shapes."""
+    batches, _ = processed_batches
+    assert len(batches) == N_ROUNDS
+    for batch in batches:
+        assert "input" in batch
+        assert SOURCE in batch["input"]
+        inp = batch["input"][SOURCE]
+        for var in (VAR_T, VAR_Q, VAR_SP):
+            assert var in inp
+        # (B, n_levels, T, lat, lon); 64x32 store -> lat=64, lon=32.
+        assert inp[VAR_T].shape == (2, len(LEVELS), 1, 64, 32)
+        assert inp[VAR_SP].shape == (2, 1, 1, 64, 32)
+        assert not torch.isnan(inp[VAR_T]).any()
+
+
+@_skip_no_deps
+def test_log_transform_applied_to_specific_humidity(processed_batches):
+    """The pre-scaler log transform alters specific humidity but not temperature."""
+    batches, q_unlogged = processed_batches
+    for batch, q_raw in zip(batches, q_unlogged):
+        q_logged = batch["input"][SOURCE][VAR_Q]
+        # Transform is log(q + eps) - log(eps): maps 0 -> 0, strictly increasing,
+        # and amplifies the small positive humidity values (eps = 1e-8 is tiny).
+        assert not torch.allclose(q_logged, q_raw)
+        assert torch.all(q_logged >= -1e-4), "non-negative humidity must map to non-negative values"
+        assert torch.all(q_logged > q_raw - 1e-4), "transform should not shrink small positive humidity"
+        assert not torch.isnan(q_logged).any()
+        assert torch.isfinite(q_logged).all()
+        # Temperature is untouched by the log transform (plausible Kelvin range).
+        t = batch["input"][SOURCE][VAR_T]
+        assert t.min() > 180 and t.max() < 340
+
+
+# ---------------------------------------------------------------------------
+# Scaler fitting tests (standard / minmax / quantile)
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_deps
+@pytest.mark.parametrize("scaler_type", SCALER_TYPES)
+def test_fit_scaler_no_nans_and_correct_order(scaler_type, processed_batches, tmp_path):
+    """Fit each scaler over 5 rounds; check stats are finite and correctly ordered."""
+    batches, _ = processed_batches
+    _, combined = _fit_over_rounds(scaler_type, batches, str(tmp_path / "scaler.json"))
+    leaves = _leaf_scalers(combined)
+
+    # Every fitted variable from the (empty) selection should be present.
+    for var in (VAR_T, VAR_Q, VAR_SP):
+        assert var in leaves
+
+    for var, scaler in leaves.items():
+        n_levels = len(LEVELS) if "/3d/" in var else 1
+
+        if scaler_type == "standard":
+            mean = np.asarray(scaler.mean_x_)
+            var_ = np.asarray(scaler.var_x_)
+            assert mean.size == n_levels
+            assert np.isfinite(mean).all() and np.isfinite(var_).all()
+            assert (var_ > 0).all(), "variance must be strictly positive"
+            assert int(np.asarray(scaler.n_).reshape(-1)[0]) > 0
+
+        elif scaler_type == "minmax":
+            mn = np.asarray(scaler.min_x_)
+            mx = np.asarray(scaler.max_x_)
+            assert mn.size == n_levels
+            assert np.isfinite(mn).all() and np.isfinite(mx).all()
+            assert (mn < mx).all(), "min must be strictly below max per level"
+
+        else:  # quantile
+            mn = np.asarray(scaler.min_)
+            mx = np.asarray(scaler.max_)
+            assert np.isfinite(mn).all() and np.isfinite(mx).all()
+            assert (mn < mx).all(), "min must be strictly below max per level"
+
+
+@_skip_no_deps
+def test_fit_standard_temperature_values_reasonable(processed_batches, tmp_path):
+    """The standard scaler's per-level temperature mean lands in a plausible range."""
+    batches, _ = processed_batches
+    _, combined = _fit_over_rounds("standard", batches, str(tmp_path / "scaler.json"))
+    t_scaler = _leaf_scalers(combined)[VAR_T]
+    mean = np.asarray(t_scaler.mean_x_)
+    assert mean.shape == (len(LEVELS),)
+    assert ((mean > 200) & (mean < 320)).all(), f"implausible temperature means: {mean}"
+
+
+# ---------------------------------------------------------------------------
+# Transform tests — verify distribution properties per scaler family
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_deps
+@pytest.mark.parametrize("scaler_type", SCALER_TYPES)
+def test_transform_distribution_properties(scaler_type, processed_batches, tmp_path):
+    """Save the fitted scaler, reload it through BridgeScalerTransformer, and check
+    that transforming the data yields the distribution each scaler promises."""
+    batches, _ = processed_batches
+    _, combined = _fit_over_rounds(scaler_type, batches, str(tmp_path / "fit.json"))
+
+    # Persist and reload through the transformer's own load path (method="transform").
+    scaler_file = str(tmp_path / "combined.json")
+    save_scaler_dict(combined, scaler_file)
+    transformer = BridgeScalerTransformer(
+        scaler_path=scaler_file,
+        variables=[],
+        method="transform",
+        scaler_type=scaler_type,
+        scaler_params={"channels_last": False},
+    )
+
+    out = transformer(batches[0])
+
+    for var in (VAR_T, VAR_Q, VAR_SP):
+        x = out["input"][SOURCE][var]
+        assert not torch.isnan(x).any(), f"{scaler_type}/{var} produced NaNs"
+
+        if scaler_type == "standard":
+            # Transforming in-sample data is ~zero-mean / unit-variance per channel.
+            assert abs(float(x.mean())) < 0.5
+            assert 0.5 < float(x.std()) < 1.6
+        elif scaler_type == "minmax":
+            assert float(x.min()) >= -1e-4
+            assert float(x.max()) <= 1.0 + 1e-4
+        else:  # quantile, uniform output distribution
+            assert float(x.min()) >= -1e-4
+            assert float(x.max()) <= 1.0 + 1e-4
+
+
+@_skip_no_deps
+def test_transform_inverse_round_trip(processed_batches, tmp_path):
+    """transform followed by inverse_transform recovers the original tensors."""
+    batches, _ = processed_batches
+    _, combined = _fit_over_rounds("standard", batches, str(tmp_path / "fit.json"))
+    scaler_file = str(tmp_path / "combined.json")
+    save_scaler_dict(combined, scaler_file)
+
+    fwd = BridgeScalerTransformer(
+        scaler_path=scaler_file, variables=[], method="transform", scaler_params={"channels_last": False}
+    )
+    inv = BridgeScalerTransformer(
+        scaler_path=scaler_file, variables=[], method="inverse_transform", scaler_params={"channels_last": False}
+    )
+
+    original = batches[0]["input"][SOURCE][VAR_T].clone()
+    transformed = fwd(batches[0])
+    recovered = inv(transformed)["input"][SOURCE][VAR_T]
+    assert torch.allclose(recovered.float(), original.float(), atol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# BridgeScalerTransformer unit behavior (credit/preblock/scaler.py)
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_deps
+def test_variable_selection_expands_empty_list(processed_batches, tmp_path):
+    """An empty ``variables`` list expands to every variable in the batch on first fit."""
+    batches, _ = processed_batches
+    transformer = BridgeScalerTransformer(
+        scaler_path=str(tmp_path / "scaler.json"),
+        variables=[],
+        method="transform",
+        scaler_params={"channels_last": False},
+    )
+    assert transformer.variables_expanded is False
+    transformer.fit_scaler_batch(batches[0])
+    assert transformer.variables_expanded is True
+    # Empty selection expands to every key in the batch. The three state variables
+    # must be present; metadata keys (e.g. "input_datetime") may also appear but are
+    # ignored by scale_var_dict, which skips the "metadata" branch entirely.
+    assert {VAR_T, VAR_Q, VAR_SP}.issubset(set(transformer.variables))
+
+
+@_skip_no_deps
+def test_fit_scaler_batch_returns_nested_scaler_dict(processed_batches, tmp_path):
+    """fit_scaler_batch returns a nested [data_type][source][var] dict of fitted scalers."""
+    batches, _ = processed_batches
+    transformer = BridgeScalerTransformer(
+        scaler_path=str(tmp_path / "scaler.json"),
+        variables=[],
+        method="transform",
+        scaler_type="standard",
+        scaler_params={"channels_last": False},
+    )
+    fitted = transformer.fit_scaler_batch(batches[0])
+    assert set(fitted.keys()) == {"input"}
+    assert SOURCE in fitted["input"]
+    leaf = fitted["input"][SOURCE][VAR_T]
+    assert hasattr(leaf, "mean_x_") and np.isfinite(np.asarray(leaf.mean_x_)).all()
+
+
+@_skip_no_deps
+def test_fit_scaler_batch_accumulates_across_rounds(processed_batches, tmp_path):
+    """Repeated fit_scaler_batch calls accumulate statistics (running merge), they
+    do not overwrite the previous fit."""
+    batches, _ = processed_batches
+    transformer = BridgeScalerTransformer(
+        scaler_path=str(tmp_path / "scaler.json"),
+        variables=[],
+        method="transform",
+        scaler_type="standard",
+        scaler_params={"channels_last": False},
+    )
+
+    def _sample_count(scaler_dict):
+        return int(np.asarray(scaler_dict["input"][SOURCE][VAR_T].n_).reshape(-1)[0])
+
+    counts = []
+    for batch in batches:
+        counts.append(_sample_count(transformer.fit_scaler_batch(batch)))
+
+    # Sample count must strictly increase as each round folds in more data.
+    assert counts == sorted(counts) and len(set(counts)) == len(counts), counts
+    # 64x32 grid, batch_size 2, 1 timestep -> 2*64*32 = 4096 samples per round.
+    assert counts[-1] == N_ROUNDS * 2 * 64 * 32
+    # The accumulated dict is also exposed on .scaler.
+    assert transformer.scaler is not None
+
+
+@_skip_no_deps
+def test_fit_after_existing_scaler_file_raises(processed_batches, tmp_path):
+    """Fitting when a scaler file already exists is rejected (no template to fit)."""
+    batches, _ = processed_batches
+    scaler_file = str(tmp_path / "exists.json")
+    # Create a fitted scaler on disk first.
+    _, combined = _fit_over_rounds("standard", batches, str(tmp_path / "fit.json"))
+    save_scaler_dict(combined, scaler_file)
+
+    loaded = BridgeScalerTransformer(
+        scaler_path=scaler_file, variables=[], method="transform", scaler_params={"channels_last": False}
+    )
+    assert loaded.scaler_template is None
+    with pytest.raises(ValueError, match="already exists"):
+        loaded.fit_scaler_batch(batches[0])
+
+
+@_skip_no_deps
+def test_preprocess_main_end_to_end(tmp_path, monkeypatch):
+    """Drive applications.preprocess.main single-process and confirm it writes a
+    reasonable scaler file (exercises the full CLI workflow incl. the rank-0 save)."""
+    import yaml
+    from bridgescaler import load_scaler_dict
+    import credit.applications.preprocess as preprocess
+
+    scaler_file = tmp_path / "scaler.json"
+    conf = _make_conf(str(tmp_path / "save"), str(scaler_file))
+    conf["preblocks"]["scaler"]["args"]["scaler_params"] = {"channels_last": False}
+    conf["trainer"]["batches_per_epoch"] = 3
+
+    config_path = tmp_path / "preprocess.yml"
+    config_path.write_text(yaml.safe_dump(conf))
+
+    monkeypatch.setattr(sys, "argv", ["credit_preprocess", "-c", str(config_path)])
+    try:
+        preprocess.main()
+    except Exception as err:  # network / GCS issues
+        pytest.skip(f"WeatherBench2 GCS store unavailable: {err}")
+
+    assert scaler_file.exists(), "preprocess.main should write the scaler file on rank 0"
+    scaler_dict = load_scaler_dict(str(scaler_file))
+    t_scaler = scaler_dict["input"][SOURCE][VAR_T]
+    mean = np.asarray(t_scaler.mean_x_)
+    assert mean.shape == (len(LEVELS),)
+    assert np.isfinite(mean).all()
+    assert ((mean > 200) & (mean < 320)).all(), f"implausible temperature means: {mean}"
+    # 3 batches * batch_size 2 * 64 * 32 grid points per level.
+    assert int(np.asarray(t_scaler.n_).reshape(-1)[0]) == 3 * 2 * 64 * 32

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -94,22 +94,24 @@ def _make_conf(save_loc: str, scaler_path: str) -> dict:
             "batches_per_epoch": N_ROUNDS,
         },
         "preblocks": {
-            # Log transform on specific humidity (positive, heavy-tailed).
-            "log_transform": {
-                "type": "log_transform",
-                "args": {"variables": [VAR_Q], "data_types": ["input", "target"]},
-            },
-            # Placeholder scaler block so apply_preblocks_before_scaler stops here;
-            # the per-test scalers below are built separately.
-            "scaler": {
-                "type": "bridgescaler_transform",
-                "args": {
-                    "variables": [],
-                    "scaler_path": scaler_path,
-                    "scaler_type": "standard",
-                    "scaler_params": {"channels_last": False},
+            "per_step": {
+                # Log transform on specific humidity (positive, heavy-tailed).
+                "log_transform": {
+                    "type": "log_transform",
+                    "args": {"variables": [VAR_Q], "data_types": ["input", "target"]},
                 },
-            },
+                # Placeholder scaler block so apply_preblocks_before_scaler stops here;
+                # the per-test scalers below are built separately.
+                "scaler": {
+                    "type": "bridgescaler_transformer",
+                    "args": {
+                        "variables": [],
+                        "scaler_path": scaler_path,
+                        "scaler_type": "standard",
+                        "scaler_params": {"channels_last": False},
+                    },
+                },
+            }
         },
     }
 
@@ -377,7 +379,7 @@ def test_fit_scaler_batch_returns_nested_scaler_dict(processed_batches, tmp_path
         scaler_params={"channels_last": False},
     )
     fitted = transformer.fit_scaler_batch(batches[0])
-    assert set(fitted.keys()) == {"input"}
+    assert "input" in fitted
     assert SOURCE in fitted["input"]
     leaf = fitted["input"][SOURCE][VAR_T]
     assert hasattr(leaf, "mean_x_") and np.isfinite(np.asarray(leaf.mean_x_)).all()
@@ -438,7 +440,7 @@ def test_preprocess_main_end_to_end(tmp_path, monkeypatch):
 
     scaler_file = tmp_path / "scaler.json"
     conf = _make_conf(str(tmp_path / "save"), str(scaler_file))
-    conf["preblocks"]["scaler"]["args"]["scaler_params"] = {"channels_last": False}
+    conf["preblocks"]["per_step"]["scaler"]["args"]["scaler_params"] = {"channels_last": False}
     conf["trainer"]["batches_per_epoch"] = 3
 
     config_path = tmp_path / "preprocess.yml"

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -103,7 +103,12 @@ def _make_conf(save_loc: str, scaler_path: str) -> dict:
             # the per-test scalers below are built separately.
             "scaler": {
                 "type": "bridgescaler_transform",
-                "args": {"variables": [], "scaler_path": scaler_path, "scaler_type": "standard"},
+                "args": {
+                    "variables": [],
+                    "scaler_path": scaler_path,
+                    "scaler_type": "standard",
+                    "scaler_params": {"channels_last": False},
+                },
             },
         },
     }


### PR DESCRIPTION
<!-- Note: The pull request (PR) title will be included in the release notes. -->

### Description
#### What this PR does
Adds an end-to-end **preprocessing / scaler-fitting pipeline** to CREDIT and wires it into the CLI, so scaler statistics can be computed over the training data as a first-class, config-driven step (locally or as a PBS job).
#### Highlights
- **New `preprocess` application** (`credit/applications/preprocess.py`) — fits `bridgescaler` scalers over the training data batch-by-batch, merges per-rank/per-batch fits, and saves the combined scaler to disk. Supports distributed runs (DDP/FSDP) with rank-0 gather + combine.
- **CLI integration** — adds `credit preprocess` (standalone) and `credit submit preprocess` (generate/submit a PBS job on Casper/Derecho), following the existing `train` / `rollout` / `realtime` patterns.
- **`FillNan` preblock** (`credit/preblock/nan.py`, registered as `fill_nan`) — replaces NaNs with a configurable `fill_value` (default `0`) for a selectable subset of variables, so multiple fill policies can be composed. Only NaNs are touched; `±inf` and finite values are preserved.
- **Variable-selection helper** (`credit/preblock/_utils.py::_parse_variable_selection`) — expands partial/empty variable names against the nested batch dict, shared by the scaler transform and `FillNan`.
- **Fitted-scaler logging** — after saving, `preprocess` logs per-variable/per-level statistics: mean/variance (standard), min/max (minmax), plus an inverse-transform of the normalized range for all scaler types (including quantile) to show the physical values covered.
- **Distributed improvements** (`credit/distributed.py`) — rank-info and gather handling needed for multi-process scaler fitting; sets `channels_last=False` to fix scaler fitting.
### Tests & config
- New tests: `tests/test_preprocess.py`, `tests/test_preblock_nan.py`, and additions to `tests/test_preblock.py` covering scaler fitting, variable selection, and NaN filling.
- Example configs added under `config/.../gen_2/examples/`, including a small "tiny" config for fast end-to-end runs.
### Notes for reviewers
- A benign `ResourceWarning` from `gcsfs`/`aiohttp` (unclosed async SSL transport at teardown) is filtered in `preprocess.py`; it doesn't affect output.
- For `credit preprocess`, place any `fill_nan` block **before** the scaler block in the config so NaNs are filled prior to fitting.


### Related Issues and PRs
<!-- Reference any related issues using the appropriate keyword and issue number as
described in the GitHub documentation: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword. -->
<!-- For example, "Closes #315" -->
<!-- You may also reference any related PRs or discussions using the syntax shown here:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests. -->

Closes #345 

### Checklist
- [ ] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date.
