### PR TITLE
fix: four CLI bugs found during systematic testing

### DIFF
--- a/credit/cli/_convert.py
+++ b/credit/cli/_convert.py
@@ -526,6 +526,9 @@ def _init(args: argparse.Namespace) -> None:
         print(f"File already exists: {output}  (use --force to overwrite)", file=sys.stderr)
         sys.exit(1)
 
+    parent = os.path.dirname(output)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
     shutil.copy(template, output)
     print(f"Created  : {output}")
     print(f"Template : {template_rel}")

--- a/credit/cli/_plot.py
+++ b/credit/cli/_plot.py
@@ -44,7 +44,16 @@ def _build_denorm_stats(conf):
     prog = v.get("prognostic") or {}
     diag = v.get("diagnostic") or {}
 
-    norm_args = conf.get("preblocks", {}).get("norm", {}).get("args", {})
+    # Support both v1 (preblocks.norm.args) and v2 (preblocks.per_step.norm.args) schemas
+    preblocks_cfg = conf.get("preblocks", {})
+    norm_args = (
+        preblocks_cfg.get("per_step", {}).get("norm", {}).get("args") or preblocks_cfg.get("norm", {}).get("args") or {}
+    )
+    if not norm_args.get("mean_path") or not norm_args.get("std_path"):
+        raise KeyError(
+            "preblocks norm mean_path/std_path not found in config. "
+            "Set preblocks.per_step.norm.args.mean_path and std_path, or omit --denorm."
+        )
     mean_ds = xr.open_dataset(norm_args["mean_path"]).load()
     std_ds = xr.open_dataset(norm_args["std_path"]).load()
 
@@ -131,7 +140,14 @@ def _plot(args) -> None:
     from credit.datasets.multi_source import MultiSourceDataset
     from credit.preblock import apply_preblocks, build_preblocks
 
-    data_conf = conf.get("data_valid", conf["data"])
+    # Build the effective validation data config: start from training data, then overlay
+    # validation_data overrides (date range, etc.) if present.  This mirrors how the
+    # trainer constructs its validation dataloader.
+    import copy
+
+    data_conf = copy.deepcopy(conf["data"])
+    val_override = conf.get("validation_data") or conf.get("data_valid") or {}
+    data_conf.update(val_override)
     dataset = MultiSourceDataset(data_conf, return_target=True)
 
     if args.sample_date is not None:
@@ -151,9 +167,12 @@ def _plot(args) -> None:
     batch = default_collate([sample])
     preblocks = build_preblocks(conf.get("preblocks", {}))
     _batch = apply_preblocks(preblocks, batch, device=device)
-    x = _batch["input"]
-    if "target" in _batch:
-        y = _batch["target"]
+    # apply_preblocks renames 'input' → 'x' and 'target' → 'y'
+    x = _batch.get("x", _batch.get("input"))
+    if x is None:
+        print("ERROR: preblocks did not produce an 'x' or 'input' key in batch.", file=sys.stderr)
+        sys.exit(1)
+    y = _batch.get("y", _batch.get("target"))
     if "meta" in _batch:
         meta = _batch["meta"]
     with torch.no_grad():

--- a/credit/cli/_submit.py
+++ b/credit/cli/_submit.py
@@ -526,6 +526,10 @@ def _build_rollout_pbs_script(
             #PBS -k eod
             {output_line}
 
+            module load conda/latest
+
+            conda activate {args.conda_env}
+
             REPO={repo}
             CONFIG={config}
             NGPUS={args.gpus}


### PR DESCRIPTION
## Summary

Systematic testing of the `credit` CLI surface turned up four bugs, all in `credit/cli/`. Each was found by running the command, observing the failure, and tracing it to the root cause.

- **`credit init`** — crashes with `FileNotFoundError` when the output path's parent directory does not exist. Fixed by calling `os.makedirs(parent, exist_ok=True)` before `shutil.copy`.

- **`credit submit --mode rollout --cluster casper`** — generated PBS scripts were missing `module load conda/latest` and `conda activate`. Every other Casper script (train, realtime) included these lines; the rollout generator did not. Jobs would fail immediately on submission.

- **`credit plot`** — crashed with `KeyError: 'input'` because `apply_preblocks()` renames the batch keys from `'input'`/`'target'` to `'x'`/`'y'`. Fixed with `.get("x", .get("input"))` fallback and a clear error message if neither key is present.

- **`credit plot`** — two related issues: (1) used `conf.get("data_valid", ...)` to find the validation dataset config, but all v2 configs use the key `validation_data`, so the fallback to training data always triggered and plots sampled the wrong date range; (2) `_build_denorm_stats` looked for norm stats at `preblocks.norm.args` (v1 schema) instead of `preblocks.per_step.norm.args` (v2 schema), causing `KeyError: 'mean_path'` whenever `--denorm` was passed with a v2 config. Both fixed together.

## Test plan

- [ ] `credit init -o /tmp/newdir/config.yml` — should create the directory and write the file
- [ ] `credit submit --cluster casper --mode rollout -c config.yml --dry-run` — PBS script should contain `module load conda/latest` and `conda activate`
- [ ] `credit plot -c config.yml --field t2m` — should produce a PNG without crashing
- [ ] `credit plot -c config.yml --field t2m --denorm` — should produce a denormalised PNG when norm stats are configured