### PR TITLE
Fix device management in preprocessing pipeline

### DIFF
--- a/config/gen_2/examples/weatherbench2_era5_wxformer_tiny.yml
+++ b/config/gen_2/examples/weatherbench2_era5_wxformer_tiny.yml
@@ -1,5 +1,4 @@
-save_loc: '/Users/dgagne/data/weatherbench2'
-#save_loc: '/glade/derecho/scratch/$USER/CREDIT/weatherbench2'
+save_loc: '/glade/derecho/scratch/$USER/CREDIT/weatherbench2'
 seed: 31415
 
 data:
@@ -49,7 +48,7 @@ preblocks:
       type: "bridgescaler_transformer"
       args:
         variables: []
-        scaler_path: "/Users/dgagne/data/weatherbench2/scaler.json"
+        scaler_path: "/glade/derecho/scratch/$USER/CREDIT/weatherbench2/scaler.json"
         scaler_type: "quantile"
         scaler_params:
           channels_last: False
@@ -58,20 +57,34 @@ preblocks:
     vars_concat:
       type: "concat"
 
-postblocks:
-  reconstruct:
-    type: "reconstruct"
-
 trainer:
-  type: era5-gen2           # use the v2 trainer (new nested data schema)
-
   mode: none
-  epochs: 1
   train_batch_size: 2
-  batches_per_epoch: 3
+  batches_per_epoch: 3  # 0 means use all data
   thread_workers: 4
-  valid_thread_workers: 2
   prefetch_factor: 2
+
+pbs:
+  # Casper
+  conda: "credit-casper"
+  project: "NAML0001"
+  job_name: "credit_preprocess"
+  walltime: "04:00:00"
+  ngpus: 1
+  ncpus: 8
+  mem: "128GB"
+  queue: "casper"
+  gpu_type: "a100_80gb"
+
+  # Derecho (uncomment and comment out Casper block above to use)
+  # conda: "credit-derecho"
+  # project: "NAML0001"
+  # job_name: "credit_preprocess"
+  # walltime: "04:00:00"
+  # ngpus: 4
+  # ncpus: 64
+  # mem: "480GB"
+  # queue: "main"
 
 
 

--- a/config/gen_2/smoke/integration_test_hrrr.yml
+++ b/config/gen_2/smoke/integration_test_hrrr.yml
@@ -101,6 +101,16 @@ preblocks:
               - 'input'
               - 'target'
 
+    scaler:
+      # please run `credit preprocess` before `credit train`
+      type: "bridgescaler_transformer"
+      args:
+        variables: []
+        scaler_path: "/glade/derecho/scratch/$USER/CREDIT_runs/gen2_integration_test_hrrr/scaler_quantile.json"
+        scaler_type: "standard"
+        scaler_params:
+          channels_last: False
+
     vars_concat:
       type: "concat"
 

--- a/config/gen_2/smoke/integration_test_hrrr.yml
+++ b/config/gen_2/smoke/integration_test_hrrr.yml
@@ -82,31 +82,32 @@ validation_data:
 # ---- USER SETTINGS: preblocks/postblocks before/after passed to model ---- #
 
 preblocks:
-
-  pressure_log_transform:
-    type: "log_transform"
-    args:
-      variables:
-        - 'Example_HRRR/prognostic/2d/sp'
-      data_types:
-        - 'input'
-        - 'target'
-
-  q_sqrt_transform:
-      type: "sqrt_transform"
+  per_step:
+    pressure_log_transform:
+      type: "log_transform"
       args:
-          variables:
-                - 'Example_HRRR/prognostic/3d/Q'
-          data_types:
-            - 'input'
-            - 'target'
+        variables:
+          - 'Example_HRRR/prognostic/2d/sp'
+        data_types:
+          - 'input'
+          - 'target'
 
-  vars_concat:
-    type: "concat"
+    q_sqrt_transform:
+        type: "sqrt_transform"
+        args:
+            variables:
+                  - 'Example_HRRR/prognostic/3d/Q'
+            data_types:
+              - 'input'
+              - 'target'
+
+    vars_concat:
+      type: "concat"
 
 postblocks:
-  reconstruct:
-    type: "reconstruct"
+  per_step:
+    reconstruct:
+      type: "reconstruct"
 
 # ---- USER SETTINGS: training hyperparameters ---- #
 trainer:

--- a/credit/applications/preprocess.py
+++ b/credit/applications/preprocess.py
@@ -109,6 +109,13 @@ def main():
     parser = argparse.ArgumentParser(
         epilog="""
 Examples:
+  # Recommended: submit via PBS using the credit CLI.
+  # Note: torchrun is hardcoded internally; --device and --backend cannot be forwarded.
+  # Device selection is automatic based on hardware detected at runtime (GPU if available, CPU otherwise).
+  credit submit --cluster casper  -c config.yml --mode preprocess
+  credit submit --cluster derecho -c config.yml --mode preprocess
+
+  # For reference only (not the recommended path): run directly with torchrun.
   # GPU run (auto-selects nccl backend)
   torchrun --nproc_per_node=4 preprocess.py -c config.yml
 

--- a/credit/applications/preprocess.py
+++ b/credit/applications/preprocess.py
@@ -13,7 +13,7 @@ import yaml
 import sys
 import shutil
 from credit.preblock import build_preblocks, apply_preblocks_before_scaler, BridgeScalerTransformer
-from credit.preblock.scaler import combine_scaler_dicts
+from credit.preblock.scaler import combine_scaler_dicts, move_scaler_dict_to_cpu
 from credit.trainers.utils import cycle, load_dataset, load_dataloader
 import torch.distributed as dist
 from torch.distributed import gather_object, barrier
@@ -106,19 +106,37 @@ def main():
     # teardown (after the scalers have already been fitted and saved). Silence it.
     warnings.filterwarnings("ignore", category=ResourceWarning)
     warnings.filterwarnings("ignore", category=UserWarning, module="bridgescaler")
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        epilog="""
+Examples:
+  # GPU run (auto-selects nccl backend)
+  torchrun --nproc_per_node=4 preprocess.py -c config.yml
+
+  # CPU-only run (auto-selects gloo backend)
+  torchrun --nproc_per_node=4 preprocess.py -c config.yml --device cpu
+
+  # Force a specific device and backend
+  torchrun --nproc_per_node=4 preprocess.py -c config.yml --device cuda:0 --backend nccl
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("-c", "--config", dest="model_config", required=True, type=str, help="Path to config file")
     parser.add_argument(
         "-b",
         "--backend",
         type=str,
-        default="nccl",
+        default=None,
         choices=["nccl", "gloo", "mpi"],
-        help="Backend for distributed training.",
+        help="Backend for distributed training. Defaults to 'nccl' for GPU, 'gloo' for CPU.",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Device to use (e.g. 'cpu', 'cuda', 'cuda:0'). Defaults to GPU if available.",
     )
     args = parser.parse_args()
     config = args.model_config
-    backend = args.backend
     root = logging.getLogger()
     root.setLevel(logging.DEBUG)
     formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
@@ -137,15 +155,19 @@ def main():
     if not os.path.exists(os.path.join(save_loc, "model.yml")):
         shutil.copy(config, os.path.join(save_loc, "model.yml"))
 
-    if conf["trainer"]["mode"] in ["fsdp", "ddp", "domain_parallel", "fsdp+domain_parallel"]:
-        setup(rank, world_size, conf["trainer"]["mode"], backend)
-
-    if torch.cuda.is_available():
+    if args.device is not None:
+        device = torch.device(args.device)
+    elif torch.cuda.is_available():
         device = torch.device(f"cuda:{local_rank % torch.cuda.device_count()}")
-        torch.cuda.set_device(local_rank % torch.cuda.device_count())
-        torch.backends.cudnn.benchmark = True
     else:
         device = torch.device("cpu")
+    if device.type == "cuda":
+        torch.cuda.set_device(device)
+        torch.backends.cudnn.benchmark = True
+
+    backend = args.backend or ("nccl" if device.type == "cuda" else "gloo")
+    if conf["trainer"]["mode"] in ["fsdp", "ddp", "domain_parallel", "fsdp+domain_parallel"]:
+        setup(rank, world_size, conf["trainer"]["mode"], backend)
 
     trainer_conf = conf["trainer"]
     train_dataset = load_dataset(conf, is_train=True)
@@ -181,7 +203,7 @@ def main():
     if dist.is_initialized() and world_size > 1:
         barrier()
         all_scalers = [None] * world_size if rank == 0 else None
-        gather_object(scaler_block.scaler, all_scalers, dst=0)
+        gather_object(move_scaler_dict_to_cpu(scaler_block.scaler), all_scalers, dst=0)
     else:
         all_scalers = [scaler_block.scaler]
 

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -117,6 +117,15 @@ def _run_preblock_group(group: nn.ModuleDict, batch: dict, device=None):
     return out
 
 
+def _move_batch_to_device(batch, device):
+    """Recursively move all tensors in a nested dict to device."""
+    if isinstance(batch, dict):
+        return {k: _move_batch_to_device(v, device) for k, v in batch.items()}
+    if torch.is_tensor(batch):
+        return batch.to(device)
+    return batch
+
+
 def apply_preblocks_before_scaler(preblocks: nn.ModuleDict, batch: dict, device=None):
     for preblock in preblocks.values():
         if isinstance(preblock, BridgeScalerTransformer):
@@ -129,6 +138,8 @@ def apply_preblocks_before_scaler(preblocks: nn.ModuleDict, batch: dict, device=
                 batch, meta = result
         else:
             batch = result
+    if device is not None:
+        batch = _move_batch_to_device(batch, device)
     return batch
 
 

--- a/credit/preblock/scaler.py
+++ b/credit/preblock/scaler.py
@@ -1,3 +1,4 @@
+import torch
 from bridgescaler import load_scaler_dict, scale_var_dict
 from bridgescaler.distributed_tensor import DStandardScalerTensor, DQuantileScalerTensor, DMinMaxScalerTensor
 from credit.preblock.base import BasePreblock
@@ -10,6 +11,30 @@ _SCALER_REGISTRY = {
     "quantile": DQuantileScalerTensor,
     "minmax": DMinMaxScalerTensor,
 }
+
+
+def _move_leaf_scaler_to_cpu(scaler):
+    """Move all tensor attributes of a single fitted scaler object to CPU in-place."""
+    for attr, val in vars(scaler).items():
+        if torch.is_tensor(val):
+            setattr(scaler, attr, val.cpu())
+        elif isinstance(val, dict):
+            for k, v in val.items():
+                if torch.is_tensor(v):
+                    val[k] = v.cpu()
+    return scaler
+
+
+def move_scaler_dict_to_cpu(scaler_dict):
+    """Recursively move all tensor statistics in a nested scaler dict to CPU.
+
+    Required before ``gather_object`` in multi-GPU runs: each rank's scaler
+    holds tensors on its own device, and combining scalers from different
+    devices raises a device-mismatch error.
+    """
+    if isinstance(scaler_dict, dict):
+        return {k: move_scaler_dict_to_cpu(v) for k, v in scaler_dict.items()}
+    return _move_leaf_scaler_to_cpu(scaler_dict)
 
 
 def _combine_scaler_dicts(a, b):
@@ -79,11 +104,11 @@ class BridgeScalerTransformer(BasePreblock):
         # ``scaler`` holds the nested dict of fitted scalers used for transform /
         # inverse_transform (loaded from disk, or accumulated by fit_scaler_batch).
         # ``scaler_template`` is the single unfitted prototype used to fit new data.
-        if exists(expandvars(self.scaler_path)):
-            self.scaler = load_scaler_dict(scaler_path)
+        if exists(self.scaler_path):
+            self.scaler = load_scaler_dict(self.scaler_path)
             self.scaler_template = None
         else:
-            full_scaler_path = expandvars(self.scaler_path)
+            full_scaler_path = self.scaler_path
             makedirs(full_scaler_path.rsplit("/", 1)[0], exist_ok=True)
             self.scaler = None
             self.scaler_template = _SCALER_REGISTRY[scaler_type](**scaler_params)


### PR DESCRIPTION
<!-- Note: The pull request (PR) title will be included in the release notes. -->

### Description

- Fix `apply_preblocks_before_scaler` to actually move batch tensors to the target device — previously the `device` argument was accepted but never applied, so batches always stayed on their original device regardless of what was passed in.
- Add `--device` CLI arg to `preprocess.py` for explicit device selection and change `--backend` default to `None`, auto-selecting `nccl` for GPU and `gloo` for CPU. This gives users the flexibility to run on CPU even when a GPU is available — for example, when preprocessing is I/O-bound rather than compute-bound, keeping the computation on CPU is sufficient.
- Add `move_scaler_dict_to_cpu` to move scaler tensor statistics to CPU before `gather_object`. When using multi-GPU runs, each rank holds scaler tensors on its own device, which causes a device-mismatch error during gathering. Moving all tensors to CPU first resolves this.
- Fix `BridgeScalerTransformer.__init__` to use `self.scaler_path` directly instead of wrapping it in `expandvars()`.


### Related Issues and PRs
Address comments in #411.

### Checklist
- [x] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date.
