### PR TITLE
Small bug fixes

### DIFF
--- a/config/gen_2/examples/weatherbench2_era5_wxformer.yml
+++ b/config/gen_2/examples/weatherbench2_era5_wxformer.yml
@@ -44,7 +44,7 @@ preblocks:
           - 'input'
           - 'target'
     scaler:
-      type: "bridgescaler_transformer"
+      type: "bridgescaler_transform"
       args:
         variables: []
         scaler_path: "/glade/derecho/scratch/$USER/CREDIT/weatherbench2/scaler_quantile.json"

--- a/config/gen_2/examples/weatherbench2_era5_wxformer_tiny.yml
+++ b/config/gen_2/examples/weatherbench2_era5_wxformer_tiny.yml
@@ -48,7 +48,7 @@ preblocks:
           - 'input'
           - 'target'
     scaler:
-      type: "bridgescaler_transformer"
+      type: "bridgescaler_transform"
       args:
         variables: []
         scaler_path: "/glade/derecho/scratch/$USER/CREDIT/weatherbench2/scaler.json"

--- a/config/gen_2/smoke/integration_test_hrrr.yml
+++ b/config/gen_2/smoke/integration_test_hrrr.yml
@@ -103,7 +103,7 @@ preblocks:
 
     scaler:
       # please run `credit preprocess` before `credit train`
-      type: "bridgescaler_transformer"
+      type: "bridgescaler_transform"
       args:
         variables: []
         scaler_path: "/glade/derecho/scratch/$USER/CREDIT_runs/gen2_integration_test_hrrr/scaler_quantile.json"

--- a/credit/datasets/local.py
+++ b/credit/datasets/local.py
@@ -185,7 +185,7 @@ class LocalDataset(BaseDataset):
                         self.levels = ds_t[self.level_coord].values.tolist()
                         self.static_metadata["levels"] = self.levels
                 else:
-                    arr = ds_t[vname].sel({self.level_coord: self.levels}).values
+                    arr = ds_t[vname].sel({self.level_coord: self.levels}, method="nearest").values
                 tensor = torch.tensor(arr, dtype=torch.float32).unsqueeze(1)
                 key = self._get_field_name(field_type, "3d", vname)
                 sample[key] = tensor

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -17,7 +17,7 @@ PREBLOCK_REGISTRY = {
     "concat": ConcatToTensor,
     "era5_normalizer": ERA5Normalizer,
     "fill_values": FillValues,
-    "bridgescaler_transformer": BridgeScalerTransformer,
+    "bridgescaler_transform": BridgeScalerTransformer,
 }
 
 _VALID_SECTIONS = {"ic_only", "per_step"}

--- a/credit/trainers/trainer_gen2.py
+++ b/credit/trainers/trainer_gen2.py
@@ -54,7 +54,7 @@ class TrainerERA5Gen2(BaseTrainer):
         source = next(iter(data_conf["source"].values()))
         vars_conf = source["variables"]
         diag = vars_conf.get("diagnostic") or {}
-        num_levels = len(source.get("levels", []))
+        num_levels = len(source.get("levels") or [])
         self.varnum_diag = (len(diag.get("vars_3D", [])) * num_levels + len(diag.get("vars_2D", []))) if diag else 0
 
         self.retain_graph = data_conf.get("retain_graph", False)

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -103,7 +103,7 @@ def _make_conf(save_loc: str, scaler_path: str) -> dict:
                 # Placeholder scaler block so apply_preblocks_before_scaler stops here;
                 # the per-test scalers below are built separately.
                 "scaler": {
-                    "type": "bridgescaler_transformer",
+                    "type": "bridgescaler_transform",
                     "args": {
                         "variables": [],
                         "scaler_path": scaler_path,


### PR DESCRIPTION
### Description
This address two bug related issues.

1. The `level_coord:` now uses the "nearest" method that will be useful for floating point level (CESM) that a user wants to subset. `levels:` in the data config now properly defaults to use all available levels if set to `null` or is absent all together. 

2. The configs and code have been modified to consistently use the `bridgescaler_transform` registry key instead of `bridgescaler_transformer` key, where there was inconsistencies.  
 
Closes #422 and #432

### Checklist
- [x] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date.