### PR TITLE
Remove dead code

### DIFF
--- a/credit/trainers/trainer_gen2.py
+++ b/credit/trainers/trainer_gen2.py
@@ -51,12 +51,6 @@ class TrainerERA5Gen2(BaseTrainer):
 
         # ---- Data schema extraction (new nested schema) ----
         data_conf = conf["data"]
-        source = next(iter(data_conf["source"].values()))
-        vars_conf = source["variables"]
-        diag = vars_conf.get("diagnostic") or {}
-        num_levels = len(source.get("levels") or [])
-        self.varnum_diag = (len(diag.get("vars_3D", [])) * num_levels + len(diag.get("vars_2D", []))) if diag else 0
-
         self.retain_graph = data_conf.get("retain_graph", False)
 
         # forecast_len: 1 = 1 step (new semantics, unlike v1 where 0 = 1 step)


### PR DESCRIPTION
### Description

@lj-dunphy (regarding #433)

It looks like that block was all dead code from gen 1. The diagnostics are cleanly handled with the preblock / postblock / data schema

I removed the dead code, and it should now succesfully operate with `levels:` as `null`, a subset list, or excluded all together which will default to all variables. 
