### PR TITLE
Allow validation_data to be fully independent from training data config

### DIFF
--- a/credit/trainers/utils.py
+++ b/credit/trainers/utils.py
@@ -440,8 +440,8 @@ def inject_postblock_info(conf: dict) -> None:
             cfg_ud["sp_inds"] = _find_ind("surface_pressure_name", single=True)
 
 
-def _resolve_data_conf(conf: dict, is_train: bool) -> dict:
-    """Resolve the data config for train or validation.
+def load_dataset(conf: dict, is_train: bool) -> MultiSourceDataset:
+    """Build a MultiSourceDataset for train or validation.
 
     For validation, conf["validation_data"] is used as-is if present, with one
     exception: "source" is inherited from conf["data"] if omitted. If validation_data
@@ -457,23 +457,19 @@ def _resolve_data_conf(conf: dict, is_train: bool) -> dict:
         - validation_data missing other keys: raises ValueError listing missing keys
     """
     if is_train:
-        return conf["data"]
+        data_conf = conf["data"]
+    else:
+        data_conf = dict(conf.get("validation_data") or conf["data"])
+        if "source" not in data_conf:
+            data_conf["source"] = conf["data"]["source"]  # inherit source from training if omitted
+        missing = set(conf["data"]) - set(data_conf)
+        if missing:
+            raise ValueError(
+                f"validation_data is missing keys: {missing}. "
+                "Either add them or remove validation_data to use training config."
+            )
 
-    data_conf = dict(conf.get("validation_data") or conf["data"])
-    if "source" not in data_conf:
-        data_conf["source"] = conf["data"]["source"]  # inherit source from training if omitted
-    missing = set(conf["data"]) - set(data_conf)
-    if missing:
-        raise ValueError(
-            f"validation_data is missing keys: {missing}. "
-            "Either add them or remove validation_data to use training config."
-        )
-    return data_conf
-
-
-def load_dataset(conf: dict, is_train: bool) -> MultiSourceDataset:
-    """Build a MultiSourceDataset for train or validation."""
-    return MultiSourceDataset(_resolve_data_conf(conf, is_train), return_target=True)
+    return MultiSourceDataset(data_conf, return_target=True)
 
 
 def load_dataloader(

--- a/credit/trainers/utils.py
+++ b/credit/trainers/utils.py
@@ -440,15 +440,40 @@ def inject_postblock_info(conf: dict) -> None:
             cfg_ud["sp_inds"] = _find_ind("surface_pressure_name", single=True)
 
 
+def _resolve_data_conf(conf: dict, is_train: bool) -> dict:
+    """Resolve the data config for train or validation.
+
+    For validation, conf["validation_data"] is used as-is if present, with one
+    exception: "source" is inherited from conf["data"] if omitted. If validation_data
+    is absent or empty, conf["data"] is used instead.
+
+    Raises ValueError if validation_data is present but missing keys that conf["data"]
+    has — partial configs are rejected to avoid silent misconfiguration.
+
+    Cases:
+        - No validation_data / empty:       uses conf["data"] entirely
+        - Full validation_data:             uses conf["validation_data"] as-is
+        - validation_data missing "source": inherits source from conf["data"]
+        - validation_data missing other keys: raises ValueError listing missing keys
+    """
+    if is_train:
+        return conf["data"]
+
+    data_conf = dict(conf.get("validation_data") or conf["data"])
+    if "source" not in data_conf:
+        data_conf["source"] = conf["data"]["source"]  # inherit source from training if omitted
+    missing = set(conf["data"]) - set(data_conf)
+    if missing:
+        raise ValueError(
+            f"validation_data is missing keys: {missing}. "
+            "Either add them or remove validation_data to use training config."
+        )
+    return data_conf
+
+
 def load_dataset(conf: dict, is_train: bool) -> MultiSourceDataset:
     """Build a MultiSourceDataset for train or validation."""
-    if is_train:
-        data_conf = conf["data"]
-    else:
-        data_conf = {**conf["data"], **conf.get("validation_data", {})}
-        data_conf["source"] = conf["data"]["source"]
-
-    return MultiSourceDataset(data_conf, return_target=True)
+    return MultiSourceDataset(_resolve_data_conf(conf, is_train), return_target=True)
 
 
 def load_dataloader(

--- a/tests/test_trainers_utils.py
+++ b/tests/test_trainers_utils.py
@@ -1,0 +1,58 @@
+"""Tests for credit.trainers.utils._resolve_data_conf validation_data config handling."""
+
+from credit.trainers.utils import _resolve_data_conf
+
+_BASE_DATA_CONF = {
+    "source": "WB2",
+    "years": [2020],
+    "variables": ["temperature"],
+}
+
+
+def _make_conf(validation_data=None):
+    conf = {"data": dict(_BASE_DATA_CONF)}
+    if validation_data is not None:
+        conf["validation_data"] = validation_data
+    return conf
+
+
+# Case: validation_data present but incomplete — should fail loudly
+def test_resolve_data_conf_missing_keys_raises():
+    """Incomplete validation_data (has source but missing other keys) raises ValueError."""
+    conf = _make_conf(validation_data={"source": "WB2"})
+    try:
+        _resolve_data_conf(conf, is_train=False)
+        raise AssertionError("Expected ValueError was not raised")
+    except ValueError as exc:
+        assert "validation_data is missing keys" in str(exc)
+
+
+# Case: validation_data present but no source — source inherited from training
+def test_resolve_data_conf_inherits_source():
+    """validation_data without 'source' inherits it from conf['data']."""
+    conf = _make_conf(validation_data={"years": [2021], "variables": ["temperature"]})
+    data_conf = _resolve_data_conf(conf, is_train=False)
+    assert data_conf["source"] == _BASE_DATA_CONF["source"]
+    assert data_conf["years"] == [2021]  # validation value, not training
+
+
+# Case: no validation_data — falls back to training config entirely
+def test_resolve_data_conf_no_validation_data_uses_training_conf():
+    """Absent validation_data returns conf['data'] unchanged."""
+    conf = _make_conf()
+    assert _resolve_data_conf(conf, is_train=False) == conf["data"]
+
+
+# Case: empty validation_data {} — treated same as absent, falls back to training config
+def test_resolve_data_conf_empty_validation_data_uses_training_conf():
+    """Empty validation_data dict returns conf['data'] unchanged."""
+    conf = _make_conf(validation_data={})
+    assert _resolve_data_conf(conf, is_train=False) == conf["data"]
+
+
+# Case: full validation_data — used as-is, training source must not bleed in
+def test_resolve_data_conf_full_uses_validation_source():
+    """Full validation_data uses its own source, not training's."""
+    conf = _make_conf(validation_data={"source": "WB2_VAL", "years": [2021], "variables": ["temperature"]})
+    data_conf = _resolve_data_conf(conf, is_train=False)
+    assert data_conf["source"] == "WB2_VAL"  # not overwritten by training source

--- a/tests/test_trainers_utils.py
+++ b/tests/test_trainers_utils.py
@@ -1,6 +1,8 @@
-"""Tests for credit.trainers.utils._resolve_data_conf validation_data config handling."""
+"""Tests for credit.trainers.utils.load_dataset validation_data config handling."""
 
-from credit.trainers.utils import _resolve_data_conf
+from unittest.mock import patch
+
+from credit.trainers.utils import load_dataset
 
 _BASE_DATA_CONF = {
     "source": "WB2",
@@ -17,42 +19,52 @@ def _make_conf(validation_data=None):
 
 
 # Case: validation_data present but incomplete — should fail loudly
-def test_resolve_data_conf_missing_keys_raises():
+def test_load_dataset_validation_missing_keys_raises():
     """Incomplete validation_data (has source but missing other keys) raises ValueError."""
     conf = _make_conf(validation_data={"source": "WB2"})
     try:
-        _resolve_data_conf(conf, is_train=False)
+        load_dataset(conf, is_train=False)
         raise AssertionError("Expected ValueError was not raised")
     except ValueError as exc:
         assert "validation_data is missing keys" in str(exc)
 
 
 # Case: validation_data present but no source — source inherited from training
-def test_resolve_data_conf_inherits_source():
+def test_load_dataset_validation_inherits_source():
     """validation_data without 'source' inherits it from conf['data']."""
     conf = _make_conf(validation_data={"years": [2021], "variables": ["temperature"]})
-    data_conf = _resolve_data_conf(conf, is_train=False)
-    assert data_conf["source"] == _BASE_DATA_CONF["source"]
-    assert data_conf["years"] == [2021]  # validation value, not training
+    with patch("credit.trainers.utils.MultiSourceDataset") as mock_ds:
+        load_dataset(conf, is_train=False)
+        called_conf = mock_ds.call_args[0][0]
+        assert called_conf["source"] == _BASE_DATA_CONF["source"]
+        assert called_conf["years"] == [2021]  # validation value, not training
 
 
 # Case: no validation_data — falls back to training config entirely
-def test_resolve_data_conf_no_validation_data_uses_training_conf():
-    """Absent validation_data returns conf['data'] unchanged."""
+def test_load_dataset_no_validation_data_uses_training_conf():
+    """Absent validation_data passes conf['data'] to MultiSourceDataset unchanged."""
     conf = _make_conf()
-    assert _resolve_data_conf(conf, is_train=False) == conf["data"]
+    with patch("credit.trainers.utils.MultiSourceDataset") as mock_ds:
+        load_dataset(conf, is_train=False)
+        called_conf = mock_ds.call_args[0][0]
+        assert called_conf == conf["data"]
 
 
 # Case: empty validation_data {} — treated same as absent, falls back to training config
-def test_resolve_data_conf_empty_validation_data_uses_training_conf():
-    """Empty validation_data dict returns conf['data'] unchanged."""
+def test_load_dataset_empty_validation_data_uses_training_conf():
+    """Empty validation_data dict passes conf['data'] to MultiSourceDataset unchanged."""
     conf = _make_conf(validation_data={})
-    assert _resolve_data_conf(conf, is_train=False) == conf["data"]
+    with patch("credit.trainers.utils.MultiSourceDataset") as mock_ds:
+        load_dataset(conf, is_train=False)
+        called_conf = mock_ds.call_args[0][0]
+        assert called_conf == conf["data"]
 
 
 # Case: full validation_data — used as-is, training source must not bleed in
-def test_resolve_data_conf_full_uses_validation_source():
+def test_load_dataset_validation_full_uses_validation_source():
     """Full validation_data uses its own source, not training's."""
     conf = _make_conf(validation_data={"source": "WB2_VAL", "years": [2021], "variables": ["temperature"]})
-    data_conf = _resolve_data_conf(conf, is_train=False)
-    assert data_conf["source"] == "WB2_VAL"  # not overwritten by training source
+    with patch("credit.trainers.utils.MultiSourceDataset") as mock_ds:
+        load_dataset(conf, is_train=False)
+        called_conf = mock_ds.call_args[0][0]
+        assert called_conf["source"] == "WB2_VAL"  # not overwritten by training source


### PR DESCRIPTION
### Description
It is natural for `validation_data` to share the same data source as the training data. However, keys under source could differ between training and validation, and the original design intended `validation_data` to override training settings — but source was always forced back to the training value.

Previously, the validation config was built as:

https://github.com/NCAR/miles-credit/blob/6a6e5f44fe2c945cf263368b3ee3f64340a826dd/credit/trainers/utils.py#L449-L450

The first line merges the training config with `validation_data`, so any key not specified in `validation_data` would silently inherit the training value. The second line then unconditionally overwrites the source with the training value, ignoring anything the user set in `validation_data`.

This PR makes `validation_data` fully independent when present: it is used as-is, with source inherited from training only as a convenience when omitted. Incomplete configs raise ValueError with the missing keys, making misconfiguration explicit rather than silent.

### Checklist
- [x] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date.
