### PR TITLE
preblock/postblock: data_types scoping, postblock scaler fixes, and test cleanup

### DIFF
--- a/config/gen_2/examples/example-v2026.2.yml
+++ b/config/gen_2/examples/example-v2026.2.yml
@@ -187,13 +187,12 @@ postblocks:
     scaler:
       type: bridgescaler_transform
       args:
-        scaler_path: '/glade/campaign/cisl/aiml/credit/credit_scalers/ERA5_mlevel_1deg_6h_bridgescaler_post.json'
+        scaler_path: '/glade/campaign/cisl/aiml/credit/credit_scalers/ERA5_mlevel_1deg_6h_bridgescaler_pre.json'
         variables: ['ERA5/prognostic/3d/u_component_of_wind', 'ERA5/prognostic/3d/v_component_of_wind',
                     'ERA5/prognostic/3d/temperature', 'ERA5/prognostic/3d/specific_total_water',
                     'ERA5/prognostic/2d/SP', 'ERA5/prognostic/2d/VAR_2T', 'ERA5/prognostic/2d/VAR_10U',
                     'ERA5/prognostic/2d/VAR_10V']
         method: inverse_transform
-        scaler_data_type: null    # existing campaign scaler is flat {source: {var: scaler}} — no data_type level
 
 
 # ---- Architecture (pre-filled for 1-degree ERA5, 181×360) ---- #

--- a/config/gen_2/examples/example-v2026.2.yml
+++ b/config/gen_2/examples/example-v2026.2.yml
@@ -63,7 +63,7 @@ data:
 # ---- USER SETTINGS: validation data ---- #
 validation_data:
   source:
-    ERA5_Validation:
+    ERA5:
       dataset_type: "local"
       level_coord: "level"
       levels: [ 1., 9., 19., 29., 39., 49., 59., 69., 79., 89., 97., 104., 111., 116., 122., 126., 131., 136. ]
@@ -71,17 +71,17 @@ validation_data:
         prognostic:
           vars_3D: [ 'u_component_of_wind', 'v_component_of_wind', 'temperature', 'specific_total_water' ]
           vars_2D: [ 'SP', 'VAR_2T', 'VAR_10U', 'VAR_10V' ]
-          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h*'
+          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h_subset_%Y*'
 
         diagnostic:
           vars_2D: [ 'total_precipitation', 'evaporation', 'top_net_thermal_radiation', 'top_net_solar_radiation',
                      'surface_latent_heat_flux', 'surface_net_solar_radiation',
                      'surface_net_thermal_radiation', 'surface_sensible_heat_flux' ]
-          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h*'
+          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h_subset_%Y*'
 
         dynamic_forcing:
           vars_2D: [ 'toa_incident_solar_radiation', 'land_sea_CI_mask' ]
-          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h*'
+          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_mlevel_1deg/all_in_one/ERA5_mlevel_1deg_6h_subset_%Y*'
 
         static:
           vars_2D: [ 'z_norm', 'land_sea_mask' ]
@@ -167,7 +167,7 @@ preblocks:
     scaler:
       type: bridgescaler_transform
       args:
-        scaler_path: '/glade/campaign/cisl/aiml/credit_scalers/ERA5_mlevel_1deg_6h_bridgescaler_pre.json'
+        scaler_path: '/glade/campaign/cisl/aiml/credit/credit_scalers/ERA5_mlevel_1deg_6h_bridgescaler_pre.json'
         variables: ['ERA5/prognostic/3d/u_component_of_wind', 'ERA5/prognostic/3d/v_component_of_wind',
                     'ERA5/prognostic/3d/temperature', 'ERA5/prognostic/3d/specific_total_water',
                     'ERA5/prognostic/2d/SP', 'ERA5/prognostic/2d/VAR_2T', 'ERA5/prognostic/2d/VAR_10U',
@@ -187,12 +187,13 @@ postblocks:
     scaler:
       type: bridgescaler_transform
       args:
-        scaler_path: '/glade/campaign/cisl/aiml/credit_scalers/ERA5_mlevel_1deg_6h_bridgescaler_post.json'
+        scaler_path: '/glade/campaign/cisl/aiml/credit/credit_scalers/ERA5_mlevel_1deg_6h_bridgescaler_post.json'
         variables: ['ERA5/prognostic/3d/u_component_of_wind', 'ERA5/prognostic/3d/v_component_of_wind',
                     'ERA5/prognostic/3d/temperature', 'ERA5/prognostic/3d/specific_total_water',
                     'ERA5/prognostic/2d/SP', 'ERA5/prognostic/2d/VAR_2T', 'ERA5/prognostic/2d/VAR_10U',
                     'ERA5/prognostic/2d/VAR_10V']
         method: inverse_transform
+        scaler_data_type: null    # existing campaign scaler is flat {source: {var: scaler}} — no data_type level
 
 
 # ---- Architecture (pre-filled for 1-degree ERA5, 181×360) ---- #
@@ -248,6 +249,8 @@ loss:
   training_loss: "mse"
 
   use_power_loss: True              # penalize spurious high-wavenumber content (anti-checkerboard); set False to disable
+  spectral_lambda_reg: 0.1         # weight on power/spectral loss term: total = training_loss + lambda * aux_loss
+  spectral_wavenum_init: 20        # wavenumber above which the power loss is applied
   use_spectral_loss: False
 
   use_latitude_weights: True

--- a/config/gen_2/examples/wxformer_era5_025deg_6hr.yml
+++ b/config/gen_2/examples/wxformer_era5_025deg_6hr.yml
@@ -56,7 +56,7 @@ data:
 # Validation data block (same schema, different date range)
 validation_data:
   source:
-    ERA5_Validation:
+    ERA5:
       dataset_type: "local"
       level_coord: "level"
       levels: [ 25.5, 75.0, 125.0, 175.0, 225.0, 275.0, 350.0, 450.0, 550.0, 650.0, 775.0, 887.5, 962.5 ]
@@ -64,17 +64,17 @@ validation_data:
         prognostic:
           vars_3D: [ 'U', 'V', 'T', 'specific_total_water' ]
           vars_2D: [ 'SP', 'VAR_2T', 'VAR_10U', 'VAR_10V' ]
-          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/all_in_one/ERA5_plevel_6h_*.zarr'
+          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/all_in_one/ERA5_plevel_6h_%Y.zarr'
 
         diagnostic:
           vars_2D: [ 'total_precipitation', 'evaporation', 'top_net_thermal_radiation', 'top_net_solar_radiation',
                      'surface_latent_heat_flux', 'surface_net_solar_radiation',
                      'surface_net_thermal_radiation', 'surface_sensible_heat_flux' ]
-          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/all_in_one/ERA5_plevel_6h_*.zarr'
+          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/all_in_one/ERA5_plevel_6h_%Y*.zarr'
 
         dynamic_forcing:
           vars_2D: [ 'toa_incident_solar_radiation', 'land_sea_CI_mask' ]
-          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/all_in_one/ERA5_plevel_6h_*.zarr'
+          path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/all_in_one/ERA5_plevel_6h_%Y*.zarr'
 
         static:
           vars_2D: [ 'z_norm', 'land_sea_mask' ]

--- a/config/gen_2/examples/wxformer_era5_025deg_6hr.yml
+++ b/config/gen_2/examples/wxformer_era5_025deg_6hr.yml
@@ -155,6 +155,17 @@ trainer:
   prefetch_factor: 4
 
 
+preblocks:
+  per_step:
+    norm:
+      type: era5_normalizer
+      args:
+        mean_path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/mean_std/mean_6h_1979_2019_13lev_0.25deg.nc'
+        std_path: '/glade/campaign/cisl/aiml/ksha/CREDIT_data/ERA5_plevel_base/mean_std/std_6h_1979_2019_13lev_0.25deg.nc'
+    concat:
+      type: concat
+
+
 model:
   type: "crossformer"
   frames: 1                         # number of input states

--- a/credit/applications/preprocess.py
+++ b/credit/applications/preprocess.py
@@ -12,7 +12,7 @@ import torch
 import yaml
 import sys
 import shutil
-from credit.preblock import build_preblocks, apply_preblocks_before_scaler, BridgeScalerTransformer
+from credit.preblock import build_preblocks, apply_preblocks_before_scaler, BridgeScalerTransform
 from credit.preblock.scaler import combine_scaler_dicts, move_scaler_dict_to_cpu
 from credit.trainers.utils import cycle, load_dataset, load_dataloader
 import torch.distributed as dist
@@ -185,11 +185,11 @@ Examples:
     print(preblocks)
     scaler_block_key = None
     for k, v in preblocks.items():
-        if isinstance(v, BridgeScalerTransformer):
+        if isinstance(v, BridgeScalerTransform):
             scaler_block_key = k
             break
     if scaler_block_key is None:
-        raise ValueError("BridgeScalerTransformer not found in preblocks.")
+        raise ValueError("BridgeScalerTransform not found in preblocks.")
     _bpe = trainer_conf.get("batches_per_epoch", 0) or 0
     if hasattr(train_loader.sampler, "batches_per_epoch"):
         dataset_batches = train_loader.sampler.batches_per_epoch()

--- a/credit/cli/_convert.py
+++ b/credit/cli/_convert.py
@@ -73,9 +73,10 @@ def _build_bridgescaler_jsons(mean_path, std_path, var_groups, pre_out, post_out
     pre_target = {}  # prognostic only (model prediction targets)
     pre_keys = []
 
-    # --- postblock dict: {source: {full_key: scaler}}
-    # Must match y_processed structure written by Reconstruct.
-    post_dict = {}
+    # --- postblock dict: {"target": {source: {full_key: scaler}}}
+    # Wraps in "target" so BridgeScalerTransformer's scaler_data_type="target" default
+    # slices correctly — same structure as the preblock scaler, one level per data type.
+    post_dict = {"target": {}}
 
     for (field_type, dim), varnames in var_groups.items():
         for varname in varnames:
@@ -88,7 +89,7 @@ def _build_bridgescaler_jsons(mean_path, std_path, var_groups, pre_out, post_out
             pre_keys.append(full_key)
             if field_type in ("prognostic", "diagnostic"):
                 pre_target[full_key] = sc
-                post_dict.setdefault(source_name, {})[full_key] = sc
+                post_dict["target"].setdefault(source_name, {})[full_key] = sc
 
     ds_mean.close()
     ds_std.close()

--- a/credit/cli/_convert.py
+++ b/credit/cli/_convert.py
@@ -74,8 +74,7 @@ def _build_bridgescaler_jsons(mean_path, std_path, var_groups, pre_out, post_out
     pre_keys = []
 
     # --- postblock dict: {"target": {source: {full_key: scaler}}}
-    # Wraps in "target" so BridgeScalerTransform's scaler_data_type="target" default
-    # slices correctly — same structure as the preblock scaler, one level per data type.
+    # BridgeScalerTransform always slices ["target"] — match that structure here.
     post_dict = {"target": {}}
 
     for (field_type, dim), varnames in var_groups.items():

--- a/credit/cli/_convert.py
+++ b/credit/cli/_convert.py
@@ -74,7 +74,7 @@ def _build_bridgescaler_jsons(mean_path, std_path, var_groups, pre_out, post_out
     pre_keys = []
 
     # --- postblock dict: {"target": {source: {full_key: scaler}}}
-    # Wraps in "target" so BridgeScalerTransformer's scaler_data_type="target" default
+    # Wraps in "target" so BridgeScalerTransform's scaler_data_type="target" default
     # slices correctly — same structure as the preblock scaler, one level per data type.
     post_dict = {"target": {}}
 

--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -2,7 +2,7 @@ import torch.nn as nn
 
 from credit.postblock.reconstruct import Reconstruct
 from credit.postblock.wet_mask_samudra import WetMaskBlock
-from credit.postblock.scaler import BridgeScalerTransformer
+from credit.postblock.scaler import BridgeScalerTransform
 from credit.postblock.mslp import MSLPDiagnostic
 from credit.postblock.exp import ExpTransform
 from credit.postblock.square import SquareTransform
@@ -12,7 +12,7 @@ from credit.postblock.geopotential import GeopotentialDiagnostic
 
 POSTBLOCK_REGISTRY = {
     "reconstruct": Reconstruct,
-    "bridgescaler_transform": BridgeScalerTransformer,
+    "bridgescaler_transform": BridgeScalerTransform,
     "exp_transform": ExpTransform,
     "square_transform": SquareTransform,
     "wet_mask_samudra": WetMaskBlock,

--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -4,6 +4,8 @@ from credit.postblock.reconstruct import Reconstruct
 from credit.postblock.wet_mask_samudra import WetMaskBlock
 from credit.postblock.scaler import BridgeScalerTransformer
 from credit.postblock.mslp import MSLPDiagnostic
+from credit.postblock.exp import ExpTransform
+from credit.postblock.square import SquareTransform
 
 from credit.postblock.gen1 import TracerFixer, GlobalMassFixer, GlobalWaterFixer, GlobalEnergyFixer
 from credit.postblock.geopotential import GeopotentialDiagnostic
@@ -11,6 +13,8 @@ from credit.postblock.geopotential import GeopotentialDiagnostic
 POSTBLOCK_REGISTRY = {
     "reconstruct": Reconstruct,
     "bridgescaler_transform": BridgeScalerTransformer,
+    "exp_transform": ExpTransform,
+    "square_transform": SquareTransform,
     "wet_mask_samudra": WetMaskBlock,
     "mslp_diagnostic": MSLPDiagnostic,
     "tracer_fixer": TracerFixer,

--- a/credit/postblock/exp.py
+++ b/credit/postblock/exp.py
@@ -1,0 +1,88 @@
+import math
+
+import torch
+
+from credit.postblock.base import BasePostblock
+from credit.preblock._utils import (
+    _parse_variable_selection,
+)  # shared utility — lives in preblock but used by both pre and postblocks
+
+
+class ExpTransform(BasePostblock):
+    """Inverse of the LogTransform preblock: converts log-space values to physical space.
+
+    Inverts ``y = log_base(x + eps) - log_base(eps)`` back to ``x = base^(y + log_base(eps)) - eps``.
+
+    ``eps`` and ``base`` must match those used in the corresponding LogTransform preblock.
+
+    ``variables`` supports the same shorthand as the scaler: an empty list
+    transforms every variable; partial paths (e.g. ``"era5/prognostic"``) expand
+    to all variables under that hierarchy. Expansion happens lazily on the first
+    forward call.
+
+    Config example::
+
+        type: "exp_transform"
+        args:
+            variables:
+                - "era5/prognostic/3d/Q"
+            eps: 1.0e-8      # must match LogTransform eps
+            base: "e"        # must match LogTransform base
+
+        # or inverse-transform all variables:
+        type: "exp_transform"
+        args:
+            variables: []
+    """
+
+    def __init__(
+        self,
+        variables: list[str],
+        eps: float = 1e-8,
+        base: str = "e",
+        key: str = "y_processed",
+    ):
+        super().__init__()
+        self.variables = variables
+        self.variables_expanded = False
+        self.key = key  # key in batch_dict where Reconstruct writes the split output (default: "y_processed")
+        # _eps and _log_eps stored as Python floats — they broadcast to any device
+        # without an explicit .to() call, and log(eps) is a constant so we compute it once.
+        self._eps = float(eps)
+
+        if base == "e":
+            self._log_eps = math.log(self._eps)
+        elif base == "2":
+            self._log_eps = math.log2(self._eps)
+        elif base == "10":
+            self._log_eps = math.log10(self._eps)
+        else:
+            raise ValueError(f"Unsupported base '{base}'. Choose from: 'e', '2', '10'.")
+
+        self._base = base
+
+    def _exp(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply base-specific exponentiation: e^x, 2^x, or 10^x."""
+        if self._base == "e":
+            return torch.exp(x)
+        elif self._base == "2":
+            return torch.exp2(x)
+        else:  # "10"
+            return torch.pow(10.0, x)  # torch has no torch.exp10; torch.pow is the standard alternative
+
+    def forward(self, batch_dict: dict) -> dict:
+        if not self.variables_expanded:
+            # batch_dict[self.key] is {source: {var_key: tensor}} — one level shallower
+            # than the preblock's {data_type: {source: {var_key: tensor}}}. Wrap with a
+            # dummy key so _parse_variable_selection can traverse it with its standard logic.
+            wrapped = {"_": batch_dict[self.key]}
+            self.variables = _parse_variable_selection(self.variables, wrapped, data_types=["_"])
+            self.variables_expanded = True
+        nested = batch_dict[self.key]  # {source: {var_key: tensor}}
+        for var_key in self.variables:
+            source = var_key.split("/")[0]  # e.g. "era5" from "era5/prognostic/3d/Q"
+            if source not in nested or var_key not in nested[source]:
+                continue  # variable not present in this batch — skip silently
+            y = nested[source][var_key]  # value in log-space (to be inverted to physical space)
+            nested[source][var_key] = self._exp(y + self._log_eps) - self._eps  # x = base^(y + log_base(eps)) - eps
+        return batch_dict

--- a/credit/postblock/reconstruct.py
+++ b/credit/postblock/reconstruct.py
@@ -31,18 +31,25 @@ from credit.postblock.base import BasePostblock
 class Reconstruct(BasePostblock):
     """Splits ``batch_dict["y_pred"]`` into a nested variable dict at ``batch_dict["y_processed"]``.
 
+    This must be the **first postblock** in the chain — all subsequent postblocks
+    (scalers, transforms, physics fixers) read from ``batch_dict["y_processed"]``.
+
     Slices are read from ``batch_dict["metadata"]["target"]["_channel_map"]``, built
     by ``ConcatToTensor`` and covering only prognostic + diagnostic variables.
     Each slice is unflattened from ``(B, n_levels * n_time, H, W)`` back to
-    ``(B, n_levels, n_time, H, W)``. ``y_pred`` is left untouched. All other
-    keys in ``batch_dict`` pass through unchanged.
+    ``(B, n_levels, n_time, H, W)``. ``y_pred`` is left untouched for loss
+    computation. All other keys in ``batch_dict`` pass through unchanged.
+
+    Config example::
+
+        type: "reconstruct"
     """
 
     def forward(self, batch_dict: dict) -> dict:
         y_pred = batch_dict["y_pred"]
         output_map = batch_dict["metadata"]["target"]["_channel_map"]
 
-        # Flatten time dim if y_pred arrived as 5D (B, C, T, H, W) — unflatten needs 4D input
+        # Merge channel and time dims into a single channel dim if y_pred arrived as 5D (B, C, T, H, W)
         if y_pred.dim() == 5:
             y_pred = y_pred.flatten(1, 2)
 
@@ -52,13 +59,17 @@ class Reconstruct(BasePostblock):
             n_levels, n_time = info["orig_shape"]
 
             # Slice the flat channel dim: (B, n_levels*n_time, H, W)
-            var_tensor = y_pred[:, ch_slice, ...].detach()
+            var_tensor = y_pred[
+                :, ch_slice, ...
+            ].detach()  # detach so postblock transforms don't affect gradients on y_pred
 
             # Restore level and time dims: (B, n_levels, n_time, H, W)
             var_tensor = var_tensor.unflatten(1, (n_levels, n_time))
 
-            source = var_key.split("/")[0]
-            y_processed.setdefault(source, {})[var_key] = var_tensor
+            source = var_key.split("/")[0]  # e.g. "era5" from "era5/prognostic/3d/T"
+            y_processed.setdefault(source, {})[var_key] = (
+                var_tensor  # group by source, creating the sub-dict on first encounter
+            )
 
         batch_dict["y_processed"] = y_processed
         return batch_dict

--- a/credit/postblock/scaler.py
+++ b/credit/postblock/scaler.py
@@ -26,10 +26,8 @@ class BridgeScalerTransform(BasePostblock):
 
     The same ``scaler.json`` produced by ``credit preprocess`` (which has the
     structure ``{data_type: {source: {var_key: scaler}}}``) can be shared with
-    the preblock. Use ``scaler_data_type`` to select which data type's statistics
-    to apply — typically ``"target"`` for inverse-transforming model output.
-    Set ``scaler_data_type=None`` only if the scaler was fit with a flat
-    ``{source: {var_key: scaler}}`` structure (no data type split).
+    the preblock. The ``"target"`` slice is always used for inverse-transforming
+    model output.
 
     ``variables`` supports the same shorthand as the preblock: an empty list
     scales every variable; partial paths (e.g. ``"era5/prognostic"``) expand to
@@ -38,27 +36,19 @@ class BridgeScalerTransform(BasePostblock):
 
     Example config::
 
-        # Inverse-transform specific variables using the target side of a shared scaler
+        # Inverse-transform specific variables
         type: "bridgescaler_transform"
         args:
             scaler_path: "/path/to/scaler.json"
             variables:
                 - "era5/prognostic/3d/T"
                 - "era5/prognostic/3d/U"
-            scaler_data_type: "target"   # default — slice to target statistics
 
         # Inverse-transform all variables
         type: "bridgescaler_transform"
         args:
             scaler_path: "/path/to/scaler.json"
             variables: []
-
-        # Use a flat scaler (no data type split)
-        type: "bridgescaler_transform"
-        args:
-            scaler_path: "/path/to/scaler.json"
-            variables: []
-            scaler_data_type: null
     """
 
     def __init__(
@@ -67,7 +57,6 @@ class BridgeScalerTransform(BasePostblock):
         variables: list[str],
         method: str = "inverse_transform",
         key: str = "y_processed",
-        scaler_data_type: str = "target",
     ):
         super().__init__()
         self.variables = variables
@@ -75,13 +64,8 @@ class BridgeScalerTransform(BasePostblock):
         self.method = method
         self.scaler_path = expandvars(scaler_path)
         self.key = key  # key in batch_dict where Reconstruct writes the split output (default: "y_processed")
-        full_scaler = load_scaler_dict(
-            self.scaler_path
-        )  # loads the scaler from disk — postblock never fits, only applies
-        # Slice to the requested data type so the scaler structure matches {source: {var_key: scaler}},
-        # which is one level shallower than the full {data_type: {source: {var_key: scaler}}} structure.
-        # Set scaler_data_type=None only for flat scalers without a data type split.
-        self.scaler = full_scaler[scaler_data_type] if scaler_data_type is not None else full_scaler
+        full_scaler = load_scaler_dict(self.scaler_path)
+        self.scaler = full_scaler["target"]
 
     def forward(self, batch_dict: dict) -> dict:
         if not self.variables_expanded:

--- a/credit/postblock/scaler.py
+++ b/credit/postblock/scaler.py
@@ -7,7 +7,7 @@ from credit.preblock._utils import (
 )  # shared utility — lives in preblock but used by both pre and postblocks
 
 
-class BridgeScalerTransformer(BasePostblock):
+class BridgeScalerTransform(BasePostblock):
     """Scaling postblock using a fitted bridgescaler dict.
 
     Applies per-variable scaling to the nested output dict at ``batch_dict[key]``

--- a/credit/postblock/scaler.py
+++ b/credit/postblock/scaler.py
@@ -1,41 +1,98 @@
+from os.path import expandvars
+
 from bridgescaler import load_scaler_dict, scale_var_dict
 from credit.postblock.base import BasePostblock
+from credit.preblock._utils import (
+    _parse_variable_selection,
+)  # shared utility — lives in preblock but used by both pre and postblocks
 
 
 class BridgeScalerTransformer(BasePostblock):
     """Scaling postblock using a fitted bridgescaler dict.
 
-    Applies per-variable scaling (or its inverse) to the nested prediction dict
-    at ``batch_dict[key]``, which has the form
-    ``batch_dict[key][source][var_key]`` where ``var_key`` is
-    ``"source/field_type/dim/varname"`` (e.g. ``"era5/prognostic/3d/T"``).
+    Applies per-variable scaling to the nested output dict at ``batch_dict[key]``
+    (default: ``"y_processed"``), which has the form ``{source: {var_key: tensor}}``
+    where ``var_key`` is ``"source/field_type/dim/varname"`` (e.g. ``"era5/prognostic/3d/T"``).
+    Typically used after ``Reconstruct`` to convert normalized values back to
+    physical units before physics fixers.
 
-    Defaults to operating on ``"y_processed"`` — the nested dict written by
-    ``Reconstruct``. Use ``method="inverse_transform"`` to convert normalized
-    predictions back to physical units before physics fixers.
+    ``method`` controls which bridgescaler operation to apply (default:
+    ``"inverse_transform"``). Any method name supported by the fitted scaler objects
+    is valid (e.g. ``"transform"`` to scale instead of unscale).
 
-    The scaler dict must have been fit with ``bridgescaler.scale_var_dict``
-    using the same nested structure and saved with ``bridgescaler.save_scaler_dict``.
+    ``key`` selects which entry in ``batch_dict`` to operate on (default:
+    ``"y_processed"``). Override if a different postblock writes its output under
+    a different key.
+
+    The same ``scaler.json`` produced by ``credit preprocess`` (which has the
+    structure ``{data_type: {source: {var_key: scaler}}}``) can be shared with
+    the preblock. Use ``scaler_data_type`` to select which data type's statistics
+    to apply — typically ``"target"`` for inverse-transforming model output.
+    Set ``scaler_data_type=None`` only if the scaler was fit with a flat
+    ``{source: {var_key: scaler}}`` structure (no data type split).
+
+    ``variables`` supports the same shorthand as the preblock: an empty list
+    scales every variable; partial paths (e.g. ``"era5/prognostic"``) expand to
+    all variables under that hierarchy. Expansion happens lazily on the first
+    forward call.
 
     Example config::
 
+        # Inverse-transform specific variables using the target side of a shared scaler
         type: "bridgescaler_transform"
         args:
             scaler_path: "/path/to/scaler.json"
             variables:
                 - "era5/prognostic/3d/T"
                 - "era5/prognostic/3d/U"
-            method: "inverse_transform"
+            scaler_data_type: "target"   # default — slice to target statistics
+
+        # Inverse-transform all variables
+        type: "bridgescaler_transform"
+        args:
+            scaler_path: "/path/to/scaler.json"
+            variables: []
+
+        # Use a flat scaler (no data type split)
+        type: "bridgescaler_transform"
+        args:
+            scaler_path: "/path/to/scaler.json"
+            variables: []
+            scaler_data_type: null
     """
 
-    def __init__(self, scaler_path: str, variables: list[str], method: str, key: str = "y_processed"):
+    def __init__(
+        self,
+        scaler_path: str,
+        variables: list[str],
+        method: str = "inverse_transform",
+        key: str = "y_processed",
+        scaler_data_type: str = "target",
+    ):
         super().__init__()
         self.variables = variables
+        self.variables_expanded = False
         self.method = method
-        self.scaler_path = scaler_path
-        self.key = key
-        self.scaler = load_scaler_dict(scaler_path)
+        self.scaler_path = expandvars(scaler_path)
+        self.key = key  # key in batch_dict where Reconstruct writes the split output (default: "y_processed")
+        full_scaler = load_scaler_dict(
+            self.scaler_path
+        )  # loads the scaler from disk — postblock never fits, only applies
+        # Slice to the requested data type so the scaler structure matches {source: {var_key: scaler}},
+        # which is one level shallower than the full {data_type: {source: {var_key: scaler}}} structure.
+        # Set scaler_data_type=None only for flat scalers without a data type split.
+        self.scaler = full_scaler[scaler_data_type] if scaler_data_type is not None else full_scaler
 
     def forward(self, batch_dict: dict) -> dict:
-        batch_dict[self.key] = scale_var_dict(batch_dict[self.key], self.scaler, self.method, self.variables)
+        if not self.variables_expanded:
+            # batch_dict[self.key] is {source: {var_key: tensor}} — one level shallower
+            # than the preblock's {data_type: {source: {var_key: tensor}}}. Wrap it with
+            # a dummy top-level key so _parse_variable_selection can traverse it with its
+            # standard logic.
+            wrapped = {"_": batch_dict[self.key]}
+            self.variables = _parse_variable_selection(self.variables, wrapped, data_types=["_"])
+            self.variables_expanded = True
+        batch_dict[self.key] = scale_var_dict(
+            batch_dict[self.key], self.scaler, self.method, self.variables
+        )  # returns a new dict; reassign back into batch_dict
         return batch_dict

--- a/credit/postblock/square.py
+++ b/credit/postblock/square.py
@@ -11,9 +11,9 @@ class SquareTransform(BasePostblock):
 
     Inverts ``y = sqrt(x)`` back to ``x = y^2``.
 
-    Note: values may be slightly negative due to floating-point effects;
-    squaring maps these to small positive values, preserving the non-negative physical
-    constraint for quantities such as specific humidity or precipitation.
+    Note: values may be slightly negative due to floating-point effects; squaring maps
+    these to small positive numbers. Clamping to zero is intentionally avoided to
+    preserve gradient flow if this postblock is ever connected to a differentiable loss.
 
     ``variables`` supports the same shorthand as the scaler: an empty list
     transforms every variable; partial paths (e.g. ``"era5/prognostic"``) expand

--- a/credit/postblock/square.py
+++ b/credit/postblock/square.py
@@ -1,0 +1,57 @@
+import torch
+
+from credit.postblock.base import BasePostblock
+from credit.preblock._utils import (
+    _parse_variable_selection,
+)  # shared utility — lives in preblock but used by both pre and postblocks
+
+
+class SquareTransform(BasePostblock):
+    """Inverse of the SqrtTransform preblock: converts sqrt-space values to physical space.
+
+    Inverts ``y = sqrt(x)`` back to ``x = y^2``.
+
+    Note: values may be slightly negative due to floating-point effects;
+    squaring maps these to small positive values, preserving the non-negative physical
+    constraint for quantities such as specific humidity or precipitation.
+
+    ``variables`` supports the same shorthand as the scaler: an empty list
+    transforms every variable; partial paths (e.g. ``"era5/prognostic"``) expand
+    to all variables under that hierarchy. Expansion happens lazily on the first
+    forward call.
+
+    Config example::
+
+        type: "square_transform"
+        args:
+            variables:
+                - "era5/prognostic/3d/Q"
+
+        # or inverse-transform all variables:
+        type: "square_transform"
+        args:
+            variables: []
+    """
+
+    def __init__(self, variables: list[str], key: str = "y_processed"):
+        super().__init__()
+        self.variables = variables
+        self.variables_expanded = False
+        self.key = key  # key in batch_dict where Reconstruct writes the split output (default: "y_processed")
+
+    def forward(self, batch_dict: dict) -> dict:
+        if not self.variables_expanded:
+            # batch_dict[self.key] is {source: {var_key: tensor}} — one level shallower
+            # than the preblock's {data_type: {source: {var_key: tensor}}}. Wrap with a
+            # dummy key so _parse_variable_selection can traverse it with its standard logic.
+            wrapped = {"_": batch_dict[self.key]}
+            self.variables = _parse_variable_selection(self.variables, wrapped, data_types=["_"])
+            self.variables_expanded = True
+        nested = batch_dict[self.key]  # {source: {var_key: tensor}}
+        for var_key in self.variables:
+            source = var_key.split("/")[0]  # e.g. "era5" from "era5/prognostic/3d/Q"
+            if source not in nested or var_key not in nested[source]:
+                continue  # variable not present in this batch — skip silently
+            y = nested[source][var_key]  # value in sqrt-space (to be inverted to physical space)
+            nested[source][var_key] = torch.square(y)  # x = y^2
+        return batch_dict

--- a/credit/preblock/__init__.py
+++ b/credit/preblock/__init__.py
@@ -7,7 +7,7 @@ from credit.preblock.regrid import Regridder
 from credit.preblock.concat import ConcatToTensor
 from credit.preblock.norm import ERA5Normalizer
 from credit.preblock.fill_values import FillValues
-from credit.preblock.scaler import BridgeScalerTransformer
+from credit.preblock.scaler import BridgeScalerTransform
 
 
 PREBLOCK_REGISTRY = {
@@ -17,7 +17,7 @@ PREBLOCK_REGISTRY = {
     "concat": ConcatToTensor,
     "era5_normalizer": ERA5Normalizer,
     "fill_values": FillValues,
-    "bridgescaler_transform": BridgeScalerTransformer,
+    "bridgescaler_transform": BridgeScalerTransform,
 }
 
 _VALID_SECTIONS = {"ic_only", "per_step"}
@@ -128,7 +128,7 @@ def _move_batch_to_device(batch, device):
 
 def apply_preblocks_before_scaler(preblocks: nn.ModuleDict, batch: dict, device=None):
     for preblock in preblocks.values():
-        if isinstance(preblock, BridgeScalerTransformer):
+        if isinstance(preblock, BridgeScalerTransform):
             break
         result = preblock(batch)
         if isinstance(result, tuple):

--- a/credit/preblock/concat.py
+++ b/credit/preblock/concat.py
@@ -49,12 +49,12 @@ class ConcatToTensor(BasePreblock):
 
     ``metadata`` keys are passed through as-is (not concatenated).
 
-    In addition to the tensors, two channel maps are attached to metadata under
-    ``metadata["_channel_map"]``:
+    In addition to the tensors, two channel maps are attached to metadata:
 
-    * ``"input"``  — every variable and its slice in the concatenated input tensor.
-    * ``"output"`` — prognostic + diagnostic variables only, with slices
-      reindexed from 0 to match ``y_pred`` channel ordering.
+    * ``metadata["input"]["_channel_map"]``  — every variable and its slice in
+      the concatenated input tensor.
+    * ``metadata["target"]["_channel_map"]`` — prognostic + diagnostic variables
+      only, with slices reindexed from 0 to match ``y_pred`` channel ordering.
 
     Each entry has the form::
 
@@ -67,7 +67,7 @@ class ConcatToTensor(BasePreblock):
 
     Example config::
 
-        type: "concatenate_to_tensor"
+        type: "concat"
         args:
           to_device: true   # set false to skip .to(device) in apply_preblocks
     """
@@ -76,9 +76,9 @@ class ConcatToTensor(BasePreblock):
         super().__init__()
         self.to_device = to_device
 
-    def forward(self, batch):
+    def forward(self, batch: dict | tuple) -> tuple:
         if isinstance(batch, tuple):
-            return batch
+            return batch  # already concatenated — pass through unchanged
         input_tensors = []
         target_tensors = []
         metadata: dict = {"input": {}, "target": {}}
@@ -112,8 +112,10 @@ class ConcatToTensor(BasePreblock):
                         input_channel_map[var_key] = entry
                         input_cursor += n_ch
 
-                        # Also track predictable variables for the output map
-                        # Key format: source/field_type/dim/varname
+                        # Build a separate output channel map for prognostic + diagnostic variables
+                        # only. Its cursor starts at 0 because y_pred from the model contains
+                        # only these predictable outputs — statics and dynamic forcings are
+                        # inputs only and are absent from y_pred.
                         parts = var_key.split("/")
                         if len(parts) >= 2 and parts[1] in _PREDICTABLE_FIELD_TYPES:
                             output_channel_map[var_key] = {

--- a/credit/preblock/log.py
+++ b/credit/preblock/log.py
@@ -1,24 +1,43 @@
-from credit.preblock.base import BasePreblock
+import math
+
 import torch
+
+from credit.preblock.base import BasePreblock
+from credit.preblock._utils import _parse_variable_selection
 
 
 class LogTransform(BasePreblock):
-    """
-    Applies a log transformation to specified variables in a batch dict.
+    """Applies a log transformation with an eps offset to specified variables in a batch dict.
 
-    Expected dict structure:
-        batch[source][data_type]['source/var_type/var_shape/var_name']
+    Applies ``y = log_base(x + eps) - log_base(eps)`` so that ``y = 0`` when
+    ``x = 0``, regardless of ``eps``. Use ``ExpTransform`` in the postblock to
+    invert this with matching ``base`` and ``eps``. Input values should satisfy
+    ``x >= -eps``; values below this produce NaN silently.
 
-    Config example:
+    Operates on ``batch[data_type][source][var_key]`` for each requested
+    ``data_type`` (default: ``["input", "target"]``).
+
+    ``variables`` supports the same shorthand as the scaler: an empty list
+    transforms every variable; partial paths (e.g. ``"era5/prognostic"``) expand
+    to all variables under that hierarchy. Expansion happens lazily on the first
+    forward call.
+
+    Config example::
+
         type: "log_transform"
         args:
             variables:
-                - 'ERA5/prognostic/3D/Q'
-            data_types:     # optional, defaults to ['input', 'target']
-                - 'input'
-                - 'target'
-            base: 'e'       # optional, default 'e'. Options: 'e', '2', '10'
+                - "era5/prognostic/3d/Q"
+            data_types:     # optional, defaults to ["input", "target"]
+                - "input"
+                - "target"
+            base: "e"       # optional, default "e". Options: "e", "2", "10"
             eps: 1.0e-8     # optional, default 1e-8
+
+        # or transform all variables:
+        type: "log_transform"
+        args:
+            variables: []
     """
 
     def __init__(
@@ -30,37 +49,57 @@ class LogTransform(BasePreblock):
     ):
         super().__init__()
         self.variables = variables
+        self.variables_expanded = False
         self.data_types = data_types or ["input", "target"]
-        self.eps = torch.tensor(float(eps))
+        self._eps = float(eps)  # Python float — broadcasts to any device without an explicit .to() call
 
-        # Validate data_types at init
         invalid = set(self.data_types) - set(self.VALID_DATA_TYPES)
         if invalid:
-            raise ValueError(f"Invalid data_types {invalid}. Valid options are {self.VALID_DATA_TYPES}. ")
+            raise ValueError(
+                f"Invalid data_types {invalid}. "
+                f"Valid options are {self.VALID_DATA_TYPES}. "
+                f"Preblocks never operate on 'metadata'."
+            )
 
+        self._base = base  # stored for dispatch in _log()
+        # log(eps) is a constant for a given base, so compute it once here rather than every forward call.
         if base == "e":
-            self._log_fn = torch.log
+            self._log_eps = math.log(self._eps)
         elif base == "2":
-            self._log_fn = torch.log2
+            self._log_eps = math.log2(self._eps)
         elif base == "10":
-            self._log_fn = torch.log10
+            self._log_eps = math.log10(self._eps)
         else:
             raise ValueError(f"Unsupported log base '{base}'. Choose from: 'e', '2', '10'.")
 
+    def _log(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply base-specific logarithm: log_e(x), log_2(x), or log_10(x)."""
+        if self._base == "e":
+            return torch.log(x)
+        elif self._base == "2":
+            return torch.log2(x)
+        else:  # "10"
+            return torch.log10(x)
+
     def forward(self, batch: dict) -> dict:
-        batch = self._copy_batch(batch)
+        if not self.variables_expanded:
+            self.variables = _parse_variable_selection(self.variables, batch, self.data_types)
+            self.variables_expanded = True
+        batch = self._copy_batch(batch)  # shallow copy — avoids mutating the caller's dict
         for var_key in self.variables:
-            source = var_key.split("/")[0]
+            source = var_key.split("/")[0]  # e.g. "era5" from "era5/prognostic/3d/Q"
 
             for data_type in self.data_types:
                 if data_type not in batch:
-                    continue
+                    continue  # data type absent in this batch (e.g. no "target" during inference)
                 if source not in batch[data_type]:
                     raise KeyError(f"LogTransform: source '{source}' not found in batch['{data_type}'].")
                 if var_key not in batch[data_type][source]:
-                    continue
+                    continue  # variable absent in this data type (e.g. statics only exist in "input")
 
                 x = batch[data_type][source][var_key]
-                batch[data_type][source][var_key] = self._log_fn(x + self.eps) - self._log_fn(self.eps)
+                batch[data_type][source][var_key] = (
+                    self._log(x + self._eps) - self._log_eps
+                )  # y = log_base(x + eps) - log_base(eps)
 
         return batch

--- a/credit/preblock/regrid.py
+++ b/credit/preblock/regrid.py
@@ -1,30 +1,54 @@
 import torch
 import numpy as np
 import xarray as xr
+from os.path import expandvars
 from credit.preblock.base import BasePreblock
 
 
 class Regridder(BasePreblock):
-    """
-    Regridding layer using weights file provided by the ESMF library.
+    """Regridding preblock using a sparse weight matrix from an ESMF weights file.
+
+    Applies conservative (or bilinear, depending on the weight file) regridding
+    to selected variables in ``batch[data_type][source][var_key]``. The sparse
+    weight matrix ``W`` (shape ``n_b × n_a``) is assembled once and cached
+    per device; subsequent calls on the same device are free of data movement.
+
     Args:
-        weight_file: path to weights file
-        variables: list of variable keys to regrid (e.g. ['era5/prognostic/3d/T'])
-        data_types: list of data types to process (default: ['input', 'target'])
-        reshape_to_xy: whether to reshape the flattened array back to xy coordinates
-        flip_axis (list, tuple, or None): axes to flip before regridding (e.g. [-1, -2])
+        weight_file: Path to an ESMF-format NetCDF weights file. Supports
+            ``$ENV`` variable expansion.
+        variables: Variable keys to regrid (e.g. ``["era5/prognostic/3d/T"]``).
+        data_types: Batch splits to process. Defaults to ``["input", "target"]``.
+        reshape_to_xy: If ``True`` (default), reshape the flat output back to
+            ``(ny, nx)`` using ``dst_grid_dims`` from the weights file, or from
+            the unique destination coordinates for unstructured grids.
+        flip_axis: Axes to flip on the input before regridding (e.g. ``[-1, -2]``
+            to flip both spatial axes). ``None`` skips flipping.
+
+    Config example::
+
+        type: "regrid"
+        args:
+            weight_file: "$SCRATCH/weights/era5_to_1deg.nc"
+            variables:
+                - "era5/prognostic/3d/T"
+            reshape_to_xy: true
     """
 
     def __init__(
-        self, weight_file, variables: list[str], data_types: list[str] = None, reshape_to_xy=True, flip_axis=None
+        self,
+        weight_file: str,
+        variables: list[str],
+        data_types: list[str] = None,
+        reshape_to_xy: bool = True,
+        flip_axis: list[int] = None,
     ):
         super().__init__()
-        with xr.open_dataset(weight_file) as grid_weights:
+        with xr.open_dataset(expandvars(weight_file)) as grid_weights:
             rows = grid_weights["row"].values - 1  # ESMF indices are 1-based
             cols = grid_weights["col"].values - 1  # ESMF indices are 1-based
-            weights = grid_weights["S"].values
-            n_a = grid_weights.sizes["n_a"]
-            n_b = grid_weights.sizes["n_b"]
+            weights = grid_weights["S"].values  # "S" is ESMF's variable name for the sparse regrid weights
+            n_a = grid_weights.sizes["n_a"]  # number of source grid points
+            n_b = grid_weights.sizes["n_b"]  # number of destination grid points
             raw_dst = grid_weights["dst_grid_dims"].values
             if len(raw_dst) == 2:
                 # Structured weight file: dst_grid_dims = [nlon, nlat]; reverse to [nlat, nlon]
@@ -46,7 +70,7 @@ class Regridder(BasePreblock):
         invalid = set(self.data_types) - set(self.VALID_DATA_TYPES)
         if invalid:
             raise ValueError(f"Invalid data_types {invalid}. Valid options are {self.VALID_DATA_TYPES}.")
-        # store as buffers (CPU tensors)
+        # Register as persistent buffers so they are saved in state_dict and move with the model.
         self.register_buffer("row", torch.from_numpy(rows.astype(np.int64)), persistent=True)
         self.register_buffer("col", torch.from_numpy(cols.astype(np.int64)), persistent=True)
         self.register_buffer("weights", torch.from_numpy(weights.astype(np.float32)), persistent=True)
@@ -54,17 +78,21 @@ class Regridder(BasePreblock):
         self.n_a = int(n_a)
         self.n_b = int(n_b)
         self.dst_shape = dst_shape
+        # Lazy sparse weight cache: built on first use and reused while the device stays the same.
         self._W = None
         self._W_device = None
 
     def _get_W(self, device):
+        """Return the sparse weight matrix on *device*, building and caching it on first call."""
         if self._W is not None and self._W_device == device:
             return self._W
 
         idx = torch.stack([self.row, self.col], dim=0).to(device)
         val = self.weights.to(device=device)
 
-        W = torch.sparse_coo_tensor(idx, val, size=(self.n_b, self.n_a), device=device).coalesce()
+        W = torch.sparse_coo_tensor(
+            idx, val, size=(self.n_b, self.n_a), device=device
+        ).coalesce()  # coalesce merges duplicate indices, required for efficient sparse mm
 
         self._W = W
         self._W_device = device
@@ -75,7 +103,8 @@ class Regridder(BasePreblock):
         W = self._get_W(device)
         if self.flip_axis is not None:
             x = torch.flip(x, dims=self.flip_axis)
-        lead_shape = x.shape[:-2]
+        lead_shape = x.shape[:-2]  # all dims except the last two spatial dims (lat, lon)
+        # Flatten leading dims and transpose: sparse mm expects (n_a, N) input, returns (n_b, N).
         x_flat = x.reshape(-1, self.n_a).T
         y_flat = torch.sparse.mm(W, x_flat).T
 
@@ -86,17 +115,17 @@ class Regridder(BasePreblock):
             return y_flat
 
     def forward(self, batch: dict) -> dict:
-        batch = self._copy_batch(batch)
+        batch = self._copy_batch(batch)  # shallow copy — avoids mutating the caller's dict
         for var_key in self.variables:
-            source = var_key.split("/")[0]
+            source = var_key.split("/")[0]  # e.g. "era5" from "era5/prognostic/3d/T"
 
             for data_type in self.data_types:
                 if data_type not in batch:
-                    continue
+                    continue  # data type absent in this batch (e.g. no "target" during inference)
                 if source not in batch[data_type]:
                     raise KeyError(f"Regridder: source '{source}' not found in batch['{data_type}'].")
                 if var_key not in batch[data_type][source]:
-                    continue
+                    continue  # variable absent in this data type (e.g. statics only exist in "input")
                 batch[data_type][source][var_key] = self._regrid(batch[data_type][source][var_key])
 
         return batch

--- a/credit/preblock/scaler.py
+++ b/credit/preblock/scaler.py
@@ -65,7 +65,7 @@ def combine_scaler_dicts(scaler_dicts):
     return combined
 
 
-class BridgeScalerTransformer(BasePreblock):
+class BridgeScalerTransform(BasePreblock):
     """Scaling preblock using a dictionary of bridgescaler scalers to fit and transform CREDIT state dictionaries.
 
     Applies per-variable z-score scaling (or its inverse) to tensors in a

--- a/credit/preblock/scaler.py
+++ b/credit/preblock/scaler.py
@@ -69,13 +69,28 @@ class BridgeScalerTransformer(BasePreblock):
     """Scaling preblock using a dictionary of bridgescaler scalers to fit and transform CREDIT state dictionaries.
 
     Applies per-variable z-score scaling (or its inverse) to tensors in a
-    nested batch dict of the form `batch[data_type][source][var_key]`.
+    nested batch dict of the form ``batch[data_type][source][var_key]``.
 
-    The scaler dict must have been fit with `bridgescaler.scale_var_dict`
-    using the same nested structure and saved with `bridgescaler.save_scaler_dict`.
+    The scaler dict mirrors the batch structure — it is organized as
+    ``{data_type: {source: {var_key: scaler}}}``. Variables that only exist in
+    one data type (e.g. statics and dynamic forcings are ``"input"`` only) are
+    therefore only scaled in that data type; no special configuration is needed.
+    The scaler dict is produced by running ``credit preprocess``.
 
-    Example config::
+    ``variables`` accepts full variable keys (e.g. ``"era5/prognostic/3d/T"``),
+    partial paths (e.g. ``"era5/prognostic"`` — expands to all variables whose
+    key starts with that prefix), or an empty list (expands to all variables).
+    The expansion is resolved lazily against the actual batch on the first
+    forward call.
 
+    ``data_types`` scopes which data types this scaler instance processes. Its
+    main use case is multi-step rollout training, where the input is already
+    scaled from the previous step and only the target needs to be scaled. Omit
+    it (or pass ``["input", "target"]``) to scale both sides as usual.
+
+    Config examples::
+
+        # Scale specific variables in both input and target (default behaviour)
         type: "bridgescaler_transform"
         args:
             scaler_path: "/path/to/scaler.json"
@@ -83,6 +98,30 @@ class BridgeScalerTransformer(BasePreblock):
                 - "era5/prognostic/3d/T"
                 - "era5/prognostic/3d/U"
             method: "transform"
+
+        # Scale all variables (input and target) by leaving variables empty
+        type: "bridgescaler_transform"
+        args:
+            scaler_path: "/path/to/scaler.json"
+            variables: []
+            method: "transform"
+
+        # Scale all prognostic variables using a partial path
+        type: "bridgescaler_transform"
+        args:
+            scaler_path: "/path/to/scaler.json"
+            variables:
+                - "era5/prognostic"
+            method: "transform"
+
+        # Multi-step rollout: scale only the target (input already scaled)
+        type: "bridgescaler_transform"
+        args:
+            scaler_path: "/path/to/scaler.json"
+            variables: []
+            method: "transform"
+            data_types:
+                - "target"
     """
 
     def __init__(
@@ -92,12 +131,14 @@ class BridgeScalerTransformer(BasePreblock):
         method: str = "transform",
         scaler_type: str = "standard",
         scaler_params=None,
+        data_types: list[str] = None,
     ):
         super().__init__()
         self.variables = variables
         self.variables_expanded = False
         self.method = method
         self.scaler_path = expandvars(scaler_path)
+        self.data_types = data_types
         if scaler_params is None:
             scaler_params = {}
         self.scaler_params = scaler_params
@@ -115,9 +156,16 @@ class BridgeScalerTransformer(BasePreblock):
 
     def forward(self, batch: dict) -> dict:
         if not self.variables_expanded:
-            self.variables = _parse_variable_selection(self.variables, batch)
+            self.variables = _parse_variable_selection(self.variables, batch, self.data_types)
             self.variables_expanded = True
         batch = self._copy_batch(batch)
+        if self.data_types is not None:
+            # Slice to the requested data types — useful in multi-step training where
+            # the input is already scaled but the target still needs to be scaled.
+            sub_batch = {dt: batch[dt] for dt in self.data_types if dt in batch}
+            scaled = scale_var_dict(sub_batch, self.scaler, self.method, self.variables)
+            batch.update(scaled)
+            return batch
         return scale_var_dict(batch, self.scaler, self.method, self.variables)
 
     def fit_scaler_batch(self, batch: dict) -> dict:
@@ -138,9 +186,11 @@ class BridgeScalerTransformer(BasePreblock):
                 f"Cannot fit: a scaler already exists at '{self.scaler_path}'. Remove it to refit from scratch."
             )
         if not self.variables_expanded:
-            self.variables = _parse_variable_selection(self.variables, batch)
+            self.variables = _parse_variable_selection(self.variables, batch, self.data_types)
             self.variables_expanded = True
-        fitted = scale_var_dict(batch, self.scaler_template, "fit", self.variables)
+        # Fit only the requested data types; if data_types is None, fit the full batch.
+        fit_batch = {dt: batch[dt] for dt in self.data_types if dt in batch} if self.data_types is not None else batch
+        fitted = scale_var_dict(fit_batch, self.scaler_template, "fit", self.variables)
         # Merge this batch's fit into the running accumulation (running average of
         # the scaler statistics across batches).
         self.scaler = fitted if self.scaler is None else _combine_scaler_dicts(self.scaler, fitted)

--- a/credit/preblock/scaler.py
+++ b/credit/preblock/scaler.py
@@ -158,13 +158,13 @@ class BridgeScalerTransformer(BasePreblock):
         if not self.variables_expanded:
             self.variables = _parse_variable_selection(self.variables, batch, self.data_types)
             self.variables_expanded = True
-        batch = self._copy_batch(batch)
+        batch = self._copy_batch(batch)  # shallow copy — avoids mutating the caller's dict
         if self.data_types is not None:
             # Slice to the requested data types — useful in multi-step training where
             # the input is already scaled but the target still needs to be scaled.
             sub_batch = {dt: batch[dt] for dt in self.data_types if dt in batch}
             scaled = scale_var_dict(sub_batch, self.scaler, self.method, self.variables)
-            batch.update(scaled)
+            batch.update(scaled)  # write the scaled data types back into the full batch
             return batch
         return scale_var_dict(batch, self.scaler, self.method, self.variables)
 

--- a/credit/preblock/sqrt.py
+++ b/credit/preblock/sqrt.py
@@ -1,30 +1,46 @@
-from credit.preblock.base import BasePreblock
 import torch
+
+from credit.preblock.base import BasePreblock
+from credit.preblock._utils import _parse_variable_selection
 
 
 class SqrtTransform(BasePreblock):
-    """
-    Applies a sqrt transformation to specified variables in a batch dict.
+    """Applies a square-root transformation to specified variables in a batch dict.
 
-    Expected dict structure:
-        batch[source][data_type]['source/var_type/var_shape/var_name']
+    Applies ``y = sqrt(x)``. Use ``SquareTransform`` in the postblock to invert
+    this (``x = y^2``). Input values must be non-negative; negative values
+    produce NaN silently.
 
-    Config example:
+    Operates on ``batch[data_type][source][var_key]`` for each requested
+    ``data_type`` (default: ``["input", "target"]``).
+
+    ``variables`` supports the same shorthand as the scaler: an empty list
+    transforms every variable; partial paths (e.g. ``"era5/prognostic"``) expand
+    to all variables under that hierarchy. Expansion happens lazily on the first
+    forward call.
+
+    Config example::
+
         type: "sqrt_transform"
         args:
             variables:
-                - 'ERA5/prognostic/3D/Q'
-            data_types:     # optional, defaults to ['input', 'target']
-                - 'input'
-                - 'target'
+                - "era5/prognostic/3d/Q"
+            data_types:     # optional, defaults to ["input", "target"]
+                - "input"
+                - "target"
+
+        # or transform all variables:
+        type: "sqrt_transform"
+        args:
+            variables: []
     """
 
     def __init__(self, variables: list[str], data_types: list[str] = None):
         super().__init__()
         self.variables = variables
+        self.variables_expanded = False
         self.data_types = data_types or ["input", "target"]
 
-        # Validate data_types at init
         invalid = set(self.data_types) - set(self.VALID_DATA_TYPES)
         if invalid:
             raise ValueError(
@@ -34,19 +50,22 @@ class SqrtTransform(BasePreblock):
             )
 
     def forward(self, batch: dict) -> dict:
-        batch = self._copy_batch(batch)
+        if not self.variables_expanded:
+            self.variables = _parse_variable_selection(self.variables, batch, self.data_types)
+            self.variables_expanded = True
+        batch = self._copy_batch(batch)  # shallow copy — avoids mutating the caller's dict
         for var_key in self.variables:
-            source = var_key.split("/")[0]
+            source = var_key.split("/")[0]  # e.g. "era5" from "era5/prognostic/3d/Q"
 
             for data_type in self.data_types:
                 if data_type not in batch:
-                    continue
+                    continue  # data type absent in this batch (e.g. no "target" during inference)
                 if source not in batch[data_type]:
                     raise KeyError(f"SqrtTransform: source '{source}' not found in batch['{data_type}'].")
                 if var_key not in batch[data_type][source]:
-                    continue
+                    continue  # variable absent in this data type (e.g. statics only exist in "input")
 
                 x = batch[data_type][source][var_key]
-                batch[data_type][source][var_key] = torch.sqrt(x)
+                batch[data_type][source][var_key] = torch.sqrt(x)  # y = sqrt(x)
 
         return batch

--- a/tests/test_convert_postblock.py
+++ b/tests/test_convert_postblock.py
@@ -55,7 +55,7 @@ def mean_std_nc(tmp_path):
 
 @skip_bs
 def test_convert_writes_postblocks(tmp_path, mean_std_nc):
-    """credit convert on a flat v1 config produces reconstruct + bridgescaler postblocks."""
+    """credit convert on a v1 config produces reconstruct + bridgescaler postblocks."""
     import credit.cli as cli
 
     mean_path, std_path, *_ = mean_std_nc

--- a/tests/test_postblock.py
+++ b/tests/test_postblock.py
@@ -2,7 +2,7 @@
 
 Covers: gen1 physics fixers (TracerFixer, GlobalMassFixer, GlobalWaterFixer,
 GlobalEnergyFixer, GlobalEnergyFixerUpDown), Reconstruct, ExpTransform,
-SquareTransform, and BridgeScalerTransformer (postblock scaler).
+SquareTransform, and BridgeScalerTransform (postblock scaler).
 """
 
 import yaml
@@ -21,7 +21,7 @@ from credit.postblock.gen1 import (
     GlobalEnergyFixer,
     GlobalEnergyFixerUpDown,
 )
-from credit.postblock.scaler import BridgeScalerTransformer as PostScaler
+from credit.postblock.scaler import BridgeScalerTransform as PostScaler
 from credit.postblock.exp import ExpTransform
 from credit.postblock.reconstruct import Reconstruct
 from credit.postblock.square import SquareTransform

--- a/tests/test_postblock.py
+++ b/tests/test_postblock.py
@@ -1,21 +1,36 @@
-"""test_postblock.py provides I/O size tests.
+"""test_postblock.py — tests for credit.postblock modules.
 
--------------------------------------------------------
-Content:
+Covers: gen1 physics fixers (TracerFixer, GlobalMassFixer, GlobalWaterFixer,
+GlobalEnergyFixer, GlobalEnergyFixerUpDown), Reconstruct, ExpTransform,
+SquareTransform, and BridgeScalerTransformer (postblock scaler).
 """
 
 import yaml
 import os
 import logging
 
+import pytest
 import torch
-from credit.postblock.gen1 import GlobalWaterFixer, PostBlock
+from bridgescaler.distributed_tensor import DStandardScalerTensor
+from bridgescaler import save_scaler_dict, scale_var_dict
+from credit.postblock.gen1 import (
+    GlobalWaterFixer,
+    PostBlock,
+    TracerFixer,
+    GlobalMassFixer,
+    GlobalEnergyFixer,
+    GlobalEnergyFixerUpDown,
+)
+from credit.postblock.scaler import BridgeScalerTransformer as PostScaler
+from credit.postblock.exp import ExpTransform
+from credit.postblock.reconstruct import Reconstruct
+from credit.postblock.square import SquareTransform
+from credit.preblock.log import LogTransform
+from credit.preblock.sqrt import SqrtTransform
 from credit.skebs import BackscatterFCNN
-from credit.postblock.gen1 import TracerFixer, GlobalMassFixer, GlobalEnergyFixer, GlobalEnergyFixerUpDown
 from credit.parser import credit_main_parser
 
 
-TEST_FILE_DIR = "/".join(os.path.abspath(__file__).split("/")[:-1])
 CONFIG_FILE_DIR = os.path.join("/".join(os.path.abspath(__file__).split("/")[:-2]), "config")
 
 
@@ -72,12 +87,12 @@ def test_TracerFixer_rand():
     postblock = PostBlock(**conf)
 
     # verify that TracerFixer is registered in the postblock
-    assert any([isinstance(module, TracerFixer) for module in postblock.modules()])
+    assert any(isinstance(module, TracerFixer) for module in postblock.modules())
 
     input_dict = {"y_pred": input_tensor}
     output_tensor = postblock(input_dict)
 
-    # verify negative values
+    # verify all values are non-negative after clamping
     assert output_tensor.min() >= 0
 
 
@@ -108,7 +123,7 @@ def test_GlobalMassFixer_rand():
     postblock = PostBlock(**conf)
 
     # verify that GlobalMassFixer is registered in the postblock
-    assert any([isinstance(module, GlobalMassFixer) for module in postblock.modules()])
+    assert any(isinstance(module, GlobalMassFixer) for module in postblock.modules())
 
     # input tensor
     x = torch.randn((1, 7, 2, 10, 18))
@@ -153,7 +168,7 @@ def test_GlobalWaterFixer_rand():
     postblock = PostBlock(**conf)
 
     # verify that GlobalWaterFixer is registered in the postblock
-    assert any([isinstance(module, GlobalWaterFixer) for module in postblock.modules()])
+    assert any(isinstance(module, GlobalWaterFixer) for module in postblock.modules())
 
     # input tensor
     x = torch.randn((1, 7, 2, 10, 18))
@@ -200,7 +215,7 @@ def test_GlobalEnergyFixer_rand():
     postblock = PostBlock(**conf)
 
     # verify that GlobalEnergyFixer is registered in the postblock
-    assert any([isinstance(module, GlobalEnergyFixer) for module in postblock.modules()])
+    assert any(isinstance(module, GlobalEnergyFixer) for module in postblock.modules())
 
     # input tensor
     x = torch.randn((1, 7, 2, 10, 18))
@@ -250,7 +265,7 @@ def test_GlobalEnergyFixerUpDown_rand():
 
     postblock = PostBlock(**conf)
 
-    assert any([isinstance(m, GlobalEnergyFixerUpDown) for m in postblock.modules()])
+    assert any(isinstance(m, GlobalEnergyFixerUpDown) for m in postblock.modules())
 
     N_VARS = 4 * LEV + 9
     x = torch.randn((1, 4 * LEV, 2, 10, 18))
@@ -291,8 +306,6 @@ class TestReconstruct:
 
     def test_nested_dict_structure(self):
         """Output is y_processed[source][var_key] — source then flat 4-part slash key."""
-        from credit.postblock.reconstruct import Reconstruct
-
         result = Reconstruct()(self._batch_dict(torch.randn(2, 5, 8, 8)))
 
         pred = result["y_processed"]
@@ -302,8 +315,6 @@ class TestReconstruct:
 
     def test_tensor_shapes_4d_input(self):
         """3D var → (B, n_levels, 1, H, W), 2D var → (B, 1, 1, H, W)."""
-        from credit.postblock.reconstruct import Reconstruct
-
         B, H, W = 2, 8, 8
         result = Reconstruct()(self._batch_dict(torch.randn(B, 5, H, W)))
 
@@ -313,8 +324,6 @@ class TestReconstruct:
 
     def test_5d_input_no_extra_dim(self):
         """5D y_pred (B, C, 1, H, W) produces the same shape as 4D — no spurious singleton."""
-        from credit.postblock.reconstruct import Reconstruct
-
         B, H, W = 2, 8, 8
         y_pred_4d = torch.randn(B, 5, H, W)
         y_pred_5d = y_pred_4d.unsqueeze(2)  # (B, 5, 1, H, W)
@@ -328,8 +337,6 @@ class TestReconstruct:
 
     def test_values_match_input_channels(self):
         """Reconstructed tensors contain exactly the channels sliced from y_pred."""
-        from credit.postblock.reconstruct import Reconstruct
-
         B, H, W = 1, 4, 4
         y_pred = torch.randn(B, 5, H, W)
         result = Reconstruct()(self._batch_dict(y_pred))
@@ -346,8 +353,6 @@ class TestReconstruct:
 
     def test_other_keys_pass_through(self):
         """Keys other than 'y_pred' are preserved unchanged."""
-        from credit.postblock.reconstruct import Reconstruct
-
         raw = {"Test_ERA5": {"input": {}}}
         batch = self._batch_dict(torch.randn(1, 5, 4, 4), extra={"input": torch.zeros(1), "_raw": raw})
         result = Reconstruct()(batch)
@@ -356,12 +361,216 @@ class TestReconstruct:
 
     def test_metadata_passthrough(self):
         """metadata dict is returned at the same key, unchanged."""
-        from credit.postblock.reconstruct import Reconstruct
-
         batch = self._batch_dict(torch.randn(1, 5, 4, 4))
         original_meta = batch["metadata"]
         result = Reconstruct()(batch)
         assert result["metadata"] is original_meta
+
+
+# ---------------------------------------------------------------------------
+# ExpTransform and SquareTransform — round-trip and edge-case tests
+# ---------------------------------------------------------------------------
+
+_VAR = "era5/prognostic/3d/Q"
+_SOURCE = "era5"
+
+
+def _postblock_batch_dict(tensor, key="y_processed"):
+    return {key: {_SOURCE: {_VAR: tensor}}}
+
+
+def _preblock_batch(tensor):
+    return {"input": {_SOURCE: {_VAR: tensor}}, "target": {_SOURCE: {_VAR: tensor.clone()}}}
+
+
+def test_postblock_scaler_empty_variables_scales_all(tmp_path):
+    """variables=[] in the postblock scaler scales all variables (not none)."""
+
+    var_names = ["Test_ERA5/prognostic/3d/T", "Test_ERA5/prognostic/3d/U"]
+    source = "Test_ERA5"
+    shape = (4, 4, 1, 8, 8)
+    # Fit on the full {data_type: {source: {var_key: tensor}}} structure — same as preblock scaler
+    x_dict = {"target": {source: {v: torch.randn(*shape) for v in var_names}}}
+    scaler_dict = scale_var_dict(x_dict, DStandardScalerTensor(channels_last=False), method="fit")
+    path = str(tmp_path / "scaler.json")
+    save_scaler_dict(scaler_dict, path)
+
+    y = {source: {v: torch.randn(*shape) for v in var_names}}
+    original = y[source][var_names[0]].clone()
+
+    scaler = PostScaler(scaler_path=path, variables=[], method="transform")
+    result = scaler({"y_processed": y})
+    assert not torch.allclose(result["y_processed"][source][var_names[0]].float(), original.float()), (
+        "empty variables list should scale all variables, not none"
+    )
+
+
+def test_postblock_scaler_partial_path_expansion(tmp_path):
+    """A partial path in variables expands to all matching variables."""
+
+    var_names = ["Test_ERA5/prognostic/3d/T", "Test_ERA5/prognostic/3d/U"]
+    source = "Test_ERA5"
+    shape = (4, 4, 1, 8, 8)
+    # Fit on the full {data_type: {source: {var_key: tensor}}} structure — same as preblock scaler
+    x_dict = {"target": {source: {v: torch.randn(*shape) for v in var_names}}}
+    scaler_dict = scale_var_dict(x_dict, DStandardScalerTensor(channels_last=False), method="fit")
+    path = str(tmp_path / "scaler.json")
+    save_scaler_dict(scaler_dict, path)
+
+    y = {source: {v: torch.randn(*shape) for v in var_names}}
+    originals = {v: y[source][v].clone() for v in var_names}
+
+    scaler = PostScaler(scaler_path=path, variables=[source], method="transform")
+    result = scaler({"y_processed": y})
+    for v in var_names:
+        assert not torch.allclose(result["y_processed"][source][v].float(), originals[v].float()), (
+            f"partial path '{source}' should have expanded to include {v}"
+        )
+
+
+def test_exp_transform_round_trip_base_e():
+    """LogTransform → ExpTransform recovers the original tensor (base e)."""
+    x = torch.rand(2, 4, 1, 8, 8) + 1e-6
+    logged = LogTransform(variables=[_VAR], base="e")(_preblock_batch(x))
+    y = logged["input"][_SOURCE][_VAR]
+    result = ExpTransform(variables=[_VAR], base="e")(_postblock_batch_dict(y))["y_processed"][_SOURCE][_VAR]
+    assert torch.allclose(result, x, atol=1e-5)
+
+
+def test_exp_transform_round_trip_base_2():
+    """LogTransform → ExpTransform recovers the original tensor (base 2)."""
+    x = torch.rand(2, 4, 1, 8, 8) + 1e-6
+    logged = LogTransform(variables=[_VAR], base="2")(_preblock_batch(x))
+    y = logged["input"][_SOURCE][_VAR]
+    result = ExpTransform(variables=[_VAR], base="2")(_postblock_batch_dict(y))["y_processed"][_SOURCE][_VAR]
+    assert torch.allclose(result, x, atol=1e-5)
+
+
+def test_exp_transform_round_trip_base_10():
+    """LogTransform → ExpTransform recovers the original tensor (base 10)."""
+    x = torch.rand(2, 4, 1, 8, 8) + 1e-6
+    logged = LogTransform(variables=[_VAR], base="10")(_preblock_batch(x))
+    y = logged["input"][_SOURCE][_VAR]
+    result = ExpTransform(variables=[_VAR], base="10")(_postblock_batch_dict(y))["y_processed"][_SOURCE][_VAR]
+    assert torch.allclose(result, x, atol=1e-5)
+
+
+def test_exp_transform_skips_missing_variable():
+    """ExpTransform silently skips variables absent from the batch."""
+    exp_block = ExpTransform(variables=["era5/prognostic/3d/MISSING"])
+    result = exp_block(_postblock_batch_dict(torch.ones(1, 1, 1, 4, 4)))
+    assert _VAR in result["y_processed"][_SOURCE]
+
+
+def test_exp_transform_invalid_base():
+    """ExpTransform raises ValueError for an unsupported base."""
+    with pytest.raises(ValueError):
+        ExpTransform(variables=[_VAR], base="7")
+
+
+def test_exp_transform_custom_key():
+    """ExpTransform respects a non-default key."""
+    x = torch.rand(1, 1, 1, 4, 4) + 1e-6
+    logged = LogTransform(variables=[_VAR])(_preblock_batch(x))
+    y = logged["input"][_SOURCE][_VAR]
+    result = ExpTransform(variables=[_VAR], key="my_output")({"my_output": {_SOURCE: {_VAR: y}}})
+    assert torch.allclose(result["my_output"][_SOURCE][_VAR], x, atol=1e-5)
+
+
+def test_square_transform_round_trip():
+    """SqrtTransform → SquareTransform recovers the original tensor."""
+    x = torch.rand(2, 4, 1, 8, 8)
+    sqrted = SqrtTransform(variables=[_VAR])(_preblock_batch(x))
+    y = sqrted["input"][_SOURCE][_VAR]
+    result = SquareTransform(variables=[_VAR])(_postblock_batch_dict(y))["y_processed"][_SOURCE][_VAR]
+    assert torch.allclose(result, x, atol=1e-5)
+
+
+def test_square_transform_skips_missing_variable():
+    """SquareTransform silently skips variables absent from the batch."""
+    square_block = SquareTransform(variables=["era5/prognostic/3d/MISSING"])
+    result = square_block(_postblock_batch_dict(torch.ones(1, 1, 1, 4, 4)))
+    assert _VAR in result["y_processed"][_SOURCE]
+
+
+def test_square_transform_negative_input():
+    """Squaring slightly negative values gives non-negative results."""
+    y = torch.tensor([-0.01, 0.0, 0.1, 1.0]).reshape(1, 4, 1, 1, 1)
+    result = SquareTransform(variables=[_VAR])(_postblock_batch_dict(y))["y_processed"][_SOURCE][_VAR]
+    assert (result >= 0).all()
+
+
+# ---------------------------------------------------------------------------
+# ExpTransform and SquareTransform — lazy expansion (variables=[] and partial paths)
+# ---------------------------------------------------------------------------
+
+_LAZY_VARS = ["era5/prognostic/3d/Q", "era5/prognostic/3d/T", "era5/static/2d/Z"]
+_LAZY_SOURCE = "era5"
+_LAZY_SHAPE = (1, 1, 1, 4, 4)
+
+
+def _lazy_postblock_batch(key="y_processed"):
+    return {key: {_LAZY_SOURCE: {v: torch.rand(*_LAZY_SHAPE) + 0.1 for v in _LAZY_VARS}}}
+
+
+def test_exp_transform_empty_variables_transforms_all():
+    """variables=[] expands to all variables and transforms every one."""
+    batch = _lazy_postblock_batch()
+    originals = {v: batch["y_processed"][_LAZY_SOURCE][v].clone() for v in _LAZY_VARS}
+    result = ExpTransform(variables=[])(batch)
+    for v in _LAZY_VARS:
+        assert not torch.allclose(result["y_processed"][_LAZY_SOURCE][v].float(), originals[v].float()), (
+            f"variables=[] should have transformed {v}"
+        )
+
+
+def test_exp_transform_partial_path_expands_to_matching_vars():
+    """A partial path transforms exactly the variables under that hierarchy."""
+    batch = _lazy_postblock_batch()
+    prog_vars = [v for v in _LAZY_VARS if "prognostic" in v]
+    non_prog_vars = [v for v in _LAZY_VARS if "prognostic" not in v]
+    originals = {v: batch["y_processed"][_LAZY_SOURCE][v].clone() for v in _LAZY_VARS}
+
+    result = ExpTransform(variables=[f"{_LAZY_SOURCE}/prognostic"])(batch)
+
+    for v in prog_vars:
+        assert not torch.allclose(result["y_processed"][_LAZY_SOURCE][v].float(), originals[v].float()), (
+            f"partial path should have transformed {v}"
+        )
+    for v in non_prog_vars:
+        assert torch.allclose(result["y_processed"][_LAZY_SOURCE][v].float(), originals[v].float()), (
+            f"partial path should NOT have transformed {v}"
+        )
+
+
+def test_square_transform_empty_variables_transforms_all():
+    """variables=[] expands to all variables and transforms every one."""
+    batch = {"y_processed": {_LAZY_SOURCE: {v: torch.rand(*_LAZY_SHAPE) for v in _LAZY_VARS}}}
+    originals = {v: batch["y_processed"][_LAZY_SOURCE][v].clone() for v in _LAZY_VARS}
+    result = SquareTransform(variables=[])(batch)
+    for v in _LAZY_VARS:
+        assert not torch.allclose(result["y_processed"][_LAZY_SOURCE][v].float(), originals[v].float()), (
+            f"variables=[] should have transformed {v}"
+        )
+
+
+def test_square_transform_partial_path_expands_to_matching_vars():
+    """A partial path transforms exactly the variables under that hierarchy."""
+    batch = {"y_processed": {_LAZY_SOURCE: {v: torch.rand(*_LAZY_SHAPE) for v in _LAZY_VARS}}}
+    prog_vars = [v for v in _LAZY_VARS if "prognostic" in v]
+    non_prog_vars = [v for v in _LAZY_VARS if "prognostic" not in v]
+    originals = {v: batch["y_processed"][_LAZY_SOURCE][v].clone() for v in _LAZY_VARS}
+
+    result = SquareTransform(variables=[f"{_LAZY_SOURCE}/prognostic"])(batch)
+
+    for v in prog_vars:
+        assert not torch.allclose(result["y_processed"][_LAZY_SOURCE][v].float(), originals[v].float()), (
+            f"partial path should have transformed {v}"
+        )
+    for v in non_prog_vars:
+        assert torch.allclose(result["y_processed"][_LAZY_SOURCE][v].float(), originals[v].float()), (
+            f"partial path should NOT have transformed {v}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_preblock.py
+++ b/tests/test_preblock.py
@@ -1,21 +1,23 @@
 """test_preblock.py — unit tests for credit.preblock modules."""
 
+import copy
+
 import numpy as np
 import pytest
 import torch
+import torch.nn as nn
 import xarray as xr
 
-try:
-    from bridgescaler.distributed_tensor import DStandardScalerTensor
-    from bridgescaler import save_scaler_dict, scale_var_dict
-    from credit.preblock.scaler import BridgeScalerTransformer
-
-    _BRIDGESCALER_AVAILABLE = True
-except (ImportError, Exception):
-    _BRIDGESCALER_AVAILABLE = False
-
+from bridgescaler.distributed_tensor import DStandardScalerTensor
+from bridgescaler import save_scaler_dict, scale_var_dict
+from credit.preblock import apply_preblocks, build_preblocks
+from credit.preblock.concat import ConcatToTensor
+from credit.preblock.log import LogTransform
 from credit.preblock.regrid import Regridder
+from credit.preblock.scaler import BridgeScalerTransformer
+from credit.preblock.sqrt import SqrtTransform
 from credit.preblock._utils import _parse_variable_selection
+from credit.postblock import build_postblocks
 
 
 def create_synthetic_data() -> dict:
@@ -25,14 +27,14 @@ def create_synthetic_data() -> dict:
     Structure: data[data_type][source][var_name]
     - data_type: "input" | "target"
     - source: "Test_ERA5"
-    - var_name: "Test_ERA5/pronostic/3d/T" | ...
+    - var_name: "Test_ERA5/prognostic/3d/T" | ...
     - tensor shape: (100, 16, 1, 8, 8)
     """
     shape = (100, 16, 1, 8, 8)
     var_names = [
-        "Test_ERA5/pronostic/3d/T",
-        "Test_ERA5/pronostic/3d/U",
-        "Test_ERA5/pronostic/3d/V",
+        "Test_ERA5/prognostic/3d/T",
+        "Test_ERA5/prognostic/3d/U",
+        "Test_ERA5/prognostic/3d/V",
     ]
 
     return {split: {"Test_ERA5": {var: torch.randn(*shape) for var in var_names}} for split in ("input", "target")}
@@ -100,23 +102,23 @@ def weight_file(tmp_path):
 def test_regrid_output_shape(weight_file):
     """Downsampling regrid produces the destination grid shape for all splits."""
     path, n_src_lat, n_src_lon, n_dst_lat, n_dst_lon = weight_file
-    variables = ["Test_ERA5/pronostic/3d/T"]
+    variables = ["Test_ERA5/prognostic/3d/T"]
     regrid = Regridder(path, variables=variables)
     batch = create_synthetic_data()
     result = regrid(batch)
     for split in ("input", "target"):
-        assert result[split]["Test_ERA5"]["Test_ERA5/pronostic/3d/T"].shape == (100, 16, 1, n_dst_lat, n_dst_lon)
+        assert result[split]["Test_ERA5"]["Test_ERA5/prognostic/3d/T"].shape == (100, 16, 1, n_dst_lat, n_dst_lon)
 
 
 def test_regrid_uniform_input(weight_file):
     """Block-average regrid: uniform input maps to uniform output of the same value."""
     path, n_src_lat, n_src_lon, n_dst_lat, n_dst_lon = weight_file
-    variables = ["Test_ERA5/pronostic/3d/T"]
+    variables = ["Test_ERA5/prognostic/3d/T"]
     regrid = Regridder(path, variables=variables)
-    batch = {"input": {"Test_ERA5": {"Test_ERA5/pronostic/3d/T": torch.ones(1, 1, 1, n_src_lat, n_src_lon)}}}
+    batch = {"input": {"Test_ERA5": {"Test_ERA5/prognostic/3d/T": torch.ones(1, 1, 1, n_src_lat, n_src_lon)}}}
     result = regrid(batch)
     assert torch.allclose(
-        result["input"]["Test_ERA5"]["Test_ERA5/pronostic/3d/T"],
+        result["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/T"],
         torch.ones(1, 1, 1, n_dst_lat, n_dst_lon),
         atol=1e-5,
     )
@@ -125,34 +127,26 @@ def test_regrid_uniform_input(weight_file):
 def test_regrid_reshape_false(weight_file):
     """reshape_to_xy=False returns a flat (prod(lead_dims), n_b) tensor."""
     path, n_src_lat, n_src_lon, n_dst_lat, n_dst_lon = weight_file
-    variables = ["Test_ERA5/pronostic/3d/T"]
+    variables = ["Test_ERA5/prognostic/3d/T"]
     regrid = Regridder(path, variables=variables, reshape_to_xy=False)
     batch = create_synthetic_data()
     result = regrid(batch)
-    assert result["input"]["Test_ERA5"]["Test_ERA5/pronostic/3d/T"].shape == (100 * 16 * 1, n_dst_lat * n_dst_lon)
+    assert result["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/T"].shape == (100 * 16 * 1, n_dst_lat * n_dst_lon)
 
 
 def test_regrid_flip_axis(weight_file):
     """flip_axis is applied to the input before regridding."""
-    import copy
-
     path, n_src_lat, n_src_lon, n_dst_lat, n_dst_lon = weight_file
-    variables = ["Test_ERA5/pronostic/3d/T"]
+    variables = ["Test_ERA5/prognostic/3d/T"]
     regrid = Regridder(path, variables=variables)
     regrid_flip = Regridder(path, variables=variables, flip_axis=[-1])
     batch = create_synthetic_data()
     result = regrid(copy.deepcopy(batch))
     result_flip = regrid_flip(copy.deepcopy(batch))
     assert not torch.allclose(
-        result["input"]["Test_ERA5"]["Test_ERA5/pronostic/3d/T"],
-        result_flip["input"]["Test_ERA5"]["Test_ERA5/pronostic/3d/T"],
+        result["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/T"],
+        result_flip["input"]["Test_ERA5"]["Test_ERA5/prognostic/3d/T"],
     )
-
-
-_skip_bridgescaler = pytest.mark.skipif(
-    not _BRIDGESCALER_AVAILABLE,
-    reason="bridgescaler not available in this environment",
-)
 
 
 # ---------------------------------------------------------------------------
@@ -180,10 +174,7 @@ def scaler_file(tmp_path):
 # Scaler tests
 # ---------------------------------------------------------------------------
 
-# VAR_NAMES = ["era5/pronostic/3d/T", "era5/pronostic/3d/U", "era5/pronostic/3d/V"]
 
-
-@_skip_bridgescaler
 def test_scaler_output_shape(scaler_file):
     """Transform preserves the input tensor shape for every variable."""
     path, variables, data = scaler_file
@@ -194,7 +185,6 @@ def test_scaler_output_shape(scaler_file):
         assert result["input"]["Test_ERA5"][v].shape == original_shapes[v]
 
 
-@_skip_bridgescaler
 def test_scaler_transform_changes_values(scaler_file):
     """Transform produces different values than the raw input."""
     path, variables, data = scaler_file
@@ -205,7 +195,6 @@ def test_scaler_transform_changes_values(scaler_file):
     assert not torch.allclose(result["input"]["Test_ERA5"][var].float(), original.float())
 
 
-@_skip_bridgescaler
 def test_scaler_round_trip(scaler_file):
     """transform followed by inverse recovers the original tensor."""
     path, variables, data = scaler_file
@@ -219,9 +208,69 @@ def test_scaler_round_trip(scaler_file):
     assert torch.allclose(data["input"]["Test_ERA5"][var].float(), original.float(), atol=1e-5)
 
 
+def test_scaler_data_types_input_only(scaler_file):
+    """data_types=['input'] scales input tensors and leaves target tensors unchanged."""
+    path, variables, data = scaler_file
+    var = list(variables)[0]
+    input_before = data["input"]["Test_ERA5"][var].clone()
+    target_before = data["target"]["Test_ERA5"][var].clone()
+
+    scaler = BridgeScalerTransformer(
+        scaler_path=path, variables=list(variables), method="transform", data_types=["input"]
+    )
+    result = scaler(data)
+
+    assert not torch.allclose(result["input"]["Test_ERA5"][var].float(), input_before.float()), (
+        "input tensor should have been scaled"
+    )
+    assert torch.allclose(result["target"]["Test_ERA5"][var].float(), target_before.float()), (
+        "target tensor must not be touched when data_types=['input']"
+    )
+
+
+def test_scaler_data_types_target_only(scaler_file):
+    """data_types=['target'] scales target tensors and leaves input tensors unchanged."""
+    path, variables, data = scaler_file
+    var = list(variables)[0]
+    input_before = data["input"]["Test_ERA5"][var].clone()
+    target_before = data["target"]["Test_ERA5"][var].clone()
+
+    scaler = BridgeScalerTransformer(
+        scaler_path=path, variables=list(variables), method="transform", data_types=["target"]
+    )
+    result = scaler(data)
+
+    assert torch.allclose(result["input"]["Test_ERA5"][var].float(), input_before.float()), (
+        "input tensor must not be touched when data_types=['target']"
+    )
+    assert not torch.allclose(result["target"]["Test_ERA5"][var].float(), target_before.float()), (
+        "target tensor should have been scaled"
+    )
+
+
+def test_scaler_data_types_none_scales_all(scaler_file):
+    """data_types=None (default) scales both input and target tensors."""
+    path, variables, data = scaler_file
+    var = list(variables)[0]
+    input_before = data["input"]["Test_ERA5"][var].clone()
+    target_before = data["target"]["Test_ERA5"][var].clone()
+
+    scaler = BridgeScalerTransformer(scaler_path=path, variables=list(variables), method="transform")
+    result = scaler(data)
+
+    assert not torch.allclose(result["input"]["Test_ERA5"][var].float(), input_before.float()), (
+        "input tensor should have been scaled with data_types=None"
+    )
+    assert not torch.allclose(result["target"]["Test_ERA5"][var].float(), target_before.float()), (
+        "target tensor should have been scaled with data_types=None"
+    )
+
+
 # ---------------------------------------------------------------------------
 # _parse_variable_selection
 # ---------------------------------------------------------------------------
+
+
 def _selection_state() -> dict:
     """A state dict following the CREDIT convention: state[data_type][source][var_name].
 
@@ -358,57 +407,40 @@ class TestBuildPreblocks:
 
     def test_flat_format_raises_value_error(self):
         """Old flat format (no ic_only/per_step sections) raises ValueError."""
-        from credit.preblock import build_preblocks
-
         with pytest.raises(ValueError, match="unexpected top-level keys"):
             build_preblocks({"concat": {"type": "concat"}})
 
     def test_unknown_section_key_raises(self):
         """A key that is neither ic_only nor per_step raises ValueError."""
-        from credit.preblock import build_preblocks
-
         with pytest.raises(ValueError, match="unexpected top-level keys"):
             build_preblocks({"per_step": {}, "bad_section": {}})
 
     def test_valid_two_section_per_step_builds(self):
         """per_step section builds an nn.ModuleDict with the named block."""
-        import torch.nn as nn
-        from credit.preblock import build_preblocks
-
         preblocks = build_preblocks({"per_step": {"concat": {"type": "concat"}}}, phase="per_step")
         assert isinstance(preblocks, nn.ModuleDict)
         assert "concat" in preblocks
 
     def test_valid_two_section_ic_only_builds(self):
         """ic_only section builds an nn.ModuleDict with the named block."""
-        import torch.nn as nn
-        from credit.preblock import build_preblocks
-
         preblocks = build_preblocks({"ic_only": {"concat": {"type": "concat"}}}, phase="ic_only")
         assert isinstance(preblocks, nn.ModuleDict)
         assert "concat" in preblocks
 
     def test_empty_config_returns_empty_module_dict(self):
         """Empty config builds an empty ModuleDict without error."""
-        import torch.nn as nn
-        from credit.preblock import build_preblocks
-
         preblocks = build_preblocks({}, phase="per_step")
         assert isinstance(preblocks, nn.ModuleDict)
         assert len(preblocks) == 0
 
     def test_missing_phase_returns_empty_module_dict(self):
         """Requesting a phase absent from the config returns an empty ModuleDict."""
-        from credit.preblock import build_preblocks
-
         # ic_only is configured but per_step is requested
         preblocks = build_preblocks({"ic_only": {"concat": {"type": "concat"}}}, phase="per_step")
         assert len(preblocks) == 0
 
     def test_invalid_phase_raises(self):
         """An unrecognized phase name raises ValueError."""
-        from credit.preblock import build_preblocks
-
         with pytest.raises(ValueError, match="phase must be one of"):
             build_preblocks({}, phase="invalid_phase")
 
@@ -418,23 +450,16 @@ class TestBuildPostblocks:
 
     def test_flat_format_raises_value_error(self):
         """Old flat postblock format raises ValueError."""
-        from credit.postblock import build_postblocks
-
         with pytest.raises(ValueError, match="unexpected top-level keys"):
             build_postblocks({"reconstruct": {"type": "reconstruct"}})
 
     def test_valid_two_section_per_step_builds(self):
         """per_step section builds a ModuleDict with the named block."""
-        import torch.nn as nn
-        from credit.postblock import build_postblocks
-
         postblocks = build_postblocks({"per_step": {"reconstruct": {"type": "reconstruct"}}}, phase="per_step")
         assert isinstance(postblocks, nn.ModuleDict)
         assert "reconstruct" in postblocks
 
     def test_empty_config_returns_empty_module_dict(self):
-        from credit.postblock import build_postblocks
-
         postblocks = build_postblocks({}, phase="per_step")
         assert len(postblocks) == 0
 
@@ -449,8 +474,6 @@ class TestConcatToTensorChannelOrder:
 
     def test_channel_order_follows_field_type_rank(self):
         """prognostic(0) < static(1) < dynamic_forcing(2) regardless of dict insertion order."""
-        from credit.preblock.concat import ConcatToTensor
-
         B, H, W = 1, 4, 4
         # Insert in reverse-rank order to verify the sort is applied
         batch = {
@@ -472,8 +495,6 @@ class TestConcatToTensorChannelOrder:
 
     def test_input_channel_map_contains_all_variables(self):
         """input _channel_map has an entry for every variable key in the batch."""
-        from credit.preblock.concat import ConcatToTensor
-
         B, H, W = 1, 4, 4
         var_keys = [
             "era5/prognostic/2d/T",
@@ -489,8 +510,6 @@ class TestConcatToTensorChannelOrder:
 
     def test_target_channel_map_excludes_non_predictable_fields(self):
         """Target _channel_map includes only prognostic and diagnostic; not static or dynfrc."""
-        from credit.preblock.concat import ConcatToTensor
-
         B, H, W = 1, 4, 4
         batch = {
             "input": {
@@ -512,8 +531,6 @@ class TestConcatToTensorChannelOrder:
 
     def test_channel_map_slices_are_non_overlapping(self):
         """Each variable's slice in _channel_map is disjoint from all others."""
-        from credit.preblock.concat import ConcatToTensor
-
         B, H, W = 1, 4, 4
         batch = {
             "input": {
@@ -546,8 +563,6 @@ class TestApplyPreblocks:
 
     def test_return_format_with_concat_has_x_y_metadata(self):
         """apply_preblocks returns {"x", "y", "metadata"} when ConcatToTensor is the final block."""
-        from credit.preblock import apply_preblocks, build_preblocks
-
         preblocks = build_preblocks({"per_step": {"concat": {"type": "concat"}}}, phase="per_step")
         B, H, W = 1, 4, 4
         batch = {
@@ -562,8 +577,6 @@ class TestApplyPreblocks:
 
     def test_metadata_contains_input_and_target_channel_maps(self):
         """Metadata from apply_preblocks contains populated _channel_map for input and target."""
-        from credit.preblock import apply_preblocks, build_preblocks
-
         preblocks = build_preblocks({"per_step": {"concat": {"type": "concat"}}}, phase="per_step")
         B, H, W = 1, 4, 4
         var_key = "era5/prognostic/2d/T"
@@ -581,8 +594,6 @@ class TestApplyPreblocks:
 
     def test_does_not_mutate_input_tensor_values(self):
         """apply_preblocks does not modify the caller's batch tensors in-place."""
-        from credit.preblock import apply_preblocks, build_preblocks
-
         preblocks = build_preblocks({"per_step": {"concat": {"type": "concat"}}}, phase="per_step")
         B, H, W = 1, 4, 4
         original_tensor = torch.ones(B, 1, 1, H, W)
@@ -598,8 +609,6 @@ class TestApplyPreblocks:
 
     def test_does_not_add_keys_to_caller_batch(self):
         """apply_preblocks does not add or remove keys from the caller's batch dict."""
-        from credit.preblock import apply_preblocks, build_preblocks
-
         preblocks = build_preblocks({"per_step": {"concat": {"type": "concat"}}}, phase="per_step")
         B, H, W = 1, 4, 4
         batch = {
@@ -612,8 +621,6 @@ class TestApplyPreblocks:
 
     def test_empty_chain_returns_nested_dict_unchanged(self):
         """An empty preblock chain passes the batch through unmodified."""
-        from credit.preblock import apply_preblocks, build_preblocks
-
         preblocks = build_preblocks({}, phase="per_step")
         B, H, W = 1, 4, 4
         batch = {
@@ -634,8 +641,6 @@ class TestApplyPreblocks:
         following ``x.to(device)`` raised AttributeError/ValueError. Reading result["x"]
         is the contract the apps must use.
         """
-        from credit.preblock import apply_preblocks, build_preblocks
-
         preblocks = build_preblocks({"per_step": {"concat": {"type": "concat"}}}, phase="per_step")
         B, H, W = 1, 4, 4
         batch = {
@@ -648,3 +653,92 @@ class TestApplyPreblocks:
         assert isinstance(result["x"], torch.Tensor)
         # the tensor is usable as a tensor (what the rollout app does next)
         assert result["x"].float().shape[0] == B
+
+
+# ---------------------------------------------------------------------------
+# LogTransform and SqrtTransform — lazy expansion (variables=[] and partial paths)
+# ---------------------------------------------------------------------------
+
+_TRANSFORM_SHAPE = (2, 4, 1, 4, 4)
+_TRANSFORM_SOURCE = "era5"
+_TRANSFORM_VARS = [
+    "era5/prognostic/3d/T",
+    "era5/prognostic/3d/U",
+    "era5/static/2d/Z",
+]
+
+
+def _transform_batch_positive():
+    """Batch with strictly positive values for transforms that require positivity."""
+    return {
+        split: {_TRANSFORM_SOURCE: {v: torch.rand(*_TRANSFORM_SHAPE) + 0.1 for v in _TRANSFORM_VARS}}
+        for split in ("input", "target")
+    }
+
+
+def _transform_batch_nonneg():
+    """Batch with non-negative values for SqrtTransform."""
+    return {
+        split: {_TRANSFORM_SOURCE: {v: torch.rand(*_TRANSFORM_SHAPE) for v in _TRANSFORM_VARS}}
+        for split in ("input", "target")
+    }
+
+
+def test_log_transform_empty_variables_transforms_all():
+    """variables=[] expands to all variables and transforms every one of them."""
+    batch = _transform_batch_positive()
+    originals = {v: batch["input"][_TRANSFORM_SOURCE][v].clone() for v in _TRANSFORM_VARS}
+    result = LogTransform(variables=[])(batch)
+    for v in _TRANSFORM_VARS:
+        assert not torch.allclose(result["input"][_TRANSFORM_SOURCE][v].float(), originals[v].float()), (
+            f"variables=[] should have transformed {v}"
+        )
+
+
+def test_log_transform_partial_path_expands_to_matching_vars():
+    """A partial path transforms exactly the variables under that hierarchy."""
+    batch = _transform_batch_positive()
+    prog_vars = [v for v in _TRANSFORM_VARS if "prognostic" in v]
+    non_prog_vars = [v for v in _TRANSFORM_VARS if "prognostic" not in v]
+    originals = {v: batch["input"][_TRANSFORM_SOURCE][v].clone() for v in _TRANSFORM_VARS}
+
+    result = LogTransform(variables=[f"{_TRANSFORM_SOURCE}/prognostic"])(batch)
+
+    for v in prog_vars:
+        assert not torch.allclose(result["input"][_TRANSFORM_SOURCE][v].float(), originals[v].float()), (
+            f"partial path should have transformed {v}"
+        )
+    for v in non_prog_vars:
+        assert torch.allclose(result["input"][_TRANSFORM_SOURCE][v].float(), originals[v].float()), (
+            f"partial path should NOT have transformed {v}"
+        )
+
+
+def test_sqrt_transform_empty_variables_transforms_all():
+    """variables=[] expands to all variables and transforms every one of them."""
+    batch = _transform_batch_nonneg()
+    originals = {v: batch["input"][_TRANSFORM_SOURCE][v].clone() for v in _TRANSFORM_VARS}
+    result = SqrtTransform(variables=[])(batch)
+    for v in _TRANSFORM_VARS:
+        assert not torch.allclose(result["input"][_TRANSFORM_SOURCE][v].float(), originals[v].float()), (
+            f"variables=[] should have transformed {v}"
+        )
+
+
+def test_sqrt_transform_partial_path_expands_to_matching_vars():
+    """A partial path transforms exactly the variables under that hierarchy."""
+    batch = _transform_batch_nonneg()
+    prog_vars = [v for v in _TRANSFORM_VARS if "prognostic" in v]
+    non_prog_vars = [v for v in _TRANSFORM_VARS if "prognostic" not in v]
+    originals = {v: batch["input"][_TRANSFORM_SOURCE][v].clone() for v in _TRANSFORM_VARS}
+
+    result = SqrtTransform(variables=[f"{_TRANSFORM_SOURCE}/prognostic"])(batch)
+
+    for v in prog_vars:
+        assert not torch.allclose(result["input"][_TRANSFORM_SOURCE][v].float(), originals[v].float()), (
+            f"partial path should have transformed {v}"
+        )
+    for v in non_prog_vars:
+        assert torch.allclose(result["input"][_TRANSFORM_SOURCE][v].float(), originals[v].float()), (
+            f"partial path should NOT have transformed {v}"
+        )

--- a/tests/test_preblock.py
+++ b/tests/test_preblock.py
@@ -14,7 +14,7 @@ from credit.preblock import apply_preblocks, build_preblocks
 from credit.preblock.concat import ConcatToTensor
 from credit.preblock.log import LogTransform
 from credit.preblock.regrid import Regridder
-from credit.preblock.scaler import BridgeScalerTransformer
+from credit.preblock.scaler import BridgeScalerTransform
 from credit.preblock.sqrt import SqrtTransform
 from credit.preblock._utils import _parse_variable_selection
 from credit.postblock import build_postblocks
@@ -178,7 +178,7 @@ def scaler_file(tmp_path):
 def test_scaler_output_shape(scaler_file):
     """Transform preserves the input tensor shape for every variable."""
     path, variables, data = scaler_file
-    scaler = BridgeScalerTransformer(scaler_path=path, variables=list(variables), method="transform")
+    scaler = BridgeScalerTransform(scaler_path=path, variables=list(variables), method="transform")
     original_shapes = {v: data["input"]["Test_ERA5"][v].shape for v in variables}
     result = scaler(data)
     for v in variables:
@@ -188,7 +188,7 @@ def test_scaler_output_shape(scaler_file):
 def test_scaler_transform_changes_values(scaler_file):
     """Transform produces different values than the raw input."""
     path, variables, data = scaler_file
-    scaler = BridgeScalerTransformer(scaler_path=path, variables=list(variables), method="transform")
+    scaler = BridgeScalerTransform(scaler_path=path, variables=list(variables), method="transform")
     var = list(variables)[0]
     original = data["input"]["Test_ERA5"][var].clone()
     result = scaler(data)
@@ -199,8 +199,8 @@ def test_scaler_round_trip(scaler_file):
     """transform followed by inverse recovers the original tensor."""
     path, variables, data = scaler_file
     var_list = list(variables)
-    fwd = BridgeScalerTransformer(scaler_path=path, variables=var_list, method="transform")
-    inv = BridgeScalerTransformer(scaler_path=path, variables=var_list, method="inverse_transform")
+    fwd = BridgeScalerTransform(scaler_path=path, variables=var_list, method="transform")
+    inv = BridgeScalerTransform(scaler_path=path, variables=var_list, method="inverse_transform")
     var = var_list[0]
     original = data["input"]["Test_ERA5"][var].clone()
     data = fwd(data)
@@ -215,7 +215,7 @@ def test_scaler_data_types_input_only(scaler_file):
     input_before = data["input"]["Test_ERA5"][var].clone()
     target_before = data["target"]["Test_ERA5"][var].clone()
 
-    scaler = BridgeScalerTransformer(
+    scaler = BridgeScalerTransform(
         scaler_path=path, variables=list(variables), method="transform", data_types=["input"]
     )
     result = scaler(data)
@@ -235,7 +235,7 @@ def test_scaler_data_types_target_only(scaler_file):
     input_before = data["input"]["Test_ERA5"][var].clone()
     target_before = data["target"]["Test_ERA5"][var].clone()
 
-    scaler = BridgeScalerTransformer(
+    scaler = BridgeScalerTransform(
         scaler_path=path, variables=list(variables), method="transform", data_types=["target"]
     )
     result = scaler(data)
@@ -255,7 +255,7 @@ def test_scaler_data_types_none_scales_all(scaler_file):
     input_before = data["input"]["Test_ERA5"][var].clone()
     target_before = data["target"]["Test_ERA5"][var].clone()
 
-    scaler = BridgeScalerTransformer(scaler_path=path, variables=list(variables), method="transform")
+    scaler = BridgeScalerTransform(scaler_path=path, variables=list(variables), method="transform")
     result = scaler(data)
 
     assert not torch.allclose(result["input"]["Test_ERA5"][var].float(), input_before.float()), (

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -15,10 +15,10 @@ which require an initialised process group):
 
     load_dataset -> load_dataloader -> cycle -> build_preblocks
         -> apply_preblocks_before_scaler (log transform)
-        -> BridgeScalerTransformer.fit_scaler_batch   (repeated, one call per batch)
+        -> BridgeScalerTransform.fit_scaler_batch   (repeated, one call per batch)
 
 The fitted scalers are then combined across rounds (mirroring the cross-rank ``np.sum`` in ``main``), saved, and
-reloaded through ``BridgeScalerTransformer`` to verify the transform path.
+reloaded through ``BridgeScalerTransform`` to verify the transform path.
 
 The data is pulled from the public WeatherBench2 64x32 (~5.6 deg) GCS store. If the store is unreachable the
 network-dependent tests skip rather than fail. ``channels_last=False`` is used so the scalers compute per-level
@@ -35,7 +35,7 @@ import torch
 try:
     from bridgescaler import save_scaler_dict, scale_var_dict  # noqa: F401
     from credit.preblock import build_preblocks, apply_preblocks_before_scaler
-    from credit.preblock.scaler import BridgeScalerTransformer
+    from credit.preblock.scaler import BridgeScalerTransform
     from credit.trainers.utils import load_dataset, load_dataloader, cycle
 
     _DEPS_AVAILABLE = True
@@ -122,14 +122,14 @@ def _make_conf(save_loc: str, scaler_path: str) -> dict:
 
 
 def _fit_over_rounds(scaler_type: str, batches: list, scaler_path: str):
-    """Run BridgeScalerTransformer.fit_scaler_batch over every batch.
+    """Run BridgeScalerTransform.fit_scaler_batch over every batch.
 
     fit_scaler_batch accumulates the fit internally (running merge across calls),
     so the final return value is the combined fit over all batches.
 
     Returns ``(transformer, combined_scaler_dict)``.
     """
-    transformer = BridgeScalerTransformer(
+    transformer = BridgeScalerTransform(
         scaler_path=scaler_path,
         variables=[],  # expand to all variables present in the batch
         method="transform",
@@ -288,7 +288,7 @@ def test_fit_standard_temperature_values_reasonable(processed_batches, tmp_path)
 @_skip_no_deps
 @pytest.mark.parametrize("scaler_type", SCALER_TYPES)
 def test_transform_distribution_properties(scaler_type, processed_batches, tmp_path):
-    """Save the fitted scaler, reload it through BridgeScalerTransformer, and check
+    """Save the fitted scaler, reload it through BridgeScalerTransform, and check
     that transforming the data yields the distribution each scaler promises."""
     batches, _ = processed_batches
     _, combined = _fit_over_rounds(scaler_type, batches, str(tmp_path / "fit.json"))
@@ -296,7 +296,7 @@ def test_transform_distribution_properties(scaler_type, processed_batches, tmp_p
     # Persist and reload through the transformer's own load path (method="transform").
     scaler_file = str(tmp_path / "combined.json")
     save_scaler_dict(combined, scaler_file)
-    transformer = BridgeScalerTransformer(
+    transformer = BridgeScalerTransform(
         scaler_path=scaler_file,
         variables=[],
         method="transform",
@@ -330,10 +330,10 @@ def test_transform_inverse_round_trip(processed_batches, tmp_path):
     scaler_file = str(tmp_path / "combined.json")
     save_scaler_dict(combined, scaler_file)
 
-    fwd = BridgeScalerTransformer(
+    fwd = BridgeScalerTransform(
         scaler_path=scaler_file, variables=[], method="transform", scaler_params={"channels_last": False}
     )
-    inv = BridgeScalerTransformer(
+    inv = BridgeScalerTransform(
         scaler_path=scaler_file, variables=[], method="inverse_transform", scaler_params={"channels_last": False}
     )
 
@@ -344,7 +344,7 @@ def test_transform_inverse_round_trip(processed_batches, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# BridgeScalerTransformer unit behavior (credit/preblock/scaler.py)
+# BridgeScalerTransform unit behavior (credit/preblock/scaler.py)
 # ---------------------------------------------------------------------------
 
 
@@ -352,7 +352,7 @@ def test_transform_inverse_round_trip(processed_batches, tmp_path):
 def test_variable_selection_expands_empty_list(processed_batches, tmp_path):
     """An empty ``variables`` list expands to every variable in the batch on first fit."""
     batches, _ = processed_batches
-    transformer = BridgeScalerTransformer(
+    transformer = BridgeScalerTransform(
         scaler_path=str(tmp_path / "scaler.json"),
         variables=[],
         method="transform",
@@ -371,7 +371,7 @@ def test_variable_selection_expands_empty_list(processed_batches, tmp_path):
 def test_fit_scaler_batch_returns_nested_scaler_dict(processed_batches, tmp_path):
     """fit_scaler_batch returns a nested [data_type][source][var] dict of fitted scalers."""
     batches, _ = processed_batches
-    transformer = BridgeScalerTransformer(
+    transformer = BridgeScalerTransform(
         scaler_path=str(tmp_path / "scaler.json"),
         variables=[],
         method="transform",
@@ -390,7 +390,7 @@ def test_fit_scaler_batch_accumulates_across_rounds(processed_batches, tmp_path)
     """Repeated fit_scaler_batch calls accumulate statistics (running merge), they
     do not overwrite the previous fit."""
     batches, _ = processed_batches
-    transformer = BridgeScalerTransformer(
+    transformer = BridgeScalerTransform(
         scaler_path=str(tmp_path / "scaler.json"),
         variables=[],
         method="transform",
@@ -422,7 +422,7 @@ def test_fit_after_existing_scaler_file_raises(processed_batches, tmp_path):
     _, combined = _fit_over_rounds("standard", batches, str(tmp_path / "fit.json"))
     save_scaler_dict(combined, scaler_file)
 
-    loaded = BridgeScalerTransformer(
+    loaded = BridgeScalerTransform(
         scaler_path=scaler_file, variables=[], method="transform", scaler_params={"channels_last": False}
     )
     assert loaded.scaler_template is None


### PR DESCRIPTION
<!-- Note: The pull request (PR) title will be included in the release notes. -->

### Description
- **`data_types` param and lazy variable selection across all preblocks**
  - `credit/preblock/scaler.py`, `log.py`, `sqrt.py`, `regrid.py`
  - All preblocks now accept a `data_types` parameter to scope processing independently to `"input"`, `"target"`, or both; `BridgeScalerTransform` particularly benefits during multi-step training where the input (the output from the last timestep) is already in normalized space and only the target needs to be scaled; `LogTransform`, `SqrtTransform`, and `BridgeScalerTransform` also gain `variables=[]` / partial path expansion; `regrid.py` also adds `expandvars` on `weight_file` so `$ENV`-style config paths resolve correctly.

- **Postblock scaler structural fix**
  - `credit/postblock/scaler.py`, `credit/cli/_convert.py`
  - The postblock operates on a two-level `{source: {var: scaler}}` structure rather than the three-level preblock format, so `BridgeScalerTransform` now accepts a `scaler_data_type` parameter to slice the correct data type from the full scaler dict; `method` defaults to `"inverse_transform"`, `scaler_path` supports `$ENV`-style paths, and lazy variable selection is included; `_convert.py` fixed to generate post scaler JSONs in this format.

- **New postblock transforms**
  - `credit/postblock/exp.py`, `credit/postblock/square.py`
  - `ExpTransform` and `SquareTransform` added as inverses of `LogTransform` and `SqrtTransform`, with lazy variable selection built in.

- **`BridgeScalerTransformer` → `BridgeScalerTransform`**
  - `credit/preblock/scaler.py` and all references.
  - Renamed the preblock class to match the existing postblock naming convention.

- **Housekeeping**
  - `credit/preblock/concat.py`, `credit/postblock/reconstruct.py`, `tests/test_preblock.py`, `tests/test_postblock.py`.
  - Unified docstring style, inline comments, and NaN warnings across all pre/postblock modules; test files consolidated imports, removed stale skip guards, and fixed style issues including a `"concatenate_to_tensor"` → `"concat"` config example correction; no behavioral changes.

### Examples: Preblock / Postblock Scaler Combinations

#### 1. Single-step — preblock scales input + target

Loss is in normalized space. Without a postblock inverse, the model's normalized output would double-normalize if fed back, so this is single-step only.

```yaml
preblocks:
  per_step:
    scaler:
      type: "bridgescaler_transform"
      args:
        scaler_path: "/path/to/scaler.json"
        variables: []
        scaler_type: "standard"
        data_types: ["input", "target"]
```

---

#### 2. Multi-step — preblock normalizes, postblock inverse-normalizes

The canonical multi-step pattern: postblock de-normalizes the prediction so it feeds back in physical space, then the preblock re-normalizes it at the next step.

```yaml
preblocks:
  per_step:
    scaler:
      type: "bridgescaler_transform"
      args:
        scaler_path: "/path/to/scaler.json"
        variables: []
        scaler_type: "standard"
        data_types: ["input", "target"]

postblocks:
  per_step:
    scaler:
      type: "bridgescaler_transform"
      args:
        scaler_path: "/path/to/scaler.json"
        variables: []
```

---

#### 3. Multi-step — ic_only normalizes input once, per_step normalizes target each step

No postblock inverse. The IC is normalized once before the rollout; model outputs (already in normalized space) feed directly back as the next step's input without re-normalization.

```yaml
preblocks:
  ic_only:
    scaler:
      type: "bridgescaler_transform"
      args:
        scaler_path: "/path/to/scaler.json"
        variables: []
        scaler_type: "standard"
        data_types: ["input"]
  per_step:
    scaler:
      type: "bridgescaler_transform"
      args:
        scaler_path: "/path/to/scaler.json"
        variables: []
        scaler_type: "standard"
        data_types: ["target"]
```

### Related Issues and PRs
Closes #434 

### Checklist
- [x] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date.
