### PR TITLE
Clean up logging for preprocess, train, and rollout to improve user experience

### DIFF
--- a/config/gen_2/examples/example-v2026.3.yml
+++ b/config/gen_2/examples/example-v2026.3.yml
@@ -136,7 +136,7 @@ trainer:
 
   start_epoch: 0
   num_epoch: 2            # epochs per qsub job (checkpoint after each)
-  epochs: &epochs 70      # total training target
+  epochs: &epochs 2      # total training target
 
   use_tensorboard: True
   use_ema: True           # exponential moving average of weights for validation

--- a/credit/applications/preprocess.py
+++ b/credit/applications/preprocess.py
@@ -1,22 +1,24 @@
 import argparse
 import logging
+import os
+import shutil
+import sys
 import warnings
+from os.path import expandvars
 
+import torch
+import torch.distributed as dist
+import yaml
 from bridgescaler import save_scaler_dict
+from torch.distributed import barrier, gather_object
 
 from credit.distributed import get_rank_info, setup
-from credit.seed import seed_everything
-from os.path import expandvars
-import os
-import torch
-import yaml
-import sys
-import shutil
-from credit.preblock import build_preblocks, apply_preblocks_before_scaler, BridgeScalerTransform
+from credit.preblock import BridgeScalerTransform, apply_preblocks_before_scaler, build_preblocks
 from credit.preblock.scaler import combine_scaler_dicts, move_scaler_dict_to_cpu
-from credit.trainers.utils import cycle, load_dataset, load_dataloader, effective_mode
-import torch.distributed as dist
-from torch.distributed import gather_object, barrier
+from credit.seed import seed_everything
+from credit.trainers.utils import cycle, effective_mode, load_dataloader, load_dataset
+
+logger = logging.getLogger("preprocess")
 
 
 def _scaler_probe_range(scaler):
@@ -184,7 +186,7 @@ Examples:
     )
     for h in root.handlers:
         h.setLevel(level)
-    root.info("Loaded config file: %s", args.model_config)
+    logger.info("Loaded config file: %s", args.model_config)
     save_loc = expandvars(conf["save_loc"])
     os.makedirs(save_loc, exist_ok=True)
     if not os.path.exists(os.path.join(save_loc, "model.yml")):
@@ -233,7 +235,7 @@ Examples:
     batches_per_epoch = _bpe if 0 < _bpe < dataset_batches else dataset_batches
     dl = cycle(train_loader)
     for i in range(batches_per_epoch):
-        root.info(f"Worker {rank}: Processing batch {i + 1} of {batches_per_epoch}.")
+        logger.info(f"Worker {rank}: Processing batch {i + 1} of {batches_per_epoch}.")
         batch = next(dl)
         processed_batch = apply_preblocks_before_scaler(preblocks, batch, device)
         preblocks[scaler_block_key].fit_scaler_batch(processed_batch)
@@ -250,12 +252,12 @@ Examples:
         all_scalers = [scaler_block.scaler]
 
     if rank == 0:
-        root.info("Combining scalers.")
+        logger.info("Combining scalers.")
         combined_scaler = combine_scaler_dicts(all_scalers)
         save_scaler_dict(combined_scaler, scaler_block.scaler_path)
-        root.info("Saved fitted scaler to %s", scaler_block.scaler_path)
-        root.info("Fitted scaler values by variable:")
-        log_fitted_scalers(combined_scaler, root)
+        logger.info("Saved fitted scaler to %s", scaler_block.scaler_path)
+        logger.info("Fitted scaler values by variable:")
+        log_fitted_scalers(combined_scaler, logger)
 
     if dist.is_initialized():
         dist.destroy_process_group()

--- a/credit/applications/preprocess.py
+++ b/credit/applications/preprocess.py
@@ -88,7 +88,11 @@ def _log_single_scaler(scaler, name, logger):
             parts.append(f"min={float(vmin[i]):.4g} max={float(vmax[i]):.4g}")
         if inv is not None:
             parts.append(f"inv[{lo:g} -> {hi:g}]=[{float(inv[0, i]):.4g}, {float(inv[1, i]):.4g}]")
-        logger.info("    %s: %s", col, "  ".join(parts) if parts else "(no stats available)")
+        logger.info(
+            "    %s: %s",
+            col + 1 if isinstance(col, int) else col,
+            "  ".join(parts) if parts else "(no stats available)",
+        )
 
 
 def log_fitted_scalers(scaler_dict, logger, path=()):
@@ -106,6 +110,15 @@ def main():
     # teardown (after the scalers have already been fitted and saved). Silence it.
     warnings.filterwarnings("ignore", category=ResourceWarning)
     warnings.filterwarnings("ignore", category=UserWarning, module="bridgescaler")
+    # Suppress the resource_tracker subprocess's "leaked semaphore" warning.
+    # warnings.filterwarnings has no effect on subprocesses; PYTHONWARNINGS is inherited
+    # at subprocess startup so the filter applies before the tracker's final audit runs.
+    # The warning is cosmetic: the tracker still unlinks the semaphores — the unregister
+    # acknowledgment from workers just arrives after the audit due to a timing race.
+    _pw = os.environ.get("PYTHONWARNINGS", "")
+    _addon = "ignore::UserWarning:multiprocessing.resource_tracker"
+    if _addon not in _pw:
+        os.environ["PYTHONWARNINGS"] = (_pw + "," + _addon).lstrip(",")
     parser = argparse.ArgumentParser(
         epilog="""
 Examples:
@@ -134,7 +147,7 @@ Examples:
         type=str,
         default=None,
         choices=["nccl", "gloo", "mpi"],
-        help="Backend for distributed training. Defaults to 'nccl' for GPU, 'gloo' for CPU.",
+        help="Backend for distributed communication. Defaults to 'gloo' (preprocess only needs CPU collectives).",
     )
     parser.add_argument(
         "--device",
@@ -142,25 +155,40 @@ Examples:
         default=None,
         help="Device to use (e.g. 'cpu', 'cuda', 'cuda:0'). Defaults to GPU if available.",
     )
+    parser.add_argument(
+        "--log-all-ranks",
+        action="store_true",
+        default=False,
+        help="Emit INFO logs from all workers, not just rank 0. Useful for debugging per-worker data issues.",
+    )
     args = parser.parse_args()
-    config = args.model_config
-    root = logging.getLogger()
-    root.setLevel(logging.DEBUG)
-    formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
-    ch = logging.StreamHandler()
-    gettrace = getattr(sys, "gettrace", None)
-    ch.setLevel(logging.DEBUG if gettrace and gettrace() else logging.INFO)
-    ch.setFormatter(formatter)
-    root.addHandler(ch)
-    root.info("Loading Config file")
-    with open(args.model_config) as config_file:
-        conf = yaml.safe_load(config_file)
+    try:
+        with open(args.model_config) as config_file:
+            conf = yaml.safe_load(config_file)
+    except Exception as exc:
+        print(f"ERROR: failed to load config file '{args.model_config}': {exc}", file=sys.stderr)
+        sys.exit(1)
     local_rank, world_rank, world_size = get_rank_info(effective_mode(conf))
     rank = world_rank
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    if not root.handlers:
+        ch = logging.StreamHandler()
+        ch.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+        root.addHandler(ch)
+    gettrace = getattr(sys, "gettrace", None)
+    level = (
+        (logging.DEBUG if gettrace and gettrace() else logging.INFO)
+        if (rank == 0 or args.log_all_ranks)
+        else logging.WARNING
+    )
+    for h in root.handlers:
+        h.setLevel(level)
+    root.info("Loaded config file: %s", args.model_config)
     save_loc = expandvars(conf["save_loc"])
     os.makedirs(save_loc, exist_ok=True)
     if not os.path.exists(os.path.join(save_loc, "model.yml")):
-        shutil.copy(config, os.path.join(save_loc, "model.yml"))
+        shutil.copy(args.model_config, os.path.join(save_loc, "model.yml"))
 
     if args.device is not None:
         device = torch.device(args.device)
@@ -172,17 +200,22 @@ Examples:
         torch.cuda.set_device(device)
         torch.backends.cudnn.benchmark = True
 
-    backend = args.backend or ("nccl" if device.type == "cuda" else "gloo")
+    # Preprocess only gathers CPU scaler objects, so gloo suffices regardless of trainer mode.
+    backend = args.backend or "gloo"
     if effective_mode(conf) in ["fsdp", "ddp", "domain_parallel", "fsdp+domain_parallel"]:
         setup(rank, world_size, effective_mode(conf), backend)
 
     trainer_conf = conf["trainer"]
     train_dataset = load_dataset(conf, is_train=True)
-    train_loader = load_dataloader(conf, train_dataset, rank=rank, world_size=world_size, is_train=True)
+    # persistent_workers=False: preprocess is a single pass, so workers are not needed
+    # across epochs. The iterator then lives only in the cycle() frame and is collected
+    # immediately when del dl runs — semaphores are unregistered well before process exit.
+    train_loader = load_dataloader(
+        conf, train_dataset, rank=rank, world_size=world_size, is_train=True, persistent_workers=False
+    )
     seed = conf.get("seed", 42) + rank
     seed_everything(seed)
     preblocks = build_preblocks(conf["preblocks"])
-    print(preblocks)
     scaler_block_key = None
     for k, v in preblocks.items():
         if isinstance(v, BridgeScalerTransform):
@@ -200,10 +233,12 @@ Examples:
     batches_per_epoch = _bpe if 0 < _bpe < dataset_batches else dataset_batches
     dl = cycle(train_loader)
     for i in range(batches_per_epoch):
-        root.info(f"Worker {rank}: Processing batch {i} of {batches_per_epoch}.")
+        root.info(f"Worker {rank}: Processing batch {i + 1} of {batches_per_epoch}.")
         batch = next(dl)
         processed_batch = apply_preblocks_before_scaler(preblocks, batch, device)
         preblocks[scaler_block_key].fit_scaler_batch(processed_batch)
+    del dl  # iterator lives only here; refcount → 0, workers shut down immediately
+    del train_loader
 
     scaler_block = preblocks[scaler_block_key]
     # Gather the per-rank fitted scaler dicts onto rank 0 (or run single-process).
@@ -221,7 +256,9 @@ Examples:
         root.info("Saved fitted scaler to %s", scaler_block.scaler_path)
         root.info("Fitted scaler values by variable:")
         log_fitted_scalers(combined_scaler, root)
-    return
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/credit/applications/rollout_gen2.py
+++ b/credit/applications/rollout_gen2.py
@@ -31,6 +31,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 import pandas as pd
 import torch
+import torch.distributed as dist
 import yaml
 from torch.utils.data import DataLoader
 
@@ -40,7 +41,7 @@ from credit.output_gen2 import ForecastWriter
 from credit.pbs import launch_script, launch_script_mpi
 from credit.postblock import build_postblocks
 from credit.preblock import build_preblocks
-from credit.samplers import DistributedMultiStepBatchSampler
+from credit.samplers import MultiStepBatchSamplerSubset
 from credit.seed import seed_everything
 from credit.trainers.rollout_utils import (
     batch_init_times,
@@ -224,19 +225,16 @@ Examples:
     }
     dataset = MultiSourceDataset(dataset_conf, return_target=False)
 
-    if world_size > 1 and len(all_init_times) % world_size != 0:
-        raise ValueError(
-            f"Number of init times ({len(all_init_times)}) is not divisible by "
-            f"world_size ({world_size}). Adjust your date range or number of GPUs."
-        )
-    sampler = DistributedMultiStepBatchSampler(
+    # Plain (non-distributed) subset sampler: each rank takes every world_size-th
+    # init time starting at its own rank, so no DistributedSampler-style padding
+    # (which would repeat init times from the start of the list to make the
+    # count divisible by world_size) ever happens.
+    rank_indices = list(range(world_rank, len(all_init_times), world_size))
+    sampler = MultiStepBatchSamplerSubset(
         dataset=dataset,
         batch_size=1,
+        index_subset=rank_indices,
         num_forecast_steps=n_steps,  # IC + (n_steps-1) forcing batches = n_steps total
-        num_replicas=world_size,
-        rank=world_rank,
-        shuffle=False,
-        seed=conf.get("seed", 0),
     )
 
     loader = DataLoader(dataset, batch_sampler=sampler, num_workers=0, pin_memory=False)
@@ -245,7 +243,7 @@ Examples:
         "Rank %d/%d: %d init time(s), %d steps each",
         world_rank,
         world_size,
-        sampler.num_samples,
+        len(rank_indices),
         n_steps,
     )
 
@@ -266,7 +264,7 @@ Examples:
     with mp.Pool(args.num_cpus) as pool:
         batch_iter = iter(loader)
 
-        for _ in range(sampler.num_samples):
+        for _ in range(len(rank_indices)):
             run_forecast(
                 conf=conf,
                 n_steps=n_steps,
@@ -286,10 +284,12 @@ Examples:
         pool.close()
         pool.join()
 
-    # Ranks work on independent init-time subsets, so no per-forecast barrier is
-    # needed. flush() inside run_forecast drains async writes before each forecast
-    # returns, so all output is on disk before we tear down the process group.
+    # Ranks now cover unequal-size init-time subsets, so they can exit their loop
+    # at different times. Wait for the slowest rank here, before any rank tears
+    # down the process group — otherwise a fast rank calling cleanup() could pull
+    # it out from under a still-running rank mid-collective.
     if mode in ("ddp", "fsdp"):
+        dist.barrier()
         cleanup()
 
 

--- a/credit/applications/rollout_gen2.py
+++ b/credit/applications/rollout_gen2.py
@@ -48,6 +48,7 @@ from credit.trainers.rollout_utils import (
     parse_length,
     run_forecast,
 )
+from credit.trainers.utils import cleanup
 
 logger = logging.getLogger(__name__)
 warnings.filterwarnings("ignore")
@@ -98,20 +99,21 @@ Examples:
     parser.add_argument(
         "-p", "--procs", dest="num_cpus", type=int, default=4, help="CPU workers for async output pool."
     )
+    parser.add_argument(
+        "--log-all-ranks",
+        action="store_true",
+        default=False,
+        help="Emit INFO logs from all workers, not just rank 0. Useful for debugging per-worker issues.",
+    )
     args = parser.parse_args()
 
-    # ── Logging ──────────────────────────────────────────────────────────────
-    root = logging.getLogger()
-    root.setLevel(logging.DEBUG)
-    if not root.handlers:
-        ch = logging.StreamHandler()
-        ch.setLevel(logging.INFO)
-        ch.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
-        root.addHandler(ch)
-
     # ── Load config ──────────────────────────────────────────────────────────
-    with open(args.model_config) as f:
-        conf = yaml.load(f, Loader=yaml.FullLoader)
+    try:
+        with open(args.model_config) as f:
+            conf = yaml.load(f, Loader=yaml.FullLoader)
+    except Exception as exc:
+        print(f"ERROR: failed to load config file '{args.model_config}': {exc}", file=sys.stderr)
+        sys.exit(1)
 
     assert "source" in conf["data"], (
         "rollout_gen2.py requires the Gen2 nested data schema (conf['data']['source']). "
@@ -164,6 +166,23 @@ Examples:
     seed_everything(conf["seed"])
     mode = inf_conf.get("mode", "none")
     local_rank, world_rank, world_size = get_rank_info(mode)
+    rank = world_rank  # conventional DDP shorthand; local_rank is only needed for device assignment above
+
+    # ── Logging ──────────────────────────────────────────────────────────────
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    if not root.handlers:
+        ch = logging.StreamHandler()
+        ch.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+        root.addHandler(ch)
+    gettrace = getattr(sys, "gettrace", None)
+    level = (
+        (logging.DEBUG if gettrace and gettrace() else logging.INFO)
+        if (rank == 0 or args.log_all_ranks)
+        else logging.WARNING
+    )
+    for h in root.handlers:
+        h.setLevel(level)
 
     if mode in ("ddp", "fsdp"):
         setup(world_rank, world_size, mode)
@@ -203,6 +222,11 @@ Examples:
     }
     dataset = MultiSourceDataset(dataset_conf, return_target=False)
 
+    if world_size > 1 and len(all_init_times) % world_size != 0:
+        raise ValueError(
+            f"Number of init times ({len(all_init_times)}) is not divisible by "
+            f"world_size ({world_size}). Adjust your date range or number of GPUs."
+        )
     sampler = DistributedMultiStepBatchSampler(
         dataset=dataset,
         batch_size=1,
@@ -223,11 +247,14 @@ Examples:
         n_steps,
     )
 
+    verbose = rank == 0 or args.log_all_ranks  # gates tqdm bars and save-path notifications
+
     # ── Output writer ─────────────────────────────────────────────────────────
     writer = ForecastWriter(
         output_conf=inf_conf.get("output", {}),
         conf=conf,
         n_steps=n_steps,
+        verbose=verbose,
     )
 
     # ── Rollout ──────────────────────────────────────────────────────────────
@@ -251,13 +278,17 @@ Examples:
                 device=device,
                 pool=pool,
                 save_output_fn=writer,
+                verbose=verbose,
             )
-
-            if mode in ("ddp", "fsdp"):
-                torch.distributed.barrier()
 
         pool.close()
         pool.join()
+
+    # Ranks work on independent init-time subsets, so no per-forecast barrier is
+    # needed. flush() inside run_forecast drains async writes before each forecast
+    # returns, so all output is on disk before we tear down the process group.
+    if mode in ("ddp", "fsdp"):
+        cleanup()
 
 
 if __name__ == "__main__":

--- a/credit/applications/rollout_gen2.py
+++ b/credit/applications/rollout_gen2.py
@@ -50,7 +50,7 @@ from credit.trainers.rollout_utils import (
 )
 from credit.trainers.utils import cleanup
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("rollout_gen2")
 warnings.filterwarnings("ignore")
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 os.environ["OMP_NUM_THREADS"] = "1"

--- a/credit/applications/train_gen2.py
+++ b/credit/applications/train_gen2.py
@@ -38,6 +38,8 @@ from credit.trainers.utils import (
 
 warnings.filterwarnings("ignore")
 
+logger = logging.getLogger("train_gen2")
+
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 # Suppress the resource_tracker subprocess's "leaked semaphore" warning.
 # warnings.filterwarnings has no effect on subprocesses; PYTHONWARNINGS is inherited
@@ -130,10 +132,10 @@ def main_cli():
     if launch:
         script_path = Path(__file__).absolute()
         if conf["pbs"]["queue"] == "casper":
-            logging.info("Launching to PBS on Casper")
+            logger.info("Launching to PBS on Casper")
             launch_script(config, script_path)
         else:
-            logging.info("Launching to PBS on Derecho")
+            logger.info("Launching to PBS on Derecho")
             launch_script_mpi(config, script_path)
         sys.exit()
 

--- a/credit/applications/train_gen2.py
+++ b/credit/applications/train_gen2.py
@@ -39,6 +39,15 @@ from credit.trainers.utils import (
 warnings.filterwarnings("ignore")
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+# Suppress the resource_tracker subprocess's "leaked semaphore" warning.
+# warnings.filterwarnings has no effect on subprocesses; PYTHONWARNINGS is inherited
+# at subprocess startup so the filter applies before the tracker's final audit runs.
+# The warning is cosmetic: the tracker still unlinks the semaphores — the unregister
+# acknowledgment from workers just arrives after the audit due to a timing race.
+_pw = os.environ.get("PYTHONWARNINGS", "")
+_addon = "ignore::UserWarning:multiprocessing.resource_tracker"
+if _addon not in _pw:
+    os.environ["PYTHONWARNINGS"] = (_pw + "," + _addon).lstrip(",")
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
@@ -62,28 +71,56 @@ def main_cli():
     parser.add_argument(
         "--backend", type=str, default="nccl", choices=["nccl", "gloo", "mpi"], help="Backend for distributed training."
     )
+    parser.add_argument(
+        "--log-all-ranks",
+        action="store_true",
+        default=False,
+        help="Emit INFO logs from all workers, not just rank 0. Useful for debugging per-worker issues.",
+    )
     args = parser.parse_args()
     config = args.model_config
     launch = int(args.launch)
     backend = args.backend
 
-    root = logging.getLogger()
-    root.setLevel(logging.DEBUG)
-    formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
-    ch = logging.StreamHandler()
-    gettrace = getattr(sys, "gettrace", None)
-    ch.setLevel(logging.DEBUG if gettrace and gettrace() else logging.INFO)
-    ch.setFormatter(formatter)
-    if not root.handlers:
-        root.addHandler(ch)
-
-    with open(config) as cf:
-        conf = yaml.load(cf, Loader=yaml.FullLoader)
+    try:
+        with open(config) as cf:
+            conf = yaml.load(cf, Loader=yaml.FullLoader)
+    except Exception as exc:
+        print(f"ERROR: failed to load config file '{config}': {exc}", file=sys.stderr)
+        sys.exit(1)
 
     assert "source" in conf["data"], (
         "train.py requires the Gen2 nested data schema (conf['data']['source']). "
         "For the legacy flat schema, use applications/train.py."
     )
+
+    # V2 parallelism configs read rank info from the launcher (torchrun or MPI).
+    # Without a launcher (plain `python`/`credit train` on one GPU), run
+    # single-process instead of letting get_rank_info sys.exit hunting for env vars.
+    # RANK: torchrun; OMPI: Open MPI; PMI: cray-mpich/MPICH; PALS: Cray PALS
+    # without PMI passthrough; SLURM_PROCID: srun.
+    _launcher_env = ("LOCAL_RANK", "RANK", "OMPI_COMM_WORLD_RANK", "PMI_RANK", "PALS_RANKID", "SLURM_PROCID")
+    if any(v in os.environ for v in _launcher_env):
+        local_rank, world_rank, world_size = get_rank_info("ddp")
+    else:
+        local_rank, world_rank, world_size = 0, 0, 1
+    rank = world_rank  # conventional DDP shorthand; local_rank is only needed for device assignment below
+
+    # ── Logging ──────────────────────────────────────────────────────────────
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    if not root.handlers:
+        ch = logging.StreamHandler()
+        ch.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+        root.addHandler(ch)
+    gettrace = getattr(sys, "gettrace", None)
+    level = (
+        (logging.DEBUG if gettrace and gettrace() else logging.INFO)
+        if (rank == 0 or args.log_all_ranks)
+        else logging.WARNING
+    )
+    for h in root.handlers:
+        h.setLevel(level)
 
     save_loc = os.path.expandvars(conf["save_loc"])
     os.makedirs(save_loc, exist_ok=True)
@@ -106,18 +143,6 @@ def main_cli():
         "and domain fields. Configs from before the parallelism block (legacy "
         "trainer.mode) can be migrated with `credit convert`."
     )
-
-    # V2 parallelism configs read rank info from the launcher (torchrun or MPI).
-    # Without a launcher (plain `python`/`credit train` on one GPU), run
-    # single-process instead of letting get_rank_info sys.exit hunting for env vars.
-    # RANK: torchrun; OMPI: Open MPI; PMI: cray-mpich/MPICH; PALS: Cray PALS
-    # without PMI passthrough; SLURM_PROCID: srun.
-    _launcher_env = ("LOCAL_RANK", "RANK", "OMPI_COMM_WORLD_RANK", "PMI_RANK", "PALS_RANKID", "SLURM_PROCID")
-    if any(v in os.environ for v in _launcher_env):
-        local_rank, world_rank, world_size = get_rank_info("ddp")
-    else:
-        local_rank, world_rank, world_size = 0, 0, 1
-    rank = world_rank
 
     conf["save_loc"] = os.path.expandvars(conf["save_loc"])
 

--- a/credit/cli/_parser.py
+++ b/credit/cli/_parser.py
@@ -78,16 +78,19 @@ def _build_parser() -> argparse.ArgumentParser:
     # ---- rollout-ensemble ----
     p = sub.add_parser(
         "rollout-ensemble",
-        help="Submit N parallel PBS rollout jobs covering all ensemble init times",
+        help="[deprecated] Submit N parallel PBS rollout jobs (see 'credit submit --mode rollout')",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=textwrap.dedent("""\
-            Split an ensemble rollout across N parallel PBS jobs — one job per
-            subset of init times.  All jobs start at once (no afterok chain).
+            Deprecated — use 'credit submit --mode rollout --jobs N' instead.
+
+            NOTE: per-job init-time subsetting is not yet implemented for gen2
+            configs, so with --jobs N > 1 each job currently runs the FULL set
+            of init times — N redundant copies, not a work split. Use --jobs 1
+            until subsetting lands.
 
             Examples:
-              credit rollout-ensemble --cluster casper -c config.yml --jobs 10 --dry-run
-              credit rollout-ensemble --cluster casper -c config.yml --jobs 10
-              credit rollout-ensemble --cluster derecho -c config.yml --jobs 20 --gpus 1
+              credit rollout-ensemble --cluster casper -c config.yml --jobs 1 --dry-run
+              credit rollout-ensemble --cluster casper -c config.yml --jobs 1
         """),
     )
     p.add_argument("-c", "--config", required=True, metavar="CONFIG", help="Path to v2 YAML config")
@@ -126,8 +129,11 @@ def _build_parser() -> argparse.ArgumentParser:
               train      (default) Submit a training job.  Use --reload / --chain for
                          resuming and chaining multiple epochs across jobs.
               preprocess Submit a single job to fit preprocessing scalers.
-              rollout    Submit N parallel PBS rollout jobs covering all init times.
-                         Use --jobs N to set parallelism.  No afterok chain.
+              rollout    Submit N parallel PBS rollout jobs.  No afterok chain.
+                         NOTE: per-job init-time subsetting is not yet
+                         implemented for gen2 configs, so --jobs N > 1
+                         currently submits N redundant full-range jobs
+                         rather than splitting the work — use --jobs 1.
               realtime   Submit a single realtime forecast job.
                          Requires --init-time and --steps.
 
@@ -137,7 +143,7 @@ def _build_parser() -> argparse.ArgumentParser:
               credit submit --cluster casper  -c config.yml --mode train --reload
               credit submit --cluster derecho -c config.yml --mode train --chain 10
               credit submit --cluster casper  -c config.yml --mode preprocess
-              credit submit --cluster casper  -c config.yml --mode rollout --jobs 10
+              credit submit --cluster casper  -c config.yml --mode rollout --jobs 1
               credit submit --cluster casper  -c config.yml --mode realtime --init-time 2024-01-15T00 --steps 40
         """),
     )
@@ -162,7 +168,12 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--conda-env", dest="conda_env", default=None, metavar="PATH", help="Conda environment path")
     p.add_argument("--dry-run", action="store_true", help="Print the PBS script without submitting")
     p.add_argument(
-        "--jobs", type=int, default=1, metavar="N", help="Parallel PBS rollout jobs for --mode rollout (default: 1)"
+        "--jobs",
+        type=int,
+        default=1,
+        metavar="N",
+        help="Parallel PBS rollout jobs for --mode rollout (default: 1). "
+        "N>1 currently submits N redundant full-range jobs — per-job subsetting isn't implemented yet.",
     )
     p.add_argument(
         "--init-time", dest="init_time", default=None, metavar="YYYY-MM-DDTHH", help="Init time for --mode realtime"

--- a/credit/cli/_submit.py
+++ b/credit/cli/_submit.py
@@ -671,7 +671,8 @@ def _build_rollout_pbs_script(
 
             {torchrun} --standalone --nnodes=1 --nproc-per-node=${{NGPUS}} \\
                 ${{REPO}}/credit/applications/rollout_gen2.py \\
-                -c ${{CONFIG}} --subset {subset} --no_subset {n_subsets}
+                -c ${{CONFIG}}
+                # -c ${{CONFIG}} --subset {subset} --no_subset {n_subsets}  # rollout_gen2.py does not support these flags yet
         """)
 
     else:  # derecho
@@ -701,14 +702,19 @@ def _build_rollout_pbs_script(
 
             ${{TORCHRUN}} --standalone --nnodes=1 --nproc-per-node={args.gpus} \\
                 ${{REPO}}/credit/applications/rollout_gen2.py \\
-                -c ${{CONFIG}} --subset {subset} --no_subset {n_subsets}
+                -c ${{CONFIG}}
+                # -c ${{CONFIG}} --subset {subset} --no_subset {n_subsets}  # rollout_gen2.py does not support these flags yet
         """)
 
 
-def _print_ensemble_rollout_plan(args: argparse.Namespace, n_jobs: int, n_forecasts: int, ensemble_size: int) -> None:
+def _print_ensemble_rollout_plan(args: argparse.Namespace, n_jobs: int, n_forecasts, ensemble_size) -> None:
     """Print a human-readable summary of an ensemble rollout submission."""
-    per_job = -(-n_forecasts // n_jobs)  # ceiling division
-    total_runs = n_forecasts * ensemble_size
+    if isinstance(n_forecasts, int):
+        per_job = -(-n_forecasts // n_jobs)  # ceiling division
+        total_runs = n_forecasts * ensemble_size if isinstance(ensemble_size, int) else "?"
+    else:
+        per_job = "?"
+        total_runs = "?"
 
     sep = "=" * 56
     logger.info(
@@ -779,14 +785,25 @@ def _do_submit_rollout(args: argparse.Namespace) -> None:
 
     n_jobs = args.jobs
 
+    conf = {}
     try:
-        from credit.forecast import load_forecasts
-
         with open(args.config) as f:
             conf = yaml.safe_load(f)
-        all_forecasts = load_forecasts(conf)
-        n_forecasts = len(all_forecasts)
-        ensemble_size = conf.get("predict", {}).get("ensemble_size", 1)
+
+        if "inference" in conf:
+            inf_conf = conf["inference"]
+            if inf_conf.get("run_mode", "batch") == "single":
+                n_forecasts = 1
+            else:
+                from credit.trainers.rollout_utils import batch_init_times
+
+                n_forecasts = len(batch_init_times(inf_conf["batch_forecast"]))
+            ensemble_size = inf_conf.get("ensemble_size", 1)
+        else:
+            from credit.forecast import load_forecasts
+
+            n_forecasts = len(load_forecasts(conf))
+            ensemble_size = conf.get("predict", {}).get("ensemble_size", 1)
     except Exception:
         n_forecasts = "?"
         ensemble_size = "?"
@@ -811,7 +828,9 @@ def _do_submit_rollout(args: argparse.Namespace) -> None:
         job_ids.append(job_id)
         logger.info("[%2d/%d] %s", i, n_jobs, job_id)
 
-    save_forecast = conf.get("predict", {}).get("save_forecast", "<save_forecast in config>")
+    save_forecast = conf.get("inference", {}).get("save_forecast") or conf.get("predict", {}).get(
+        "save_forecast", "<save_forecast in config>"
+    )
     logger.info(
         "\nSubmitted %d parallel rollout jobs.\nOutput will be written to: %s\nMonitor with:\n  qstat -u $USER",
         n_jobs,

--- a/credit/datasets/multi_source.py
+++ b/credit/datasets/multi_source.py
@@ -134,7 +134,7 @@ class MultiSourceDataset(AbstractBaseDataset):
             sub-dataset's ``static_metadata`` attribute.
     """
 
-    def __init__(self, config: dict[str, Any], return_target: bool = False) -> None:
+    def __init__(self, config: dict[str, Any], return_target: bool = False, label: str | None = None) -> None:
         super().__init__(config, return_target)
         self.datasets: dict[str, BaseDataset] = {}
         source_cfg = config.get("source", {})
@@ -148,7 +148,8 @@ class MultiSourceDataset(AbstractBaseDataset):
             # Route to the appropriate dataset class based on the "dataset_name" field in the sub-config
             cls = route_to_dataset_class(sub_config["source"][user_dataset_name])
             self.datasets[user_dataset_name] = cls(sub_config, return_target=return_target)
-            logger.info(f"MultiSourceDataset: registered dataset '{user_dataset_name}' with class '{cls.__name__}'")
+            prefix = f"MultiSourceDataset ({label})" if label else "MultiSourceDataset"
+            logger.info(f"{prefix}: registered dataset '{user_dataset_name}' with class '{cls.__name__}'")
 
         self.dt: pd.Timedelta = pd.Timedelta(config["timestep"])
         self.datetimes: pd.DatetimeIndex = self._build_master_clock(config)

--- a/credit/distributed.py
+++ b/credit/distributed.py
@@ -26,6 +26,8 @@ from credit.mixed_precision import parse_dtype
 import functools
 import logging
 
+logger = logging.getLogger(__name__)
+
 
 def setup(rank, world_size, mode, backend="nccl", device_id=None):
     """Initializes the distributed process group.
@@ -39,7 +41,7 @@ def setup(rank, world_size, mode, backend="nccl", device_id=None):
             to suppress the PyTorch 2.3+ barrier() UserWarning about missing device_id.
     """
 
-    logging.info(f"Running {mode.upper()} on rank {rank} with world_size {world_size} using {backend}.")
+    logger.info(f"Running {mode.upper()} on rank {rank} with world_size {world_size} using {backend}.")
     kwargs = {}
     if device_id is not None and backend == "nccl":
         kwargs["device_id"] = device_id
@@ -127,7 +129,7 @@ def configure_gloo_ifname():
     ifname = resolve_socket_ifname()
     if ifname is not None:
         os.environ["GLOO_SOCKET_IFNAME"] = ifname
-        logging.info("Set GLOO_SOCKET_IFNAME=%s for Gloo CPU collectives", ifname)
+        logger.info("Set GLOO_SOCKET_IFNAME=%s for Gloo CPU collectives", ifname)
 
 
 def get_rank_info(trainer_mode):
@@ -147,7 +149,7 @@ def get_rank_info(trainer_mode):
                 WORLD_SIZE = int(os.environ["WORLD_SIZE"])
                 WORLD_RANK = int(os.environ["RANK"])
             else:
-                logging.info("Using MPI for distributed training.")
+                logger.info("Using MPI for distributed training.")
                 from mpi4py import MPI
 
                 comm = MPI.COMM_WORLD
@@ -171,14 +173,14 @@ def get_rank_info(trainer_mode):
                 os.environ["MASTER_PORT"] = comm.bcast(master_port, root=0)
                 comm.barrier()
                 print("MASTER_ADDR: ", os.environ.get("MASTER_ADDR", "Still Not set"))
-                logging.info("Using MASTER_ADDR={}".format(os.environ["MASTER_ADDR"]))
-                logging.info("Using MASTER_PORT={}".format(os.environ["MASTER_PORT"]))
+                logger.info("Using MASTER_ADDR={}".format(os.environ["MASTER_ADDR"]))
+                logger.info("Using MASTER_PORT={}".format(os.environ["MASTER_PORT"]))
                 if 0 == WORLD_RANK:
-                    logging.info("Using MASTER_ADDR={}".format(os.environ["MASTER_ADDR"]))
-                    logging.info("Using MASTER_PORT={}".format(os.environ["MASTER_PORT"]))
+                    logger.info("Using MASTER_ADDR={}".format(os.environ["MASTER_ADDR"]))
+                    logger.info("Using MASTER_PORT={}".format(os.environ["MASTER_PORT"]))
 
         except Exception as e:
-            logging.info(e)
+            logger.info(e)
 
             if "LOCAL_RANK" in os.environ:
                 # Environment variables set by torch.distributed.launch or torchrun
@@ -207,7 +209,7 @@ def get_rank_info(trainer_mode):
             # jobs must export MASTER_ADDR/MASTER_PORT explicitly to be safe.
             if "MASTER_ADDR" not in os.environ:
                 os.environ["MASTER_ADDR"] = resolve_master_addr()
-                logging.warning(
+                logger.warning(
                     "MASTER_ADDR was not set and could not be broadcast via MPI; "
                     "defaulting to %s. For multi-node jobs, export MASTER_ADDR "
                     "explicitly so all nodes agree on the rendezvous address.",
@@ -215,7 +217,7 @@ def get_rank_info(trainer_mode):
                 )
             if "MASTER_PORT" not in os.environ:
                 os.environ["MASTER_PORT"] = str(DEFAULT_MASTER_PORT)
-                logging.warning(
+                logger.warning(
                     "MASTER_PORT was not set; defaulting to %s.",
                     os.environ["MASTER_PORT"],
                 )
@@ -325,7 +327,7 @@ def distributed_model_wrapper(conf, neural_network, device):
         # Store manager on the model for access by trainer
         neural_network._domain_parallel_manager = domain_manager
 
-        logging.info(
+        logger.info(
             f"Domain parallelism enabled: {domain_parallel_size} domain shards, "
             f"{world_size // domain_parallel_size} data-parallel replicas"
         )
@@ -339,12 +341,12 @@ def distributed_model_wrapper(conf, neural_network, device):
 
     # logger announcement
     if activation_checkpoint:
-        logging.info(f"Activation checkpointing on {mode}: {activation_checkpoint}")
+        logger.info(f"Activation checkpointing on {mode}: {activation_checkpoint}")
         if checkpoint_all_layers:
-            logging.info("Checkpointing all available layers in your model")
-            logging.warning("This may cause performance degredation -- consider supplying a list to checkpoint")
+            logger.info("Checkpointing all available layers in your model")
+            logger.warning("This may cause performance degredation -- consider supplying a list to checkpoint")
         else:
-            logging.info(f"Checkpointing custom layers {transformer_layers_cls}")
+            logger.info(f"Checkpointing custom layers {transformer_layers_cls}")
 
     # FSDP policies
     if fsdp_mode:
@@ -367,7 +369,7 @@ def distributed_model_wrapper(conf, neural_network, device):
             conf["trainer"]["use_mixed_precision"] if "use_mixed_precision" in conf["trainer"] else False
         )
 
-        logging.info(f"Using mixed_precision: {use_mixed_precision}")
+        logger.info(f"Using mixed_precision: {use_mixed_precision}")
 
         if use_mixed_precision:
             for key, val in conf["trainer"]["mixed_precision"].items():
@@ -380,7 +382,7 @@ def distributed_model_wrapper(conf, neural_network, device):
 
         cpu_offload = conf["trainer"]["cpu_offload"] if "cpu_offload" in conf["trainer"] else False
 
-        logging.info(f"Using CPU offloading: {cpu_offload}")
+        logger.info(f"Using CPU offloading: {cpu_offload}")
 
         # FSDP module — for fsdp+domain_parallel, use data-parallel process group
         fsdp_kwargs = dict(
@@ -480,7 +482,7 @@ def distributed_model_wrapper_gen2(conf: dict, model, device):
     # replicated parameters' gradients never sync across dp — regardless of
     # whether the extra ranks come from domain or tensor parallelism.
     if data_mode == "none" and dp_size > 1:
-        logging.warning(
+        logger.warning(
             f"data=none with dp_size={dp_size} (world={_world_size}, tensor={tp_size}, "
             f"domain={domain_size}): gradients will NOT sync across data-parallel "
             "replicas. Wrap with data=ddp or data=fsdp2."
@@ -502,7 +504,7 @@ def distributed_model_wrapper_gen2(conf: dict, model, device):
         )
         model = convert_to_domain_parallel(model, domain_manager)
         model._domain_parallel_manager = domain_manager
-        logging.info(
+        logger.info(
             f"[V2] Domain parallelism: {domain_size} shards, {world_size // domain_size} data-parallel replicas"
         )
 
@@ -514,7 +516,7 @@ def distributed_model_wrapper_gen2(conf: dict, model, device):
         if tp_mesh is None:
             raise ValueError("TP mesh not found — check tensor > 1 and world_size")
         model = apply_tensor_parallel(model, tp_mesh)
-        logging.info(f"[V2] Tensor parallelism: degree={tp_size}")
+        logger.info(f"[V2] Tensor parallelism: degree={tp_size}")
 
     # Ensure all parameters/buffers are on the target device after domain/TP
     # transforms (which may create new modules via wrapping). Must happen before
@@ -529,7 +531,7 @@ def distributed_model_wrapper_gen2(conf: dict, model, device):
         if dp_size <= 1:
             # FSDP2 with dp=1 is a no-op for gradient sync and converts params to
             # DTensors, which breaks sync_domain_gradients when domain > 1.
-            logging.warning(
+            logger.warning(
                 f"[V2] FSDP2 requested but dp_size={dp_size} (world={dist.get_world_size()}, "
                 f"tensor={tp_size}, domain={domain_size}). Skipping FSDP2 — use data=none or "
                 "increase GPUs so dp_size > 1. Mixed precision falls back to plain autocast "
@@ -540,13 +542,13 @@ def distributed_model_wrapper_gen2(conf: dict, model, device):
 
             model = apply_fsdp2(model, dp_mesh, conf)
             fsdp2_applied = True
-            logging.info("[V2] FSDP2 applied over dp_mesh")
+            logger.info("[V2] FSDP2 applied over dp_mesh")
 
     elif data_mode == "ddp":
         if not dist.is_initialized():
             # Single-process run of a ddp config (plain `python`/`credit train`
             # with no launcher): there is no process group, and DDP would raise.
-            logging.warning("[V2] DDP requested but no process group is initialized — running unwrapped.")
+            logger.warning("[V2] DDP requested but no process group is initialized — running unwrapped.")
         else:
             dp_group = dp_mesh.get_group() if dp_mesh is not None else None
             # static_graph caches the reducer plan from the first iteration, which
@@ -562,7 +564,7 @@ def distributed_model_wrapper_gen2(conf: dict, model, device):
             if dp_group is not None:
                 ddp_kwargs["process_group"] = dp_group
             model = torch.nn.parallel.DistributedDataParallel(model, **ddp_kwargs)
-            logging.info("[V2] DDP applied")
+            logger.info("[V2] DDP applied")
 
     if domain_manager is not None:
         model._domain_parallel_manager = domain_manager

--- a/credit/losses/__init__.py
+++ b/credit/losses/__init__.py
@@ -39,14 +39,15 @@ def load_loss(conf, reduction="none", validation=False):
 
     is_downscaling = "datasets" in conf["data"]
     # downscaling could also use_variable_weights, so it needs to come first
+    mode = "validation" if validation else "train"
     if is_downscaling:
-        logger.info("Loaded DownscalingLoss")
+        logger.info("Loaded DownscalingLoss (%s)", mode)
         return DownscalingLoss(conf, validation=validation)
 
     use_weighted_loss = loss_conf.get("use_latitude_weights", False) or loss_conf.get("use_variable_weights", False)
 
     if use_weighted_loss:
-        logger.info("Loaded the VariableTotalLoss2D loss wrapper class for applying latititude or variable weights")
+        logger.info("Loaded VariableTotalLoss2D (%s)", mode)
         return VariableTotalLoss2D(conf, validation=validation)
 
     # Select loss type for training or validation

--- a/credit/losses/__init__.py
+++ b/credit/losses/__init__.py
@@ -51,6 +51,8 @@ def load_loss(conf, reduction="none", validation=False):
     # downscaling could also use_variable_weights, so it needs to come first
     mode = "validation" if validation else "train"
     if is_downscaling:
+        from credit.losses.downscaling_loss import DownscalingLoss
+
         logger.info("Loaded DownscalingLoss (%s)", mode)
         return DownscalingLoss(conf, validation=validation)
 
@@ -64,6 +66,8 @@ def load_loss(conf, reduction="none", validation=False):
         )
 
     if use_weighted_loss:
+        from credit.losses.weighted_loss import VariableTotalLoss2D
+
         logger.info("Loaded VariableTotalLoss2D (%s)", mode)
         return VariableTotalLoss2D(conf, validation=validation)
 

--- a/credit/losses/base_losses.py
+++ b/credit/losses/base_losses.py
@@ -35,7 +35,8 @@ def base_losses(conf, reduction="mean", validation=False):
     if "reduction" not in loss_params:
         loss_params["reduction"] = reduction
 
-    logger.info(f"Loaded the {loss_type} loss function with parameters: {loss_params}")
+    mode = "validation" if validation else "train"
+    logger.info(f"Loaded the {loss_type} loss function ({mode}) with parameters: {loss_params}")
 
     # Standard loss registry
     losses = {

--- a/credit/losses/weighted_loss.py
+++ b/credit/losses/weighted_loss.py
@@ -28,7 +28,7 @@ def latitude_weights(conf):
     """
     # Open the dataset and extract latitude and longitude information
     ds = xr.open_dataset(conf["loss"]["latitude_weights"])
-    lat = torch.from_numpy(ds["latitude"].values).float()
+    lat = torch.tensor(ds["latitude"].values, dtype=torch.float32)
     lon_dim = ds["longitude"].shape[0]
 
     # Calculate weights using PyTorch operations
@@ -153,7 +153,8 @@ class VariableTotalLoss2D(torch.nn.Module):
 
         self.lat_weights = None
         if conf["loss"]["use_latitude_weights"]:
-            logger.info("Using latitude weights in loss calculations")
+            mode = "validation" if validation else "train"
+            logger.info("Using latitude weights in loss calculations (%s)", mode)
             self.lat_weights = latitude_weights(conf)[:, 10].unsqueeze(0).unsqueeze(-1)
 
         # ------------------------------------------------------------- #

--- a/credit/models/__init__.py
+++ b/credit/models/__init__.py
@@ -274,7 +274,7 @@ def load_model(conf, load_weights=False, model_name=False):
             if not os.path.isfile(ckpt):
                 raise ValueError("No saved checkpoint exists. You must train a model first. Exiting.")
 
-            logging.info(f"Loading a model with pre-trained weights from path {ckpt}")
+            logger.info(f"Loading a model with pre-trained weights from path {ckpt}")
 
             checkpoint = torch.load(ckpt)
             if "model_state_dict" in checkpoint.keys():
@@ -350,7 +350,7 @@ def load_model_name(conf, model_name, load_weights=False):
             if not os.path.isfile(ckpt):
                 raise ValueError("No saved checkpoint exists. You must train a model first. Exiting.")
 
-            logging.info(f"Loading a model with pre-trained weights from path {ckpt}")
+            logger.info(f"Loading a model with pre-trained weights from path {ckpt}")
 
             checkpoint = torch.load(ckpt)
             model.load_state_dict(checkpoint["model_state_dict"])

--- a/credit/models/base_model.py
+++ b/credit/models/base_model.py
@@ -67,7 +67,7 @@ class BaseModel(nn.Module):
         if not os.path.isfile(ckpt):
             raise ValueError("No saved checkpoint exists. You must train a model first. Exiting.")
 
-        logging.info(f"Loading a model with pre-trained weights from path {ckpt}")
+        logger.info(f"Loading a model with pre-trained weights from path {ckpt}")
 
         checkpoint = torch.load(
             ckpt,
@@ -101,7 +101,7 @@ class BaseModel(nn.Module):
         if not os.path.isfile(ckpt):
             raise ValueError(f"No saved checkpoint {ckpt} exists. You must train a model first. Exiting.")
 
-        logging.info(f"Loading a model with pre-trained weights from path {ckpt}")
+        logger.info(f"Loading a model with pre-trained weights from path {ckpt}")
 
         checkpoint = torch.load(
             ckpt,

--- a/credit/models/checkpoint.py
+++ b/credit/models/checkpoint.py
@@ -26,9 +26,9 @@ def load_state_dict_error_handler(load_msg):
     if load_msg[1]:
         raise RuntimeError(str(load_msg))
     elif load_msg[0]:
-        logging.warning(f"Loaded partial model {load_msg}")
+        logging.getLogger(__name__).warning(f"Loaded partial model {load_msg}")
     else:  # all keys matched
-        logging.info(load_msg)
+        logging.getLogger(__name__).info("All keys matched successfully")
 
 
 def get_file_extension(file_path):

--- a/credit/output_gen2.py
+++ b/credit/output_gen2.py
@@ -27,6 +27,7 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
+import tqdm
 import xarray as xr
 import yaml
 
@@ -68,7 +69,6 @@ _VALID_GROUP_BY: dict[str, str] = {
 def _write_netcdf_worker(ds: xr.Dataset, path: str, encoding: dict) -> None:
     try:
         ds.to_netcdf(path, mode="w", encoding=encoding)
-        logger.info("Saved: %s", path)
     except Exception:
         logger.error("Failed to write %s:\n%s", path, traceback.format_exc())
 
@@ -79,7 +79,6 @@ def _write_zarr_worker(ds: xr.Dataset, path: str, append: bool) -> None:
             ds.to_zarr(path, mode="a", append_dim="time")
         else:
             ds.to_zarr(path, mode="w")
-        logger.info("Zarr %s: %s", "appended" if append else "created", path)
     except Exception:
         logger.error("Failed to write zarr %s:\n%s", path, traceback.format_exc())
 
@@ -114,7 +113,7 @@ class ForecastWriter:
             when to flush without an external flush() call.
     """
 
-    def __init__(self, output_conf: dict, conf: dict, n_steps: int) -> None:
+    def __init__(self, output_conf: dict, conf: dict, n_steps: int, verbose: bool = True) -> None:
         self._n_steps = n_steps
         self._conf = conf
 
@@ -156,6 +155,11 @@ class ForecastWriter:
 
         # One-time validation runs on first __call__ when fhr_per_step is known
         self._validated: bool = False
+
+        self._verbose = verbose
+
+        # Pending async netcdf writes: list of (AsyncResult, path) in submission order
+        self._pending: list = []
 
     # ------------------------------------------------------------------
     # Public interface
@@ -267,12 +271,28 @@ class ForecastWriter:
         os.makedirs(os.path.dirname(path), exist_ok=True)
         if self._fmt == "zarr":
             _write_zarr_worker(ds, path, append)
+            if self._verbose:
+                tqdm.tqdm.write(f"Zarr {'appended' if append else 'created'}: {path}")
         else:
             enc = encoding or {}
             if pool is not None:
-                pool.apply_async(_write_netcdf_worker, args=(ds, path, enc))
+                result = pool.apply_async(_write_netcdf_worker, args=(ds, path, enc))
+                self._pending.append((result, path))
             else:
                 _write_netcdf_worker(ds, path, enc)
+                if self._verbose:
+                    tqdm.tqdm.write(f"Saved: {path}")
+
+    def flush(self) -> None:
+        """Wait for all pending async writes in submission order and print each path."""
+        for result, path in self._pending:
+            try:
+                result.get()
+                if self._verbose:
+                    tqdm.tqdm.write(f"Saved: {path}")
+            except Exception as exc:
+                tqdm.tqdm.write(f"Failed: {path}: {exc}")
+        self._pending.clear()
 
     # ------------------------------------------------------------------
     # Path construction

--- a/credit/trainers/base_trainer.py
+++ b/credit/trainers/base_trainer.py
@@ -19,6 +19,7 @@ from collections import OrderedDict, defaultdict
 from typing import Any, Dict, Optional, Callable
 
 import numpy as np
+from tqdm import tqdm
 import pandas as pd
 import torch
 from torch.amp import GradScaler
@@ -300,6 +301,7 @@ class BaseTrainer(ABC):
                 logger.info(f"EMA enabled (decay={ema_decay})")
         else:
             self.ema = None
+        logger.info(f"Grad-max-norm: {self.grad_max_norm}")
 
         # ---- TensorBoard setup ----
         use_tb = trainer_conf.get("use_tensorboard", False)
@@ -314,7 +316,7 @@ class BaseTrainer(ABC):
                 tb_dir = os.path.join(self.save_loc, "tensorboard")
                 self.tb_writer = _SummaryWriter(log_dir=tb_dir)
                 logger.info(f"TensorBoard log dir: {tb_dir}")
-                logger.info(f"  View with: tensorboard --logdir {tb_dir}")
+                logger.info(f"View with: tensorboard --logdir {tb_dir}")
         else:
             self.tb_writer = None
 
@@ -595,7 +597,8 @@ class BaseTrainer(ABC):
                         if os.path.exists(src):
                             shutil.copyfile(src, os.path.join(self.save_loc, f"backup_{fname}"))
 
-            logger.info(f"Beginning epoch {epoch}")
+            if any(h.level <= logging.INFO for h in logging.getLogger().handlers):
+                tqdm.write(f"INFO:credit.trainers.base_trainer:Beginning epoch {epoch}")
 
             # Set epoch on sampler/dataset for reproducible distributed shuffling
             if hasattr(train_loader, "sampler") and hasattr(train_loader.sampler, "set_epoch"):
@@ -717,6 +720,12 @@ class BaseTrainer(ABC):
 
             if self.stop_after_epoch:
                 break
+
+        # Shut down DataLoader workers to avoid leaked semaphore warnings at exit
+        for _loader in (train_loader, valid_loader):
+            if _loader is not None:
+                _loader._iterator = None
+        del train_loader, valid_loader
 
         # Close TensorBoard writer
         if self.tb_writer is not None:

--- a/credit/trainers/rollout_utils.py
+++ b/credit/trainers/rollout_utils.py
@@ -75,6 +75,12 @@ def load_model_for_inference(conf: dict, device: torch.device) -> torch.nn.Modul
     if mode == "ddp":
         model = load_model(conf).to(device)
         model = distributed_model_wrapper(conf, model, device)
+        # Buffers are static once the checkpoint is loaded below (eval mode, no
+        # training), so there's nothing to sync. DDP's default broadcast_buffers=True
+        # makes every forward() a collective requiring all ranks to call it the same
+        # number of times — but rollout ranks can cover an uneven number of init
+        # times, so disable it to avoid a mid-loop hang.
+        model.broadcast_buffers = False
         # Mirror BaseModel.load_model: prefer model_checkpoint.pt, fall back to checkpoint.pt
         ckpt_path = os.path.join(save_loc, "model_checkpoint.pt")
         if not os.path.isfile(ckpt_path):

--- a/credit/trainers/rollout_utils.py
+++ b/credit/trainers/rollout_utils.py
@@ -114,6 +114,7 @@ def run_forecast(
     device: torch.device,
     pool,
     save_output_fn,
+    verbose: bool = True,  # False on non-rank-0 workers in DDP to suppress tqdm and save-path output
 ) -> None:
     """Run one autoregressive forecast, consuming n_steps batches from batch_iter.
 
@@ -162,7 +163,9 @@ def run_forecast(
 
     # ── Autoregressive loop ──────────────────────────────────────────────────
     with torch.no_grad():
-        for step in tqdm(range(1, n_steps + 1), desc=f"Rollout {init_str}"):
+        for step in tqdm(
+            range(1, n_steps + 1), desc=f"Rollout {init_str}", disable=not verbose
+        ):  # one bar on rank 0 only
             full_data_dict["y_pred"] = model(full_data_dict["x"])
 
             # postblocks: Reconstruct → inverse_scaler → physics fixers
@@ -186,6 +189,9 @@ def run_forecast(
     # post_rollout postblocks (e.g. global physics fixers applied once)
     apply_postblocks(rollout_postblocks, full_data_dict)
 
+    # Make sure all output files are fully written before starting the next forecast.
+    if hasattr(save_output_fn, "flush"):
+        save_output_fn.flush()
     logger.info("Done: %s", init_str)
 
 

--- a/credit/trainers/trainer_gen2.py
+++ b/credit/trainers/trainer_gen2.py
@@ -49,7 +49,6 @@ class TrainerERA5Gen2(BaseTrainer):
             conf: Full configuration dict.
         """
         super().__init__(model, rank, conf)
-        logger.info("Loading ERA5 Gen 2 trainer (new nested data schema, preblock-assembled batches)")
 
         # The config can request fsdp2 while the wrapper skips it (dp_size <= 1).
         # AMP decisions must follow what was actually applied: when FSDP2 is
@@ -210,7 +209,6 @@ class TrainerERA5Gen2(BaseTrainer):
         """
         if self.ensemble_size > 1:
             logger.info(f"ensemble training with ensemble_size {self.ensemble_size}")
-        logger.info(f"Using grad-max-norm value: {self.grad_max_norm}")
 
         if self.use_scheduler and self.scheduler_type == "lambda":
             scheduler.step()
@@ -238,7 +236,12 @@ class TrainerERA5Gen2(BaseTrainer):
         if hasattr(_sampler, "set_epoch"):
             _sampler.set_epoch(epoch)
 
-        batch_group_generator = tqdm.tqdm(range(batches_per_epoch), total=batches_per_epoch, leave=True)
+        batch_group_generator = tqdm.tqdm(
+            range(batches_per_epoch),
+            total=batches_per_epoch,
+            leave=True,
+            disable=not any(h.level <= logging.INFO for h in logging.getLogger().handlers),
+        )
         self.model.train()
 
         dl = cycle(trainloader)
@@ -423,7 +426,12 @@ class TrainerERA5Gen2(BaseTrainer):
             )
 
         results_dict = defaultdict(list)
-        batch_group_generator = tqdm.tqdm(range(valid_batches_per_epoch), total=valid_batches_per_epoch, leave=True)
+        batch_group_generator = tqdm.tqdm(
+            range(valid_batches_per_epoch),
+            total=valid_batches_per_epoch,
+            leave=True,
+            disable=not any(h.level <= logging.INFO for h in logging.getLogger().handlers),
+        )
 
         dl = cycle(valid_loader)
         with torch.no_grad():

--- a/credit/trainers/utils.py
+++ b/credit/trainers/utils.py
@@ -470,7 +470,7 @@ def load_dataset(conf: dict, is_train: bool) -> MultiSourceDataset:
                 "Either add them or remove validation_data to use training config."
             )
 
-    return MultiSourceDataset(data_conf, return_target=True)
+    return MultiSourceDataset(data_conf, return_target=True, label="train" if is_train else "valid")
 
 
 def load_dataloader(
@@ -479,6 +479,7 @@ def load_dataloader(
     rank: int,
     world_size: int,
     is_train: bool,
+    persistent_workers: bool | None = None,
 ) -> DataLoader:
     """Build a DataLoader with DistributedMultiStepBatchSampler.
 
@@ -518,13 +519,14 @@ def load_dataloader(
         seed=seed,
     )
 
+    _persistent_workers = (num_workers > 0) if persistent_workers is None else persistent_workers
     return DataLoader(
         dataset,
         batch_sampler=sampler,
         num_workers=num_workers,
         prefetch_factor=prefetch_factor,
         pin_memory=True,
-        persistent_workers=num_workers > 0,
+        persistent_workers=_persistent_workers,
         multiprocessing_context="spawn" if num_workers > 0 else None,
     )
 


### PR DESCRIPTION
## Summary
Improves logging readability across `preprocess`, `train`, and `rollout`. For DDP runs, progress output is now shown only from rank 0 to avoid interleaved logs. A `--log-all-ranks` flag has been added to all three applications to restore full multi-rank output for debugging.

Also fixes `credit submit --mode rollout` for gen2 (`inference:`-schema) configs, which previously crashed or produced broken jobs:
- Forecast counting now reads `inference.batch_forecast` instead of the gen1-only `predict.forecasts` path, which silently failed and crashed the plan-summary printer with a `TypeError`.
- Dropped the `--subset`/`--no_subset` flags passed to `rollout_gen2.py` — it doesn't implement per-job subsetting yet, so they errored as unrecognized arguments. `--jobs N > 1` currently submits N redundant full-range jobs rather than splitting the work; `--help` text now says so, and recommends `--jobs 1` until subsetting lands.
- `rollout_gen2.py`'s DDP sampler no longer pads init times to force even divisibility across ranks (previously via `DistributedMultiStepBatchSampler`), so ranks can cover an uneven number of forecasts without silently duplicating work. Added a `dist.barrier()` before process-group teardown, and disabled `broadcast_buffers` on the inference DDP wrap, so an uneven per-rank forecast count can no longer deadlock mid-loop. **This resolved the issue I raised during standup yesterday.**

**Note:** the rollout CLI flags (`--jobs`, `--subset`/`--no_subset`) should be revisited once ensemble support is fully merged into CREDIT Gen2 — this PR only unblocks single-job (`--jobs 1`) submission.

## How to test

```bash
credit submit -c config/gen_2/examples/example-end-to-end.yml --mode [preprocess | train | rollout] --cpus 9 --gpu-type v100 --gpus 2 --walltime 00:15:00 --cluster casper --conda-env credit-casper
```

The only remaining issue is that, during DDP training, the following warning message appears. @jsschreck, could you take a look when you get a chance? I believe it has something to do with WXFormer.
<img width="3048" height="450" alt="image" src="https://github.com/user-attachments/assets/d9f26450-788e-4f4f-8297-22e538953277" />

### Checklist
- [X] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date.