### PR TITLE
Small postblock bug (gen1 / gen2)

### DIFF
--- a/credit/postblock/__init__.py
+++ b/credit/postblock/__init__.py
@@ -17,7 +17,7 @@ _POSTBLOCK_REGISTRY = {
     "square_transform": ("credit.postblock.square", "SquareTransform"),
     "wet_mask_samudra": ("credit.postblock.wet_mask_samudra", "WetMaskBlock"),
     "mslp_diagnostic": ("credit.postblock.mslp", "MSLPDiagnostic"),
-    "tracer_fixer": ("credit.postblock.gen1", "TracerFixer"),
+    "tracer_fixer": ("credit.postblock.conservation", "TracerFixer"),
     "global_mass_fixer": ("credit.postblock.conservation", "GlobalMassFixer"),
     "global_water_fixer": ("credit.postblock.conservation", "GlobalWaterFixer"),
     "global_energy_fixer": ("credit.postblock.conservation", "GlobalEnergyFixerUpDown"),


### PR DESCRIPTION
### Description

Tracer Postblock had a gen1 reference in the registry that this fixes (1 line). 

Closes #XXX

### Checklist
- [ ] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date.
