### PR TITLE
GFS and GEFS Gen 2 Datasets

### DIFF
--- a/credit/datasets/__init__.py
+++ b/credit/datasets/__init__.py
@@ -29,6 +29,7 @@ _CLASS_SOURCES = {
     "GOESDataset": ("credit.datasets.gen_2.goes", "GOESDataset"),
     "MRMSDataset": ("credit.datasets.gen_2.mrms", "MRMSDataset"),
     "HRRRDataset": ("credit.datasets.gen_2.hrrr", "HRRRDataset"),
+    "GFSDataset": ("credit.datasets.gen_2.gfs", "GFSDataset"),
     "TISRDataset": ("credit.datasets.gen_2.tisr", "TISRDataset"),
     "build_channel_layout": ("credit.datasets.gen_2.channel_utils", "build_channel_layout"),
     "update_x": ("credit.datasets.gen_2.channel_utils", "update_x"),

--- a/credit/datasets/__init__.py
+++ b/credit/datasets/__init__.py
@@ -30,6 +30,7 @@ _CLASS_SOURCES = {
     "MRMSDataset": ("credit.datasets.gen_2.mrms", "MRMSDataset"),
     "HRRRDataset": ("credit.datasets.gen_2.hrrr", "HRRRDataset"),
     "GFSDataset": ("credit.datasets.gen_2.gfs", "GFSDataset"),
+    "GEFSDataset": ("credit.datasets.gen_2.gefs", "GEFSDataset"),
     "TISRDataset": ("credit.datasets.gen_2.tisr", "TISRDataset"),
     "build_channel_layout": ("credit.datasets.gen_2.channel_utils", "build_channel_layout"),
     "update_x": ("credit.datasets.gen_2.channel_utils", "update_x"),

--- a/credit/datasets/gen_2/gefs.py
+++ b/credit/datasets/gen_2/gefs.py
@@ -1,0 +1,529 @@
+"""
+gefs.py
+-------
+GEFS ensemble cube-sphere data loading for CREDIT Gen2.
+
+This module provides ``GEFSDataset`` for the raw GEFS initialization files in
+the public ``gfs-ensemble-forecast-system`` Google Cloud bucket. Each selected
+ensemble member contains six atmospheric and six surface cube-sphere tiles.
+The dataset reads only configured variables, stacks members first, flattens
+the six tiles into ``tile_lat_lon``, and leaves regridding and vertical
+interpolation to downstream CREDIT blocks.
+
+The raw files are organized as::
+
+    gefs.YYYYMMDD/HH/atmos/init/{member}/gfs_ctrl.nc
+    gefs.YYYYMMDD/HH/atmos/init/{member}/gfs_data.tile{1..6}.nc
+    gefs.YYYYMMDD/HH/atmos/init/{member}/sfc_data.tile{1..6}.nc
+
+Only initialization-time cube-sphere NetCDF files are supported. Forecast
+lead products in the bucket are different GRIB2 products and are intentionally
+outside this dataset's scope.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import torch
+import xarray as xr
+
+from credit.datasets.gen_2.base_dataset import VALID_FIELD_TYPES, BaseDataset
+from credit.datasets.gen_2.gfs import _ObstoreFile  # pyright: ignore[reportPrivateUsage]
+from credit.datasets.gen_2.grid_utils import write_source_grid_schema_if_missing
+
+logger = logging.getLogger(__name__)
+
+_GEFS_BUCKET = "gfs-ensemble-forecast-system"
+_NUM_TILES = 6
+_MEMBER_PATTERN = re.compile(r"(?:c00|p\d{2})$")
+_ATM_2D_VARIABLES = {"ps"}
+_ATM_3D_VARIABLES = {
+    "w",
+    "zh",
+    "t",
+    "delp",
+    "sphum",
+    "liq_wat",
+    "o3mr",
+    "ice_wat",
+    "rainwat",
+    "snowwat",
+    "graupel",
+    "u_w",
+    "v_w",
+    "u_s",
+    "v_s",
+    "u_a",
+    "v_a",
+}
+_SURFACE_VARIABLES = {
+    "slmsk",
+    "tsea",
+    "sheleg",
+    "tg3",
+    "zorl",
+    "alvsf",
+    "alvwf",
+    "alnsf",
+    "alnwf",
+    "facsf",
+    "facwf",
+    "vfrac",
+    "canopy",
+    "f10m",
+    "t2m",
+    "q2m",
+    "vtype",
+    "stype",
+    "uustar",
+    "ffmm",
+    "ffhh",
+    "hice",
+    "fice",
+    "tisfc",
+    "tprcp",
+    "srflag",
+    "snwdph",
+    "shdmin",
+    "shdmax",
+    "slope",
+    "snoalb",
+    "stc",
+    "smc",
+    "slc",
+    "tref",
+    "z_c",
+    "c_0",
+    "c_d",
+    "w_0",
+    "w_d",
+    "xt",
+    "xs",
+    "xu",
+    "xv",
+    "xz",
+    "zm",
+    "xtts",
+    "xzts",
+    "d_conv",
+    "ifd",
+    "dt_cool",
+    "qrain",
+}
+
+
+def _run_prefix(t: pd.Timestamp) -> str:
+    return f"gefs.{t:%Y%m%d}/{t:%H}/atmos/init"
+
+
+def _member_prefix(t: pd.Timestamp, member: str, base_path: str | None = None) -> str:
+    prefix = f"{_run_prefix(t)}/{member}"
+    return os.path.join(base_path, prefix) if base_path else prefix
+
+
+def _member_file_paths(
+    t: pd.Timestamp,
+    member: str,
+    base_path: str | None = None,
+) -> tuple[str, list[str], list[str]]:
+    prefix = _member_prefix(t, member, base_path)
+    control = os.path.join(prefix, "gfs_ctrl.nc")
+    atmospheric = [os.path.join(prefix, f"gfs_data.tile{tile}.nc") for tile in range(1, _NUM_TILES + 1)]
+    surface = [os.path.join(prefix, f"sfc_data.tile{tile}.nc") for tile in range(1, _NUM_TILES + 1)]
+    return control, atmospheric, surface
+
+
+def _member_sort_key(member: str) -> tuple[int, int]:
+    return (0, 0) if member == "c00" else (1, int(member[1:]))
+
+
+class GEFSDataset(BaseDataset):
+    """Read raw GEFS cube-sphere initialization data for selected members.
+
+    The selected members are stacked in the leading tensor dimension. Six
+    cube-sphere tiles are flattened into one spatial dimension so a 3D tensor
+    has shape ``(members, levels, 1, tile_lat_lon)`` and a 2D tensor has shape
+    ``(members, 1, 1, tile_lat_lon)``. This leading member dimension is
+    intentionally preserved through the Gen2 data pipeline and is compatible
+    with the flattened-spatial handling in the ``Regridder`` preblock.
+
+    Raw staggered wind fields are requested with their native names ``u_s``,
+    ``v_s``, ``u_w``, and ``v_w``. Users who want unstaggered winds should
+    request the virtual variables ``u_a`` and ``v_a``; these are computed from
+    ``u_s`` and ``v_w`` respectively. There is no ``forecast_hour`` setting:
+    this class reads only the cube-sphere initialization NetCDF files.
+
+    Input settings:
+        dataset_type (str): Must be ``"gefs"`` when routed through
+            ``MultiSourceDataset``.
+        members (list[str] | None): Members to read, such as
+            ``["c00", "p01", "p02"]``. Omitted configuration defaults to
+            ``["c00"]``. An explicit empty list discovers and selects every
+            member available in the first requested run.
+        mode (str): ``"remote"`` reads from Google Cloud Storage using
+            obstore. ``"local"`` reads the directory created by
+            ``gefs_download.py``. Defaults to ``"remote"``.
+        base_path (str): Root directory for local mode. Required when
+            ``mode`` is ``"local"``.
+        levels (list[int] | None): One-based model-level indices in the raw
+            ``lev`` dimension. The GEFS cube-sphere files contain 65 model
+            levels. ``None`` selects all 65 levels. ``zh`` is converted from
+            66 interfaces to 65 model-level midpoints before this selection.
+        variables (dict): Field definitions grouped under ``prognostic``,
+            ``dynamic_forcing``, ``static``, and ``diagnostic``. Use native
+            GEFS names in ``vars_3D`` and ``vars_2D``.
+        return_target (bool): Constructor argument controlling whether the
+            sample includes the next initialization time under ``target``.
+
+    Attributes:
+        dataset_type (str): The registered dataset type, ``"gefs"``.
+        members (list[str]): Selected members in output stacking order.
+        mode (str): Active storage mode, ``"remote"`` or ``"local"``.
+        base_path (str | None): Expanded local storage root, if configured.
+        levels (list[int] | None): Configured one-based model-level selection.
+        datetimes (pandas.DatetimeIndex): Available initialization timestamps.
+        file_dict (dict): Registered field types and their source markers.
+        var_dict (dict): Registered native GEFS variables grouped by field.
+        static_metadata (dict): Selected members, vertical-coordinate metadata,
+            and the native unstructured cube-sphere grid.
+
+    Example YAML configuration::
+
+        data:
+          source:
+            GEFS:
+              dataset_type: "gefs"
+              mode: "remote"
+              members: ["c00"]
+              levels: [1, 65]
+              variables:
+                prognostic:
+                  vars_3D: [t]
+                  vars_2D: [ps]
+                dynamic_forcing: null
+                static: null
+                diagnostic: null
+          start_datetime: "2024-01-01T00:00:00"
+          end_datetime: "2024-01-01T06:00:00"
+          timestep: "6h"
+          forecast_len: 1
+
+    An empty member list selects all members discovered in the first run::
+
+        members: []
+
+    Python usage::
+
+        import yaml
+        from credit.datasets.gen_2.gefs import GEFSDataset
+
+        with open("config/gefs.yml") as file:
+            config = yaml.safe_load(file)
+        dataset = GEFSDataset(config["data"], return_target=True)
+        sample = dataset[(dataset.datetimes[0], 0)]
+        print(sample["input"]["GEFS/prognostic/3d/t"].shape)
+    """
+
+    def __init__(self, data_config: dict[str, Any], return_target: bool = False) -> None:
+        source_name = next(iter(data_config.get("source", {})), None)
+        source_cfg = data_config.get("source", {}).get(source_name, {}) if source_name else {}
+        if "forecast_hour" in source_cfg:
+            raise ValueError(
+                "GEFSDataset supports initialization-time cube-sphere NetCDF files only; remove forecast_hour."
+            )
+
+        configured_members = source_cfg.get("members")
+        self._select_all_members = configured_members == []
+        self.members: list[str] = ["c00"] if configured_members is None else list(configured_members)
+        self._validate_members(self.members)
+        self.mode = source_cfg.get("mode", "remote")
+        self.engine = source_cfg.get("engine")
+        self.base_path = (
+            os.path.expanduser(os.path.expandvars(source_cfg["base_path"])) if source_cfg.get("base_path") else None
+        )
+        self.levels: list[int] | None = source_cfg.get("levels")
+        self._obstore = None
+        self._run_objects: dict[tuple[pd.Timestamp, str], set[str]] = {}
+        self._vcoord: np.ndarray | None = None
+        self._initial_source_cfg = source_cfg
+
+        super().__init__(data_config, return_target)
+
+        if "mode" not in self.curr_source_cfg:
+            self.mode = "remote"
+        if self.mode not in ("local", "remote"):
+            raise ValueError(f"Unknown mode '{self.mode}'. Expected 'local' or 'remote'.")
+        if self.mode == "local" and self.base_path is None:
+            raise ValueError(f"A base_path is required for local GEFS mode in source '{self.curr_source_name}'.")
+        if self.levels is not None:
+            self.levels = [int(level) for level in self.levels]
+
+        self.dataset_type = "gefs"
+        self.static_metadata = {
+            "members": self.members,
+            "levels": self.levels,
+            "datetime_fmt": "unix_ns",
+        }
+        if self._vcoord is not None:
+            self._set_vertical_metadata(self._vcoord)
+        self.init_register_all_fields()
+
+    @staticmethod
+    def _validate_members(members: list[str]) -> None:
+        invalid = [
+            member for member in members if not isinstance(member, str) or _MEMBER_PATTERN.fullmatch(member) is None
+        ]
+        if invalid:
+            raise ValueError(f"Invalid GEFS members {invalid}; use 'c00' or perturbation members such as 'p01'.")
+        if len(set(members)) != len(members):
+            raise ValueError(f"GEFS members must be unique, got {members}.")
+
+    def _build_timestamps(self) -> pd.DatetimeIndex:
+        timestamps = super()._build_timestamps()
+        if not isinstance(timestamps, pd.DatetimeIndex) or not len(timestamps):
+            return timestamps
+
+        first_time = pd.Timestamp(timestamps[0])
+        if self._select_all_members:
+            self.members = self._discover_members(first_time)
+            if not self.members:
+                raise FileNotFoundError(f"No GEFS members were found for initialization {first_time}.")
+
+        for timestamp in timestamps:
+            self._require_run(pd.Timestamp(timestamp))
+        self._load_control_metadata(first_time, self.members[0])
+        return timestamps
+
+    def _discover_members(self, t: pd.Timestamp) -> list[str]:
+        if self.mode == "local":
+            run_path = os.path.join(self.base_path or "", _run_prefix(t))
+            if not os.path.isdir(run_path):
+                raise FileNotFoundError(f"GEFS initialization directory not found: {run_path}")
+            members = [name for name in os.listdir(run_path) if os.path.isdir(os.path.join(run_path, name))]
+        else:
+            import obstore
+            from obstore.store import GCSStore
+
+            if self._obstore is None:
+                self._obstore = GCSStore(bucket=_GEFS_BUCKET, config={"skip_signature": True})
+            result = obstore.list_with_delimiter(self._obstore, prefix=f"{_run_prefix(t)}/")
+            members = [prefix.rstrip("/").rsplit("/", 1)[-1] for prefix in result.get("common_prefixes", [])]
+            members.extend(
+                entry["path"].rstrip("/").rsplit("/", 1)[-1]
+                for entry in result.get("objects", [])
+                if entry["path"].rstrip("/").count("/") == _run_prefix(t).count("/") + 1
+            )
+        valid = sorted({member for member in members if _MEMBER_PATTERN.fullmatch(member)}, key=_member_sort_key)
+        return valid
+
+    def _require_run(self, t: pd.Timestamp) -> None:
+        missing_by_member: dict[str, list[str]] = {}
+        for member in self.members:
+            missing = self._missing_member_files(t, member)
+            if missing:
+                missing_by_member[member] = missing
+        if missing_by_member:
+            details = "; ".join(f"{member}: {', '.join(files)}" for member, files in missing_by_member.items())
+            raise FileNotFoundError(f"GEFS initialization {t} is incomplete for selected members ({details}).")
+
+    def _missing_member_files(self, t: pd.Timestamp, member: str) -> list[str]:
+        control, atmospheric, surface = _member_file_paths(t, member, self.base_path)
+        required = [
+            os.path.basename(control),
+            *(os.path.basename(path) for path in atmospheric),
+            *(os.path.basename(path) for path in surface),
+        ]
+        if self.mode == "local":
+            paths = [control, *atmospheric, *surface]
+            return [os.path.basename(path) for path in paths if not os.path.isfile(path)]
+
+        key = (t, member)
+        if key not in self._run_objects:
+            self._run_objects[key] = self._list_member_objects(t, member)
+        return [name for name in required if name not in self._run_objects[key]]
+
+    def _list_member_objects(self, t: pd.Timestamp, member: str) -> set[str]:
+        import obstore
+        from obstore.store import GCSStore
+
+        if self._obstore is None:
+            self._obstore = GCSStore(bucket=_GEFS_BUCKET, config={"skip_signature": True})
+        result = obstore.list_with_delimiter(self._obstore, prefix=f"{_member_prefix(t, member)}/")
+        return {entry["path"].rsplit("/", 1)[-1] for entry in result.get("objects", [])}
+
+    def _get_file_source(self, field_config: dict[str, Any]) -> bool:
+        return True
+
+    def _register_field(self, field_type: VALID_FIELD_TYPES, field_config: dict[str, Any] | None) -> None:
+        super()._register_field(field_type, field_config)
+        if field_config is None:
+            return
+        for variable in self.var_dict[field_type]["vars_3D"] + self.var_dict[field_type]["vars_2D"]:
+            if variable not in _ATM_3D_VARIABLES | _ATM_2D_VARIABLES | _SURFACE_VARIABLES:
+                raise KeyError(f"Unknown GEFS variable '{variable}'.")
+        self.file_dict[field_type] = True
+
+    def _open_dataset(self, path: str) -> tuple[xr.Dataset, Any | None]:
+        if self.mode == "local":
+            return xr.open_dataset(path, engine=self.engine or "netcdf4"), None
+
+        import obstore
+        from obstore.store import GCSStore
+
+        if self._obstore is None:
+            self._obstore = GCSStore(bucket=_GEFS_BUCKET, config={"skip_signature": True})
+        reader = obstore.open_reader(self._obstore, path)
+        return xr.open_dataset(_ObstoreFile(reader), engine="h5netcdf"), reader
+
+    def _load_control_metadata(self, t: pd.Timestamp, member: str) -> None:
+        base_path = self.base_path if self.mode == "local" else None
+        control_path, _, _ = _member_file_paths(t, member, base_path)
+        ds, reader = self._open_dataset(control_path)
+        try:
+            self._vcoord = np.asarray(ds["vcoord"].values)
+        finally:
+            ds.close()
+            if reader is not None:
+                reader.close()
+        self._set_vertical_metadata(self._vcoord)
+
+    def _set_vertical_metadata(self, vcoord: np.ndarray | None) -> None:
+        if vcoord is None or not hasattr(self, "static_metadata"):
+            return
+        self.static_metadata["vcoord"] = vcoord
+        self.static_metadata["model_a"] = vcoord[0]
+        self.static_metadata["model_b"] = vcoord[1]
+        self.static_metadata["levels"] = self.levels or list(range(1, vcoord.shape[1]))
+
+    def _extract_field(
+        self,
+        field_type: VALID_FIELD_TYPES,
+        t: pd.Timestamp,
+        sample: dict[str, Any],
+    ) -> None:
+        vd = self.var_dict.get(field_type)
+        if not vd:
+            return
+        vars_3d = vd["vars_3D"]
+        vars_2d = vd["vars_2D"]
+        arrays: dict[str, list[np.ndarray]] = {variable: [] for variable in vars_3d + vars_2d}
+        grid_lat: list[np.ndarray] = []
+        grid_lon: list[np.ndarray] = []
+
+        for member in self.members:
+            member_arrays = {variable: [] for variable in vars_3d + vars_2d}
+            for tile in range(1, _NUM_TILES + 1):
+                base_path = self.base_path if self.mode == "local" else None
+                _, atmospheric, surface = _member_file_paths(pd.Timestamp(t), member, base_path)
+                atm_path = atmospheric[tile - 1]
+                sfc_path = surface[tile - 1]
+                atm_vars = [variable for variable in vars_3d if variable in _ATM_3D_VARIABLES]
+                atm_vars.extend(variable for variable in vars_2d if variable in _ATM_2D_VARIABLES)
+                if "u_a" in vars_3d and "u_s" not in atm_vars:
+                    atm_vars.append("u_s")
+                if "v_a" in vars_3d and "v_w" not in atm_vars:
+                    atm_vars.append("v_w")
+                if atm_vars:
+                    ds, reader = self._open_dataset(atm_path)
+                    try:
+                        if len(grid_lat) < tile:
+                            grid_lat.append(np.asarray(ds["geolat"].values))
+                            grid_lon.append(np.asarray(ds["geolon"].values))
+                        for variable in vars_3d:
+                            if variable in _ATM_3D_VARIABLES:
+                                member_arrays[variable].append(self._read_atmospheric_variable(ds, variable))
+                        for variable in vars_2d:
+                            if variable in _ATM_2D_VARIABLES:
+                                member_arrays[variable].append(np.asarray(ds[variable].values))
+                    finally:
+                        ds.close()
+                        if reader is not None:
+                            reader.close()
+                sfc_vars = [variable for variable in vars_2d if variable in _SURFACE_VARIABLES]
+                if sfc_vars:
+                    ds, reader = self._open_dataset(sfc_path)
+                    try:
+                        ds_t = ds.isel(Time=0, drop=True) if "Time" in ds.dims else ds
+                        if len(grid_lat) < tile and "geolat" in ds_t and "geolon" in ds_t:
+                            grid_lat.append(np.asarray(ds_t["geolat"].values))
+                            grid_lon.append(np.asarray(ds_t["geolon"].values))
+                        for variable in sfc_vars:
+                            member_arrays[variable].append(np.asarray(ds_t[variable].values))
+                    finally:
+                        ds.close()
+                        if reader is not None:
+                            reader.close()
+
+            for variable in vars_3d + vars_2d:
+                if not member_arrays[variable]:
+                    raise KeyError(f"GEFS variable '{variable}' was not found in the requested files.")
+                arrays[variable].append(
+                    np.concatenate([array.reshape(array.shape[0], -1) for array in member_arrays[variable]], axis=1)
+                    if variable in vars_3d
+                    else np.concatenate([array.reshape(-1) for array in member_arrays[variable]])
+                )
+
+        if grid_lat and "grid" not in self.static_metadata:
+            self._cache_grid(grid_lat, grid_lon)
+        for variable in vars_3d:
+            values = torch.as_tensor(np.stack(arrays[variable]), dtype=torch.float32).unsqueeze(2)
+            sample[self._get_field_name(field_type, "3d", variable)] = values
+        for variable in vars_2d:
+            values = torch.as_tensor(np.stack(arrays[variable]), dtype=torch.float32).unsqueeze(1).unsqueeze(2)
+            sample[self._get_field_name(field_type, "2d", variable)] = values
+
+    def _read_atmospheric_variable(self, ds: xr.Dataset, variable: str) -> np.ndarray:
+        indices = self._level_indices(ds.sizes["lev"])
+        if variable == "u_a":
+            values = np.asarray(ds["u_s"].values)
+            values = 0.5 * (values[:, :-1, :] + values[:, 1:, :])
+        elif variable == "v_a":
+            values = np.asarray(ds["v_w"].values)
+            values = 0.5 * (values[:, :, :-1] + values[:, :, 1:])
+        elif variable == "zh":
+            values = np.asarray(ds["zh"].values)
+            values = 0.5 * (values[:-1] + values[1:])
+        else:
+            values = np.asarray(ds[variable].values)
+        return values[indices]
+
+    def _level_indices(self, n_levels: int) -> list[int]:
+        if self.levels is None:
+            return list(range(n_levels))
+        if any(level < 1 or level > n_levels for level in self.levels):
+            raise ValueError(f"GEFS model levels must be one-based indices in [1, {n_levels}], got {self.levels}.")
+        return [level - 1 for level in self.levels]
+
+    def _cache_grid(self, lat_tiles: list[np.ndarray], lon_tiles: list[np.ndarray]) -> None:
+        lat = np.concatenate([tile.reshape(-1) for tile in lat_tiles])
+        lon = np.concatenate([tile.reshape(-1) for tile in lon_tiles])
+        grid = {"grid_type": "unstructured", "lat": lat, "lon": lon}
+        self.static_metadata["grid"] = grid
+        write_source_grid_schema_if_missing(self.curr_source_name, grid, self.save_loc)
+
+    def _extract_field_window(
+        self,
+        field_type: VALID_FIELD_TYPES,
+        t_history: pd.DatetimeIndex,
+        sample: dict[str, Any],
+    ) -> None:
+        if field_type == "static":
+            step_sample: dict[str, Any] = {}
+            self._extract_field(field_type, t_history[-1], step_sample)
+            for key, value in step_sample.items():
+                sample[key] = value.repeat(1, 1, len(t_history), 1)
+            return
+
+        per_step: list[dict[str, Any]] = []
+        for timestamp in t_history:
+            step_sample: dict[str, Any] = {}
+            self._extract_field(field_type, timestamp, step_sample)
+            per_step.append(step_sample)
+        for key in per_step[0]:
+            sample[key] = torch.cat([step[key] for step in per_step], dim=2)

--- a/credit/datasets/gen_2/gefs_download.py
+++ b/credit/datasets/gen_2/gefs_download.py
@@ -1,0 +1,143 @@
+"""
+gefs_download.py
+----------------
+Download raw GEFS cube-sphere initialization files for local Gen2 loading.
+
+The downloader uses the same source configuration as ``GEFSDataset`` and
+preserves the public GEFS layout::
+
+    {base_path}/gefs.YYYYMMDD/HH/atmos/init/{member}/gfs_ctrl.nc
+    {base_path}/gefs.YYYYMMDD/HH/atmos/init/{member}/gfs_data.tile1.nc
+    {base_path}/gefs.YYYYMMDD/HH/atmos/init/{member}/sfc_data.tile1.nc
+
+All six atmospheric and six surface tiles are downloaded for every selected
+member and initialization time. Forecast lead products are not supported;
+
+Command-line usage::
+
+    python -m credit.datasets.gen_2.gefs_download -c config/gefs.yml
+    python -m credit.datasets.gen_2.gefs_download -c config/gefs.yml --num-workers 8 --overwrite
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, NamedTuple
+
+import pandas as pd
+
+from credit.datasets.gen_2.gefs import (
+    _GEFS_BUCKET,
+    GEFSDataset,
+    _member_file_paths,
+)
+from credit.datasets.gen_2.multi_source import make_single_source_subconfig
+
+logger = logging.getLogger(__name__)
+
+
+class _DownloadTask(NamedTuple):
+    remote_path: str
+    local_path: str
+    overwrite: bool
+
+
+def _download_one(task: _DownloadTask, store: Any) -> str:
+    if os.path.exists(task.local_path) and not task.overwrite:
+        return f"skip  {task.local_path}"
+    os.makedirs(os.path.dirname(task.local_path), exist_ok=True)
+    try:
+        result = store.get(task.remote_path)
+        with open(task.local_path, "wb") as output:
+            output.write(result.bytes())
+        return f"ok    {task.local_path}"
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not download %s: %s", task.remote_path, exc)
+        return f"miss  {task.remote_path}"
+
+
+def download_gefs(data_config: dict[str, Any], num_workers: int = 4, overwrite: bool = False) -> None:
+    """Download selected GEFS initialization files for local ``GEFSDataset`` use.
+
+    Args:
+        data_config: Top-level ``data`` configuration with exactly one
+            ``dataset_type: "gefs"`` source. The source must define
+            ``base_path``. Omitted ``members`` downloads ``c00``; an empty
+            member list discovers all members in the first requested run.
+        num_workers: Number of concurrent file downloads. Defaults to ``4``.
+        overwrite: Redownload existing files when ``True``. Defaults to
+            ``False``.
+
+    Raises:
+        KeyError: If the configuration does not contain a ``source`` block.
+        ValueError: If the configuration has multiple sources, the wrong
+            dataset type, no base path, or a forecast lead setting.
+        FileNotFoundError: If any selected member or required tile is missing
+            for a requested initialization.
+
+    Example:
+        >>> from credit.datasets.gen_2.gefs_download import download_gefs
+        >>> download_gefs(config["data"], num_workers=8)
+    """
+    source_name = next(iter(data_config["source"]))
+    if len(data_config["source"]) > 1:
+        raise ValueError("Provide a config containing exactly one GEFS source.")
+    source_cfg = data_config["source"][source_name]
+    if source_cfg.get("dataset_type") != "gefs":
+        raise ValueError(f"Expected dataset_type 'gefs', got {source_cfg.get('dataset_type')!r}.")
+    if "base_path" not in source_cfg:
+        raise ValueError("base_path is required to download GEFS files.")
+    if "forecast_hour" in source_cfg:
+        raise ValueError("GEFS cube-sphere downloads support initialization times only; remove forecast_hour.")
+
+    source_data = make_single_source_subconfig(data_config, source_name)
+    source_data["source"][source_name] = {
+        **source_data["source"][source_name],
+        "mode": "remote",
+    }
+    dataset = GEFSDataset(source_data)
+    tasks: list[_DownloadTask] = []
+    seen: set[str] = set()
+    for timestamp in dataset.datetimes:
+        t = pd.Timestamp(timestamp)
+        for member in dataset.members:
+            control, atmospheric, surface = _member_file_paths(t, member)
+            local_control, local_atmospheric, local_surface = _member_file_paths(t, member, dataset.base_path)
+            for remote_path, local_path in zip(
+                [control, *atmospheric, *surface],
+                [local_control, *local_atmospheric, *local_surface],
+            ):
+                if remote_path not in seen:
+                    seen.add(remote_path)
+                    tasks.append(_DownloadTask(remote_path, local_path, overwrite))
+
+    import obstore
+    from obstore.store import GCSStore
+
+    del obstore
+    store = GCSStore(bucket=_GEFS_BUCKET, config={"skip_signature": True})
+    with ThreadPoolExecutor(max_workers=num_workers) as executor:
+        for result in executor.map(lambda task: _download_one(task, store), tasks):
+            logger.info(result)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    import yaml
+
+    parser = argparse.ArgumentParser(description="Download GEFS cube-sphere initialization NetCDF files.")
+    parser.add_argument("-c", "--config", required=True, help="Path to YAML config file.")
+    parser.add_argument("--source-name", default=None, help="Name of the GEFS source in the data config.")
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    with open(args.config) as config_file:
+        config = yaml.safe_load(config_file)
+    if args.source_name is not None:
+        config["data"] = make_single_source_subconfig(config["data"], args.source_name)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    download_gefs(config["data"], num_workers=args.num_workers, overwrite=args.overwrite)

--- a/credit/datasets/gen_2/gfs.py
+++ b/credit/datasets/gen_2/gfs.py
@@ -1,0 +1,449 @@
+"""
+gfs.py
+------
+GFS and GDAS data loading for CREDIT Gen2.
+
+This module provides ``GFSDataset``, a PyTorch dataset for the public GFS/GDAS
+NetCDF files in Google Cloud Storage. A model run is represented by two files:
+an atmospheric file containing model-level fields and a surface file
+containing two-dimensional surface fields. ``GFSDataset`` discovers available
+runs, reads only the requested variables and levels, and returns CREDIT's
+standard input/target sample dictionaries.
+
+The dataset deliberately does not derive pressure, geopotential, or other
+diagnostics and does not regrid the native Gaussian grid. Those operations are
+handled by CREDIT postblocks or preblocks so the raw GFS state remains
+available to downstream processing.
+
+Remote reads use anonymous ``obstore`` range requests, allowing xarray to read
+selected portions of the large NetCDF objects without downloading each file in
+full. Local mode reads files downloaded with
+``credit.datasets.gen_2.gfs_download``. Both modes use the same native layout::
+
+    {system}.YYYYMMDD/HH/atmos/{system}.tHHz.atmanl.nc
+    {system}.YYYYMMDD/HH/atmos/{system}.tHHz.sfcanl.nc
+
+Here ``system`` is ``gdas`` by default and may be changed to ``gfs`` in the
+source configuration. Forecast files can be selected with ``forecast_hour``.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+from typing import Any, Literal
+
+import numpy as np
+import pandas as pd
+import torch
+import xarray as xr
+
+from credit.datasets.gen_2.base_dataset import VALID_FIELD_TYPES, BaseDataset
+from credit.datasets.gen_2.grid_utils import write_source_grid_schema_if_missing
+
+logger = logging.getLogger(__name__)
+
+_GCS_BUCKET = "global-forecast-system"
+VALID_SYSTEMS = Literal["gdas", "gfs"]
+VALID_LEVEL_TYPES = Literal["model", "pressure"]
+_ATM_2D_VARIABLES = {"hgtsfc", "pressfc"}
+
+
+def _run_path(system: str, t: pd.Timestamp, base_path: str | None = None) -> str:
+    prefix = f"{system}.{t:%Y%m%d}/{t:%H}/atmos"
+    return os.path.join(base_path, prefix) if base_path else prefix
+
+
+def _file_names(system: str, t: pd.Timestamp, forecast_hour: int | None) -> tuple[str, str]:
+    suffix = "anl" if forecast_hour is None else f"f{forecast_hour:03d}"
+    prefix = f"{system}.t{t:%H}z."
+    return f"{prefix}atm{suffix}.nc", f"{prefix}sfc{suffix}.nc"
+
+
+def _file_paths(
+    system: str,
+    t: pd.Timestamp,
+    forecast_hour: int | None,
+    base_path: str | None = None,
+) -> tuple[str, str]:
+    run_path = _run_path(system, t, base_path)
+    atm_name, sfc_name = _file_names(system, t, forecast_hour)
+    return os.path.join(run_path, atm_name), os.path.join(run_path, sfc_name)
+
+
+class _ObstoreFile:
+    """Adapt obstore's ``ReadableFile`` to the bytes interface expected by h5py."""
+
+    def __init__(self, reader: Any) -> None:
+        self._reader = reader
+        self.closed = False
+
+    def read(self, size: int = -1) -> bytes:
+        return self._reader.read(size).to_bytes()
+
+    def readinto(self, buffer: bytearray) -> int:
+        data = self.read(len(buffer))
+        buffer[: len(data)] = data
+        return len(data)
+
+    def readline(self, size: int = -1) -> bytes:
+        return self._reader.readline(size).to_bytes()
+
+    def readlines(self, hint: int = -1) -> list[bytes]:
+        return [line.to_bytes() for line in self._reader.readlines(hint)]
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        return self._reader.seek(offset, whence)
+
+    def tell(self) -> int:
+        return self._reader.tell()
+
+    def seekable(self) -> bool:
+        return self._reader.seekable()
+
+    def readable(self) -> bool:
+        return True
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        if not self.closed:
+            self._reader.close()
+            self.closed = True
+
+
+class GFSDataset(BaseDataset):
+    """Read GFS or GDAS atmospheric and surface NetCDF output.
+
+    ``GFSDataset`` reads the paired atmospheric and surface files published in
+    the ``global-forecast-system`` Google Cloud bucket. Atmospheric files
+    contain three-dimensional model-level fields and a small number of
+    two-dimensional fields such as ``pressfc``. Surface files contain the
+    two-dimensional surface fields such as ``tmp2m`` and ``land``. The dataset
+    returns the same flat, slash-delimited tensor keys as the other Gen2
+    datasets; derivations, regridding, and vertical interpolation are left to
+    later preblocks or postblocks.
+
+    Remote mode uses ``obstore`` for anonymous, range-based GCS reads. The
+    remote NetCDF files are opened with xarray and h5netcdf because the
+    obstore reader is a seekable file-like object. Local mode uses the
+    ``netcdf4`` xarray engine by default and expects files laid out like the
+    public bucket. Availability is checked during initialization by default,
+    so missing model runs are removed from ``datetimes`` rather than failing
+    later during sampling.
+
+    Input settings:
+        dataset_type (str): Must be ``"gfs"`` when routed through
+            ``MultiSourceDataset``.
+        system (str): Forecast system, either ``"gdas"`` or ``"gfs"``.
+            Defaults to ``"gdas"``. The aliases ``model`` and ``gfs_type``
+            are also accepted in source configuration.
+        mode (str): ``"remote"`` to read from GCS or ``"local"`` to read
+            downloaded files. Defaults to ``"remote"`` for this dataset.
+        base_path (str): Root directory for local files. Required when
+            ``mode`` is ``"local"``. The downloader creates the same
+            ``{system}.YYYYMMDD/HH/atmos/`` layout used by the bucket.
+        forecast_hour (int | None): Forecast lead hour. ``None`` selects the
+            analysis files ``atmanl.nc`` and ``sfcanl.nc``. An integer selects
+            files such as ``atmf003.nc`` and ``sfcf003.nc``.
+        level_type (str): ``"model"`` selects one-based positions in the
+            ``pfull`` dimension. ``"pressure"`` selects the nearest values of
+            the file's ``pfull`` coordinate, in hPa. Defaults to ``"model"``.
+        level_coord (str): Atmospheric vertical dimension. Defaults to
+            ``"pfull"``.
+        levels (list[int | float] | None): Requested model-level indices or
+            pressure values, depending on ``level_type``. ``None`` reads all
+            atmospheric levels.
+        check_availability (bool): Check that the required atmospheric and
+            surface objects exist before adding a timestamp to ``datetimes``.
+            Defaults to ``True``.
+        variables (dict): Field definitions grouped under ``prognostic``,
+            ``dynamic_forcing``, ``static``, and ``diagnostic``. Each field
+            may contain ``vars_3D`` and/or ``vars_2D`` using native GFS names.
+        return_target (bool): Constructor argument controlling whether the
+            sample includes the next timestep under ``target``.
+
+    Attributes:
+        dataset_type (str): The registered dataset type, ``"gfs"``.
+        system (str): Active forecast system, ``"gdas"`` or ``"gfs"``.
+        mode (str): Active storage mode, ``"remote"`` or ``"local"``.
+        base_path (str | None): Expanded local storage root, if configured.
+        forecast_hour (int | None): Active analysis or forecast lead hour.
+        level_type (str): Active vertical-level interpretation.
+        level_coord (str): Name of the atmospheric vertical dimension.
+        levels (list[int | float] | None): Configured level selection.
+        datetimes (pandas.DatetimeIndex): Available sampling timestamps after
+            applying the configured clock and availability checks.
+        file_dict (dict): Registered field types and their remote/local file
+            source marker.
+        var_dict (dict): Registered native GFS variables grouped by field type.
+        static_metadata (dict): Calendar, grid, system, level, and forecast
+            metadata exposed to ``MultiSourceDataset`` and downstream setup.
+
+    Example YAML configuration::
+
+        data:
+          source:
+            GDAS:
+              dataset_type: "gfs"
+              system: "gdas"
+              mode: "remote"
+              level_type: "model"
+              levels: [1, 10, 30, 60, 90, 127]  # selected from the 127 available model levels (1-127)
+              check_availability: true
+              variables:
+                prognostic:
+                  vars_3D: [tmp, ugrd, vgrd, spfh]
+                  vars_2D: [pressfc, tmp2m]
+                dynamic_forcing: null
+                static:
+                  vars_2D: [land, orog]
+                diagnostic: null
+          start_datetime: "2024-01-01T00:00:00"
+          end_datetime: "2024-01-31T18:00:00"
+          timestep: "6h"
+          forecast_len: 1
+
+    For pressure-coordinate selection, change the source settings to
+    ``level_type: "pressure"`` and provide values such as
+    ``levels: [50, 100, 500, 850, 1000]``. To read downloaded files, use
+    ``mode: "local"`` and set ``base_path`` to the downloader's output root.
+
+    Command-line usage::
+
+        # Download the configured files for local mode.
+        python -m credit.datasets.gen_2.gfs_download -c config/gfs.yml
+
+        # Instantiate GFSDataset directly from a YAML file.
+        python - <<'PY'
+        import yaml
+        from credit.datasets.gen_2.gfs import GFSDataset
+
+        with open("config/gfs.yml") as file:
+            config = yaml.safe_load(file)
+        dataset = GFSDataset(config["data"], return_target=True)
+        print(len(dataset))
+        PY
+
+        # In normal training, MultiSourceDataset instantiates GFSDataset from
+        # the same data block.
+        credit_train_gen2 -c config/gfs.yml
+    """
+
+    def __init__(
+        self,
+        data_config: dict[str, Any],
+        return_target: bool = False,
+        gfs_type: VALID_SYSTEMS | None = None,
+    ) -> None:
+        source_name = next(iter(data_config.get("source", {})), None)
+        source_cfg = data_config.get("source", {}).get(source_name, {}) if source_name else {}
+        self.system: VALID_SYSTEMS = self._validate_system(
+            gfs_type or source_cfg.get("gfs_type", source_cfg.get("system", source_cfg.get("model", "gdas")))
+        )
+        self.mode = source_cfg.get("mode", "remote")
+        self.forecast_hour: int | None = source_cfg.get("forecast_hour")
+        if self.forecast_hour is not None:
+            self.forecast_hour = int(self.forecast_hour)
+            if self.forecast_hour < 0 or self.forecast_hour > 999:
+                raise ValueError(f"forecast_hour must be between 0 and 999, got {self.forecast_hour}")
+        self.base_path = (
+            os.path.expanduser(os.path.expandvars(source_cfg["base_path"])) if source_cfg.get("base_path") else None
+        )
+        self.level_type: VALID_LEVEL_TYPES = self._validate_level_type(source_cfg.get("level_type", "model"))
+        self.levels: list[int | float] | None = source_cfg.get("levels")
+        self.level_coord = source_cfg.get("level_coord", "pfull")
+        self.check_availability = bool(source_cfg.get("check_availability", True))
+        self._obstore = None
+        self._run_objects: dict[str, set[str]] = {}
+        self._initial_source_cfg = source_cfg
+
+        super().__init__(data_config, return_target)
+
+        if "mode" not in self.curr_source_cfg:
+            self.mode = "remote"
+        if self.mode not in ("local", "remote"):
+            raise ValueError(f"Unknown mode '{self.mode}'. Expected 'local' or 'remote'.")
+        if self.mode == "local" and self.base_path is None:
+            raise ValueError(f"A base_path is required for local GFS mode in source '{self.curr_source_name}'.")
+
+        self.dataset_type = "gfs"
+        self.static_metadata = {
+            "system": self.system,
+            "forecast_hour": self.forecast_hour,
+            "level_type": self.level_type,
+            "levels": self.levels,
+            "calendar": self.calendar,
+            "datetime_fmt": "unix_ns",
+        }
+        self.init_register_all_fields()
+
+    @staticmethod
+    def _validate_system(value: str) -> VALID_SYSTEMS:
+        system = str(value).lower()
+        if system not in ("gdas", "gfs"):
+            raise ValueError(f"Unknown GFS system '{value}'. Expected 'gdas' or 'gfs'.")
+        return system  # type: ignore[return-value]
+
+    @staticmethod
+    def _validate_level_type(value: str) -> VALID_LEVEL_TYPES:
+        level_type = str(value).lower()
+        if level_type not in ("model", "pressure"):
+            raise ValueError(f"Unknown GFS level_type '{value}'. Expected 'model' or 'pressure'.")
+        return level_type  # type: ignore[return-value]
+
+    def _build_timestamps(self) -> pd.DatetimeIndex:
+        timestamps = super()._build_timestamps()
+        if not isinstance(timestamps, pd.DatetimeIndex) or not self.check_availability or not len(timestamps):
+            return timestamps
+
+        available = [t for t in timestamps if self._run_is_available(pd.Timestamp(t))]
+        missing = len(timestamps) - len(available)
+        if missing:
+            logger.warning(
+                "GFSDataset '%s': excluded %d unavailable %s runs from the sampling clock.",
+                getattr(self, "curr_source_name", "source"),
+                missing,
+                self.system.upper(),
+            )
+        return pd.DatetimeIndex(available)
+
+    def _run_is_available(self, t: pd.Timestamp) -> bool:
+        atm_name, sfc_name = _file_names(self.system, t, self.forecast_hour)
+        atm_path, sfc_path = _file_paths(self.system, t, self.forecast_hour, self.base_path)
+        required_atm, required_sfc = self._required_file_types()
+        if self.mode == "local":
+            return (not required_atm or os.path.isfile(atm_path)) and (not required_sfc or os.path.isfile(sfc_path))
+
+        prefix = f"{self.system}.{t:%Y%m%d}/{t:%H}"
+        if prefix not in self._run_objects:
+            self._run_objects[prefix] = self._list_run_objects(prefix)
+        objects = self._run_objects[prefix]
+        return (not required_atm or atm_name in objects) and (not required_sfc or sfc_name in objects)
+
+    def _required_file_types(self) -> tuple[bool, bool]:
+        source_cfg = self.curr_source_cfg if hasattr(self, "curr_source_cfg") else self._initial_source_cfg
+        need_atm = False
+        need_sfc = False
+        for field_cfg in (source_cfg.get("variables") or {}).values():
+            if not isinstance(field_cfg, dict):
+                continue
+            need_atm |= bool(field_cfg.get("vars_3D"))
+            for vname in field_cfg.get("vars_2D") or []:
+                if vname in _ATM_2D_VARIABLES:
+                    need_atm = True
+                else:
+                    need_sfc = True
+        return need_atm, need_sfc
+
+    def _list_run_objects(self, prefix: str) -> set[str]:
+        import obstore
+        from obstore.store import GCSStore
+
+        if self._obstore is None:
+            self._obstore = GCSStore(bucket=_GCS_BUCKET, config={"skip_signature": True})
+        result = obstore.list_with_delimiter(self._obstore, prefix=f"{prefix}/atmos/")
+        return {entry["path"].rsplit("/", 1)[-1] for entry in result.get("objects", [])}
+
+    def _get_file_source(self, field_config: dict[str, Any]) -> bool:
+        return True
+
+    def _register_field(self, field_type: VALID_FIELD_TYPES, field_config: dict[str, Any] | None) -> None:
+        super()._register_field(field_type, field_config)
+        if field_config is not None:
+            self.file_dict[field_type] = True
+
+    def _open_dataset(self, path: str) -> tuple[xr.Dataset, Any | None]:
+        if self.mode == "local":
+            return xr.open_dataset(path, engine=self.engine or "netcdf4"), None
+
+        import obstore
+
+        if self._obstore is None:
+            from obstore.store import GCSStore
+
+            self._obstore = GCSStore(bucket=_GCS_BUCKET, config={"skip_signature": True})
+        reader = obstore.open_reader(self._obstore, path)
+        return xr.open_dataset(_ObstoreFile(reader), engine="h5netcdf"), reader
+
+    def _extract_field(
+        self,
+        field_type: VALID_FIELD_TYPES,
+        t: pd.Timestamp,
+        sample: dict[str, Any],
+    ) -> None:
+        vd = self.var_dict.get(field_type)
+        if not vd:
+            return
+
+        vars_3d = vd["vars_3D"]
+        vars_2d = vd["vars_2D"]
+        atm_vars = vars_3d + [v for v in vars_2d if v in _ATM_2D_VARIABLES]
+        sfc_vars = [v for v in vars_2d if v not in _ATM_2D_VARIABLES]
+        atm_path, sfc_path = _file_paths(self.system, pd.Timestamp(t), self.forecast_hour, self.base_path)
+
+        if atm_vars:
+            self._extract_from_file(field_type, t, atm_path, atm_vars, vars_3d, sample)
+        if sfc_vars:
+            self._extract_from_file(field_type, t, sfc_path, sfc_vars, [], sample)
+
+    def _extract_from_file(
+        self,
+        field_type: VALID_FIELD_TYPES,
+        t: pd.Timestamp,
+        path: str,
+        variables: list[str],
+        vars_3d: list[str],
+        sample: dict[str, Any],
+    ) -> None:
+        del t
+        ds, reader = self._open_dataset(path)
+        try:
+            if "grid" not in self.static_metadata:
+                self._cache_grid(ds)
+            missing = [v for v in variables if v not in ds.data_vars]
+            if missing:
+                raise KeyError(f"Variables {missing} were not found in GFS file '{path}'.")
+            ds_t = ds.isel(time=0, drop=True) if "time" in ds.dims else ds
+            ds_t = self._select_levels(ds_t) if vars_3d else ds_t
+            for vname in variables:
+                arr = np.asarray(ds_t[vname].values)
+                if vname in vars_3d:
+                    key = self._get_field_name(field_type, "3d", vname)
+                    sample[key] = torch.as_tensor(arr, dtype=torch.float32).unsqueeze(1)
+                else:
+                    key = self._get_field_name(field_type, "2d", vname)
+                    sample[key] = torch.as_tensor(arr, dtype=torch.float32).unsqueeze(0).unsqueeze(0)
+        finally:
+            ds.close()
+            if reader is not None:
+                reader.close()
+
+    def _select_levels(self, ds: xr.Dataset) -> xr.Dataset:
+        if self.level_coord not in ds.dims:
+            raise ValueError(f"GFS atmospheric data does not contain level dimension '{self.level_coord}'.")
+        if self.levels is None:
+            if self.level_type == "model" and self.level_coord == "pfull":
+                self.static_metadata["levels"] = list(range(1, ds.sizes[self.level_coord] + 1))
+            else:
+                self.static_metadata["levels"] = ds[self.level_coord].values.tolist()
+            return ds
+        if self.level_type == "model":
+            indices = []
+            for level in self.levels:
+                if int(level) != level or not 1 <= int(level) <= ds.sizes[self.level_coord]:
+                    raise ValueError(
+                        f"GFS model levels must be one-based indices in [1, {ds.sizes[self.level_coord]}], got {self.levels}."
+                    )
+                indices.append(int(level) - 1)
+            return ds.isel({self.level_coord: indices})
+        return ds.sel({self.level_coord: self.levels}, method="nearest")
+
+    def _cache_grid(self, ds: xr.Dataset) -> None:
+        if "lat" not in ds or "lon" not in ds:
+            return
+        grid = {"grid_type": "curvilinear", "lat": ds["lat"].values, "lon": ds["lon"].values}
+        self.static_metadata["grid"] = grid
+        write_source_grid_schema_if_missing(self.curr_source_name, grid, self.save_loc)

--- a/credit/datasets/gen_2/gfs_download.py
+++ b/credit/datasets/gen_2/gfs_download.py
@@ -1,0 +1,146 @@
+"""
+gfs_download.py
+---------------
+Download GFS or GDAS NetCDF files for ``GFSDataset`` local mode.
+
+The downloader reads the same single-source data configuration used by
+``GFSDataset``, checks which configured timestamps are available in the public
+Google Cloud bucket, and downloads the atmospheric/surface file pair for each
+available run. Files are written without renaming, so a local ``GFSDataset``
+can use the resulting directory directly.
+
+The output layout is::
+
+    {base_path}/{system}.YYYYMMDD/HH/atmos/{system}.tHHz.atmanl.nc
+    {base_path}/{system}.YYYYMMDD/HH/atmos/{system}.tHHz.sfcanl.nc
+
+For forecast output, ``forecast_hour`` changes the final names to forms such
+as ``atmf003.nc`` and ``sfcf003.nc``. Downloads use obstore and a thread pool;
+``num_workers`` controls the number of concurrent file transfers.
+
+Command-line usage::
+
+    python -m credit.datasets.gen_2.gfs_download -c config/gfs.yml
+    python -m credit.datasets.gen_2.gfs_download -c config/gfs.yml --num-workers 8 --overwrite
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, NamedTuple
+
+import pandas as pd
+
+from credit.datasets.gen_2.gfs import (
+    _GCS_BUCKET,
+    GFSDataset,
+    _file_paths,
+)
+from credit.datasets.gen_2.multi_source import make_single_source_subconfig
+
+logger = logging.getLogger(__name__)
+
+
+class _DownloadTask(NamedTuple):
+    remote_path: str
+    local_path: str
+    overwrite: bool
+
+
+def _download_one(task: _DownloadTask, store: Any) -> str:
+    if os.path.exists(task.local_path) and not task.overwrite:
+        return f"skip  {task.local_path}"
+    os.makedirs(os.path.dirname(task.local_path), exist_ok=True)
+    try:
+        result = store.get(task.remote_path)
+        with open(task.local_path, "wb") as output:
+            output.write(result.bytes())
+        return f"ok    {task.local_path}"
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not download %s: %s", task.remote_path, exc)
+        return f"miss  {task.remote_path}"
+
+
+def download_gfs(data_config: dict[str, Any], num_workers: int = 4, overwrite: bool = False) -> None:
+    """Download configured GFS/GDAS files for local ``GFSDataset`` use.
+
+    Args:
+        data_config: The top-level ``data`` configuration passed to
+            ``GFSDataset``. It must contain exactly one source with
+            ``dataset_type: "gfs"`` and a local ``base_path``.
+        num_workers: Number of concurrent file downloads. Defaults to ``4``.
+        overwrite: If ``True``, download files even when the corresponding
+            local file already exists. Defaults to ``False``.
+
+    Raises:
+        KeyError: If the configuration does not contain the required ``source``
+            block.
+        ValueError: If multiple sources, a non-GFS source, or no ``base_path``
+            is supplied.
+        ImportError: If obstore is not installed when the download begins.
+
+    Example:
+        >>> from credit.datasets.gen_2.gfs_download import download_gfs
+        >>> download_gfs(config["data"], num_workers=8)
+
+    After downloading, set the source ``mode`` to ``"local"`` and point
+    ``base_path`` at the download directory before constructing
+    ``GFSDataset``.
+    """
+    source_name = next(iter(data_config["source"]))
+    if len(data_config["source"]) > 1:
+        raise ValueError("Provide a config containing exactly one GFS source.")
+    source_cfg = data_config["source"][source_name]
+    if source_cfg.get("dataset_type") != "gfs":
+        raise ValueError(f"Expected dataset_type 'gfs', got {source_cfg.get('dataset_type')!r}.")
+    if "base_path" not in source_cfg:
+        raise ValueError("base_path is required to download GFS/GDAS files.")
+
+    source_data = make_single_source_subconfig(data_config, source_name)
+    source_data["source"][source_name] = {
+        **source_data["source"][source_name],
+        "mode": "remote",
+        "check_availability": True,
+    }
+    dataset = GFSDataset(source_data)
+    timestamps = dataset.datetimes
+    tasks: list[_DownloadTask] = []
+    seen: set[str] = set()
+    for timestamp in timestamps:
+        t = pd.Timestamp(timestamp)
+        for remote_path, local_path in zip(
+            _file_paths(dataset.system, t, dataset.forecast_hour),
+            _file_paths(dataset.system, t, dataset.forecast_hour, dataset.base_path),
+        ):
+            if remote_path not in seen:
+                seen.add(remote_path)
+                tasks.append(_DownloadTask(remote_path, local_path, overwrite))
+
+    from obstore.store import GCSStore
+
+    store = GCSStore(bucket=_GCS_BUCKET, config={"skip_signature": True})
+    with ThreadPoolExecutor(max_workers=num_workers) as executor:
+        for result in executor.map(lambda task: _download_one(task, store), tasks):
+            logger.info(result)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    import yaml
+
+    parser = argparse.ArgumentParser(description="Download GFS/GDAS NetCDF files from Google Cloud Storage.")
+    parser.add_argument("-c", "--config", required=True, help="Path to YAML config file.")
+    parser.add_argument("--source-name", default=None, help="Name of the GFS source in the data config.")
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    with open(args.config) as config_file:
+        config = yaml.safe_load(config_file)
+    if args.source_name is not None:
+        config["data"] = make_single_source_subconfig(config["data"], args.source_name)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    download_gfs(config["data"], num_workers=args.num_workers, overwrite=args.overwrite)

--- a/credit/datasets/gen_2/multi_source.py
+++ b/credit/datasets/gen_2/multi_source.py
@@ -73,6 +73,7 @@ _SOURCE_REGISTRY: dict[str, tuple[str, str]] = {
     "hrrr_nat": ("credit.datasets.gen_2.hrrr", "HRRRDataset"),
     "hrrr_subh": ("credit.datasets.gen_2.hrrr", "HRRRDataset"),
     "gfs": ("credit.datasets.gen_2.gfs", "GFSDataset"),
+    "gefs": ("credit.datasets.gen_2.gefs", "GEFSDataset"),
     "tisr": ("credit.datasets.gen_2.tisr", "TISRDataset"),
 }
 

--- a/credit/datasets/gen_2/multi_source.py
+++ b/credit/datasets/gen_2/multi_source.py
@@ -72,6 +72,7 @@ _SOURCE_REGISTRY: dict[str, tuple[str, str]] = {
     "hrrr": ("credit.datasets.gen_2.hrrr", "HRRRDataset"),
     "hrrr_nat": ("credit.datasets.gen_2.hrrr", "HRRRDataset"),
     "hrrr_subh": ("credit.datasets.gen_2.hrrr", "HRRRDataset"),
+    "gfs": ("credit.datasets.gen_2.gfs", "GFSDataset"),
     "tisr": ("credit.datasets.gen_2.tisr", "TISRDataset"),
 }
 

--- a/tests/test_gefs.py
+++ b/tests/test_gefs.py
@@ -1,0 +1,227 @@
+"""Fast mocked tests for the Gen2 GEFS dataset and downloader."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import obstore
+import pandas as pd
+import pytest
+import torch
+import xarray as xr
+from credit.datasets.gen_2.gefs import GEFSDataset, _member_file_paths
+from credit.datasets.gen_2.gefs_download import download_gefs
+
+
+class _FakeBytes:
+    def __init__(self, value: bytes) -> None:
+        self.value = value
+
+    def to_bytes(self) -> bytes:
+        return self.value
+
+    def bytes(self) -> bytes:
+        return self.value
+
+
+class _FakeReader:
+    def __init__(self, value: bytes) -> None:
+        self.buffer = io.BytesIO(value)
+
+    def read(self, size: int = -1) -> _FakeBytes:
+        return _FakeBytes(self.buffer.read(size))
+
+    def readline(self, size: int = -1) -> _FakeBytes:
+        return _FakeBytes(self.buffer.readline(size))
+
+    def readlines(self, hint: int = -1) -> list[_FakeBytes]:
+        return [_FakeBytes(line) for line in self.buffer.readlines(hint)]
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        return self.buffer.seek(offset, whence)
+
+    def tell(self) -> int:
+        return self.buffer.tell()
+
+    def seekable(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        self.buffer.close()
+
+
+class _FakeStore:
+    def __init__(self, files: dict[str, bytes]) -> None:
+        self.files = files
+
+    def get(self, path: str) -> _FakeBytes:
+        return _FakeBytes(self.files[path])
+
+
+def _netcdf_bytes(member_offset: float) -> tuple[bytes, bytes, bytes]:
+    coords = {
+        "lev": [1, 2, 3],
+        "levp": [1, 2, 3, 4],
+        "lat": [0, 1],
+        "lon": [0, 1],
+        "latp": [0, 1, 2],
+        "lonp": [0, 1, 2],
+    }
+    atm = xr.Dataset(
+        {
+            "geolat": (("lat", "lon"), np.array([[10, 11], [12, 13]], dtype=np.float32)),
+            "geolon": (("lat", "lon"), np.array([[20, 21], [22, 23]], dtype=np.float32)),
+            "ps": (("lat", "lon"), np.full((2, 2), 1000 + member_offset, dtype=np.float32)),
+            "t": (("lev", "lat", "lon"), np.full((3, 2, 2), 250 + member_offset, dtype=np.float32)),
+            "zh": (("levp", "lat", "lon"), np.arange(16, dtype=np.float32).reshape(4, 2, 2)),
+            "u_s": (("lev", "latp", "lon"), np.full((3, 3, 2), 3 + member_offset, dtype=np.float32)),
+            "v_w": (("lev", "lat", "lonp"), np.full((3, 2, 3), 4 + member_offset, dtype=np.float32)),
+            "u_w": (("lev", "lat", "lonp"), np.full((3, 2, 3), 5 + member_offset, dtype=np.float32)),
+            "v_s": (("lev", "latp", "lon"), np.full((3, 3, 2), 6 + member_offset, dtype=np.float32)),
+        },
+        coords=coords,
+    )
+    surface = xr.Dataset(
+        {
+            "geolat": (("yaxis_1", "xaxis_1"), np.array([[10, 11], [12, 13]], dtype=np.float32)),
+            "geolon": (("yaxis_1", "xaxis_1"), np.array([[20, 21], [22, 23]], dtype=np.float32)),
+            "t2m": (("Time", "yaxis_1", "xaxis_1"), np.full((1, 2, 2), 280 + member_offset, dtype=np.float32)),
+            "slmsk": (("Time", "yaxis_1", "xaxis_1"), np.ones((1, 2, 2), dtype=np.float32)),
+        },
+        coords={"Time": [1], "yaxis_1": [1, 2], "xaxis_1": [1, 2]},
+    )
+    control = xr.Dataset({"vcoord": (("nvcoord", "levsp"), np.arange(8, dtype=np.float64).reshape(2, 4))})
+    return (
+        bytes(atm.to_netcdf(engine="h5netcdf")),
+        bytes(surface.to_netcdf(engine="h5netcdf")),
+        bytes(control.to_netcdf(engine="h5netcdf")),
+    )
+
+
+@pytest.fixture
+def fake_remote(monkeypatch: pytest.MonkeyPatch) -> dict[str, bytes]:
+    files: dict[str, bytes] = {}
+    timestamp = pd.Timestamp("2024-01-01")
+    for member, offset in (("c00", 0.0), ("p01", 10.0)):
+        atm_bytes, surface_bytes, control_bytes = _netcdf_bytes(offset)
+        control, atmospheric, surface = _member_file_paths(timestamp, member)
+        files[control] = control_bytes
+        for path in atmospheric:
+            files[path] = atm_bytes
+        for path in surface:
+            files[path] = surface_bytes
+
+    store = _FakeStore(files)
+    monkeypatch.setattr(obstore.store, "GCSStore", lambda **kwargs: store)
+    monkeypatch.setattr(obstore, "open_reader", lambda current_store, path: _FakeReader(current_store.files[path]))
+
+    def list_with_delimiter(current_store, prefix=None):
+        prefix = prefix or ""
+        if prefix.endswith("/init/"):
+            members = {path[len(prefix) :].split("/", 1)[0] for path in current_store.files if path.startswith(prefix)}
+            return {"common_prefixes": [f"{prefix}{member}" for member in sorted(members)], "objects": []}
+        return {
+            "common_prefixes": [],
+            "objects": [{"path": path} for path in current_store.files if path.startswith(prefix)],
+        }
+
+    monkeypatch.setattr(obstore, "list_with_delimiter", list_with_delimiter)
+    return files
+
+
+def _config(
+    *,
+    members: list[str] | None = None,
+    mode: str = "remote",
+    base_path: str | None = None,
+    variables: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    source: dict[str, Any] = {
+        "dataset_type": "gefs",
+        "mode": mode,
+        "levels": [1, 3],
+        "variables": variables
+        or {
+            "prognostic": {"vars_3D": ["t", "u_a", "v_a", "zh"], "vars_2D": ["ps", "t2m"]},
+            "static": {"vars_2D": ["slmsk"]},
+        },
+    }
+    if members is not None:
+        source["members"] = members
+    if base_path is not None:
+        source["base_path"] = base_path
+    return {
+        "source": {"GEFS": source},
+        "start_datetime": "2024-01-01",
+        "end_datetime": "2024-01-01",
+        "timestep": "6h",
+        "forecast_len": 0,
+    }
+
+
+def _assert_finite(sample: dict[str, Any]) -> None:
+    for data_type in ("input", "target"):
+        for tensor in sample.get(data_type, {}).values():
+            assert torch.isfinite(tensor).all()
+
+
+def test_default_control_member_and_unstaggered_shapes(fake_remote):
+    dataset = GEFSDataset(_config())
+    sample = dataset[(dataset.datetimes[0], 0)]
+
+    assert dataset.members == ["c00"]
+    assert sample["input"]["GEFS/prognostic/3d/t"].shape == (1, 2, 1, 24)
+    assert sample["input"]["GEFS/prognostic/3d/u_a"].shape == (1, 2, 1, 24)
+    assert sample["input"]["GEFS/prognostic/2d/ps"].shape == (1, 1, 1, 24)
+    assert sample["input"]["GEFS/static/2d/slmsk"].shape == (1, 1, 1, 24)
+    assert dataset.static_metadata["grid"]["grid_type"] == "unstructured"
+    assert dataset.static_metadata["grid"]["lat"].shape == (24,)
+    _assert_finite(sample)
+
+
+def test_all_members_and_raw_staggered_winds(fake_remote):
+    variables = {"prognostic": {"vars_3D": ["u_s", "v_w"]}}
+    dataset = GEFSDataset(_config(members=[], variables=variables))
+    sample = dataset[(dataset.datetimes[0], 0)]
+
+    assert dataset.members == ["c00", "p01"]
+    assert sample["input"]["GEFS/prognostic/3d/u_s"].shape == (2, 2, 1, 36)
+    assert sample["input"]["GEFS/prognostic/3d/v_w"].shape == (2, 2, 1, 36)
+    _assert_finite(sample)
+
+
+def test_zh_is_converted_from_interfaces_to_selected_midlevels(fake_remote):
+    config = _config(variables={"prognostic": {"vars_3D": ["zh"]}})
+    dataset = GEFSDataset(config)
+    sample = dataset[(dataset.datetimes[0], 0)]
+    values = sample["input"]["GEFS/prognostic/3d/zh"]
+
+    assert values.shape == (1, 2, 1, 24)
+    assert torch.equal(values[0, :, 0, 0], torch.tensor([2.0, 10.0]))
+
+
+def test_missing_selected_member_fails_initialization(fake_remote):
+    fake_remote.pop(next(path for path in fake_remote if "/p01/" in path and path.endswith("sfc_data.tile6.nc")))
+    with pytest.raises(FileNotFoundError, match="p01.*sfc_data.tile6.nc"):
+        GEFSDataset(_config(members=["c00", "p01"]))
+
+
+def test_download_and_local_read(fake_remote, tmp_path: Path):
+    config = _config(members=["c00", "p01"], mode="local", base_path=str(tmp_path))
+    download_gefs(config, num_workers=1)
+
+    dataset = GEFSDataset(config)
+    sample = dataset[(dataset.datetimes[0], 0)]
+    assert len(list(tmp_path.rglob("*.nc"))) == 26
+    assert sample["input"]["GEFS/prognostic/3d/t"].shape == (2, 2, 1, 24)
+    _assert_finite(sample)
+
+
+def test_forecast_hour_is_rejected(fake_remote):
+    config = _config()
+    config["source"]["GEFS"]["forecast_hour"] = 3
+    with pytest.raises(ValueError, match="initialization-time"):
+        GEFSDataset(config)

--- a/tests/test_gfs.py
+++ b/tests/test_gfs.py
@@ -1,0 +1,224 @@
+"""Fast unit tests for the Gen2 GFS dataset and downloader."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import obstore
+import pandas as pd
+import pytest
+import torch
+import xarray as xr
+from credit.datasets.gen_2.gfs import GFSDataset, _file_paths
+from credit.datasets.gen_2.gfs_download import download_gfs
+
+
+class _FakeBytes:
+    def __init__(self, value: bytes) -> None:
+        self.value = value
+
+    def to_bytes(self) -> bytes:
+        return self.value
+
+    def bytes(self) -> bytes:
+        return self.value
+
+
+class _FakeReader:
+    def __init__(self, value: bytes) -> None:
+        self.buffer = io.BytesIO(value)
+
+    def read(self, size: int = -1) -> _FakeBytes:
+        return _FakeBytes(self.buffer.read(size))
+
+    def readline(self, size: int = -1) -> _FakeBytes:
+        return _FakeBytes(self.buffer.readline(size))
+
+    def readlines(self, hint: int = -1) -> list[_FakeBytes]:
+        return [_FakeBytes(line) for line in self.buffer.readlines(hint)]
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        return self.buffer.seek(offset, whence)
+
+    def tell(self) -> int:
+        return self.buffer.tell()
+
+    def seekable(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        self.buffer.close()
+
+
+class _FakeStore:
+    def __init__(self, files: dict[str, bytes]) -> None:
+        self.files = files
+
+    def get(self, path: str) -> _FakeBytes:
+        return _FakeBytes(self.files[path])
+
+
+def _make_dataset_bytes() -> tuple[bytes, bytes]:
+    shape_3d = (1, 4, 2, 3)
+    shape_2d = (1, 2, 3)
+    coords = {
+        "time": [np.datetime64("2024-01-01T00:00")],
+        "pfull": [100.0, 500.0, 850.0, 1000.0],
+        "grid_yt": [45.0, 15.0],
+        "grid_xt": [0.0, 120.0, 240.0],
+    }
+    atm = xr.Dataset(
+        {
+            "lon": (("grid_yt", "grid_xt"), np.zeros((2, 3), dtype=np.float64)),
+            "lat": (("grid_yt", "grid_xt"), np.zeros((2, 3), dtype=np.float64)),
+            "tmp": (("time", "pfull", "grid_yt", "grid_xt"), np.full(shape_3d, 250.0, dtype=np.float32)),
+            "ugrd": (("time", "pfull", "grid_yt", "grid_xt"), np.full(shape_3d, 12.0, dtype=np.float32)),
+            "pressfc": (("time", "grid_yt", "grid_xt"), np.full(shape_2d, 100000.0, dtype=np.float32)),
+        },
+        coords=coords,
+    )
+    sfc = xr.Dataset(
+        {
+            "lon": (("grid_yt", "grid_xt"), np.zeros((2, 3), dtype=np.float64)),
+            "lat": (("grid_yt", "grid_xt"), np.zeros((2, 3), dtype=np.float64)),
+            "tmp2m": (("time", "grid_yt", "grid_xt"), np.full(shape_2d, 280.0, dtype=np.float32)),
+            "land": (("time", "grid_yt", "grid_xt"), np.ones(shape_2d, dtype=np.float32)),
+        },
+        coords={key: value for key, value in coords.items() if key != "pfull"},
+    )
+    return bytes(atm.to_netcdf(engine="h5netcdf")), bytes(sfc.to_netcdf(engine="h5netcdf"))
+
+
+@pytest.fixture
+def fake_remote(monkeypatch: pytest.MonkeyPatch) -> dict[str, bytes]:
+    atm_bytes, sfc_bytes = _make_dataset_bytes()
+    files: dict[str, bytes] = {}
+    timestamps = pd.date_range("2024-01-01", periods=2, freq="6h")
+    for system in ("gdas", "gfs"):
+        for forecast_hour in (None, 1):
+            for timestamp in timestamps:
+                atm_path, sfc_path = _file_paths(system, timestamp, forecast_hour)
+                files[atm_path] = atm_bytes
+                files[sfc_path] = sfc_bytes
+
+    store = _FakeStore(files)
+    monkeypatch.setattr(obstore.store, "GCSStore", lambda **kwargs: store)
+    monkeypatch.setattr(
+        obstore,
+        "open_reader",
+        lambda current_store, path: _FakeReader(current_store.files[path]),
+    )
+    monkeypatch.setattr(
+        obstore,
+        "list_with_delimiter",
+        lambda current_store, prefix=None: {
+            "common_prefixes": [],
+            "objects": [{"path": path} for path in current_store.files if path.startswith(prefix or "")],
+        },
+    )
+    return files
+
+
+def _config(
+    *,
+    system: str = "gdas",
+    mode: str = "remote",
+    base_path: str | None = None,
+    forecast_hour: int | None = None,
+    level_type: str = "model",
+    levels: list[int | float] | None = None,
+    check_availability: bool = True,
+) -> dict[str, Any]:
+    source: dict[str, Any] = {
+        "dataset_type": "gfs",
+        "system": system,
+        "mode": mode,
+        "level_type": level_type,
+        "levels": levels,
+        "forecast_hour": forecast_hour,
+        "check_availability": check_availability,
+        "variables": {
+            "prognostic": {"vars_3D": ["tmp", "ugrd"], "vars_2D": ["pressfc", "tmp2m"]},
+            "static": {"vars_2D": ["land"]},
+        },
+    }
+    if base_path is not None:
+        source["base_path"] = base_path
+    return {
+        "source": {"GFS": source},
+        "start_datetime": "2024-01-01T00:00",
+        "end_datetime": "2024-01-01T06:00",
+        "timestep": "6h",
+        "forecast_len": 0,
+    }
+
+
+def _assert_finite(sample: dict[str, Any]) -> None:
+    for data_type in ("input", "target"):
+        for tensor in sample.get(data_type, {}).values():
+            assert torch.isfinite(tensor).all()
+
+
+@pytest.mark.parametrize(
+    ("system", "forecast_hour"),
+    [("gdas", None), ("gfs", 1)],
+)
+def test_remote_read_shapes_and_finite_values(fake_remote, system, forecast_hour):
+    dataset = GFSDataset(_config(system=system, forecast_hour=forecast_hour, levels=[1, 3]))
+
+    assert len(dataset) == 2
+    sample = dataset[(dataset.datetimes[0], 0)]
+    assert sample["input"]["GFS/prognostic/3d/tmp"].shape == (2, 1, 2, 3)
+    assert sample["input"]["GFS/prognostic/3d/ugrd"].shape == (2, 1, 2, 3)
+    assert sample["input"]["GFS/prognostic/2d/pressfc"].shape == (1, 1, 2, 3)
+    assert sample["input"]["GFS/prognostic/2d/tmp2m"].shape == (1, 1, 2, 3)
+    assert sample["input"]["GFS/static/2d/land"].shape == (1, 1, 2, 3)
+    _assert_finite(sample)
+
+
+def test_remote_pressure_levels_and_missing_runs_are_filtered(fake_remote):
+    dataset = GFSDataset(_config(level_type="pressure", levels=[850, 500]))
+
+    assert len(dataset) == 2
+    sample = dataset[(dataset.datetimes[0], 0)]
+    tensor = sample["input"]["GFS/prognostic/3d/tmp"]
+    assert tensor.shape == (2, 1, 2, 3)
+    assert torch.equal(tensor[:, 0, 0, 0], torch.tensor([250.0, 250.0]))
+    _assert_finite(sample)
+
+
+def test_remote_availability_check_excludes_a_dropped_run(fake_remote, monkeypatch):
+    dropped_path, _ = _file_paths("gdas", pd.Timestamp("2024-01-01 06:00"), None)
+    fake_remote.pop(dropped_path)
+    dataset = GFSDataset(_config())
+
+    assert list(dataset.datetimes) == [pd.Timestamp("2024-01-01 00:00")]
+
+
+def test_local_download_and_local_read(fake_remote, tmp_path: Path):
+    config = _config(system="gfs", forecast_hour=1, base_path=str(tmp_path), mode="local")
+    download_gfs(config, num_workers=1)
+
+    dataset = GFSDataset(config)
+    assert len(dataset) == 2
+    assert all(path.is_file() for path in tmp_path.rglob("*.nc"))
+    sample = dataset[(dataset.datetimes[0], 0)]
+    assert sample["input"]["GFS/prognostic/3d/tmp"].shape == (4, 1, 2, 3)
+    _assert_finite(sample)
+
+
+@pytest.mark.parametrize(
+    ("source_update", "message"),
+    [
+        ({"system": "unknown"}, "Expected 'gdas' or 'gfs'"),
+        ({"level_type": "hybrid"}, "Expected 'model' or 'pressure'"),
+    ],
+)
+def test_invalid_gfs_settings_raise(fake_remote, source_update, message):
+    config = _config(check_availability=False)
+    config["source"]["GFS"].update(source_update)
+    with pytest.raises(ValueError, match=message):
+        GFSDataset(config)


### PR DESCRIPTION
<!-- Note: The pull request (PR) title will be included in the release notes. -->

# Description
<!-- Provide a standalone description of changes in this PR. -->
Adds Gen2 dataset support for GFS/GDAS and GEFS ensemble data from Google Cloud Storage.
## Changes
- Added GFSDataset with:
  - Remote obstore streaming and local NetCDF4 support.
  - GDAS default with optional GFS selection.
  - Model-level and pressure-level selection.
  - Availability checks for missing runs.
  - Native atmospheric and surface variable loading.
  - Grid metadata and downloader support.
- Added GEFSDataset with:
  - Obstore streaming of raw GEFS cube-sphere initialization NetCDF files.
  - Control-member-only default, explicit member selection, or all available members.
  - Member-stacked tensors:
  - 3D: (members, levels, 1, tile_lat_lon)
  - 2D: (members, 1, 1, tile_lat_lon)
  - Raw staggered wind support and virtual unstaggered u_a/v_a fields.
  - zh interface-to-model-level midpoint conversion.
  - GEFS vertical-coordinate metadata from gfs_ctrl.nc.
  - Unstructured native grid metadata.
  - Initialization-time validation of all selected members and tiles.
- Added local download utilities:
  - gfs_download.py
  - gefs_download.py
- Registered gfs and gefs with MultiSourceDataset and credit.datasets.
- Added mocked unit tests covering:
  - Remote and local reads.
  - Member selection and stacking.
  - Tensor shapes and finite values.
  - Wind handling.
  - Missing-file validation.
  - Download workflows.
  - Pressure/model-level selection.
## Validation
- pytest tests/test_gfs.py tests/test_gefs.py tests/multi_source_dataset_test.py
- Result: 22 passed
- Targeted Ruff checks and formatting passed.
- Public GFS and GEFS example configurations were manually validated.

### Related Issues and PRs
<!-- Reference any related issues using the appropriate keyword and issue number as
described in the GitHub documentation: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword. -->
<!-- For example, "Closes #315" -->
<!-- You may also reference any related PRs or discussions using the syntax shown here:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests. -->

Closes #384

### Checklist
- [ ] I am familiar with the [contributing guidelines](https://miles-credit.readthedocs.io/en/latest/contrib.html).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date.
