### PR TITLE
Add register_trainer: custom_objects support for trainers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,9 +94,11 @@ Seven subsystems — models, trainers, datasets, preblocks, postblocks, losses, 
 by a string key in the config (`model.type`, `trainer.type`, `data.source.<name>.dataset_type`, etc.),
 resolved through per-package `_REGISTRY` dicts with lazy imports:
 - `credit/models/__init__.py` → `load_model(conf)`, keys like `crossformer`, `wxformer`, `unet`, `fuxi`, `swin`, `graph`
-- `credit/trainers/__init__.py` → keys like `era5-gen1`/`era5`, `gen2`/`era5-gen2`, `era5-diffusion`, `era5-ensemble`, `ic-opt`
-- `credit/datasets/`, `credit/preblock/`, `credit/postblock/`, `credit/losses/`, `credit/metrics/` follow the
-  same `register_*` decorator pattern
+- `credit/trainers/__init__.py` → `load_trainer(conf)`, keys like `era5-gen1`/`era5`, `gen2`/`era5-gen2`,
+  `era5-diffusion`, `era5-ensemble`, `ic-opt`
+- `credit/datasets/`, `credit/preblock/`, `credit/postblock/`, `credit/losses/`, `credit/metrics/`, `credit/trainers/`
+  all follow the same `register_*` decorator pattern (`register_trainer` mirrors `register_model`, requiring the
+  class subclass `credit.trainers.base_trainer.BaseTrainer`)
 
 `credit/registry.py` (`load_custom_objects`) is the meta-layer: a config's `custom_objects:` block lets users
 plug in their *own* classes (must subclass the relevant `Base*` class) by dotted import path, without

--- a/credit/registry.py
+++ b/credit/registry.py
@@ -16,6 +16,7 @@ _REGISTRY_MAP = {
     "postblock": ("credit.postblock", "register_postblock"),
     "loss": ("credit.losses", "register_loss"),
     "metric": ("credit.metrics", "register_metric"),
+    "trainer": ("credit.trainers", "register_trainer"),
 }
 
 # Tracks what has already been registered so repeated calls with the same conf
@@ -61,11 +62,12 @@ def load_custom_objects(conf):
     - ``torch.nn.Module`` for metrics, but a metric is called as
       ``metric(full_data_dict)``, so subclass
       ``credit.metrics.base.BaseVariableMetric`` unless it handles that itself
+    - ``credit.trainers.base_trainer.BaseTrainer`` for trainers
 
     Note: CREDIT's built-in types use snake_case (``unet``, ``log_transform``).
     Use a distinct key to avoid accidentally overwriting a built-in.
 
-    Full example — all six object types::
+    Full example — all seven object types::
 
         # ---- Register custom classes ----
         custom_objects:
@@ -94,6 +96,10 @@ def load_custom_objects(conf):
           MyMetric:
             object_type: metric
             module_path: mypackage.metrics
+
+          MyTrainer:
+            object_type: trainer
+            module_path: mypackage.trainers
 
         # ---- Use the registered classes elsewhere in the config ----
 
@@ -142,6 +148,10 @@ def load_custom_objects(conf):
             metrics: {rmse: {}, MyMetric: {}}
         metrics:
           type: MyMetric
+
+        # trainer: referenced as trainer.type
+        trainer:
+          type: MyTrainer
 
     Args:
         conf (dict): Top-level config dict. If ``custom_objects`` is absent or

--- a/credit/trainers/__init__.py
+++ b/credit/trainers/__init__.py
@@ -4,7 +4,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-# Registry: trainer_type -> (module_path, class_name, description)
+# Registry: trainer_type -> entry. Entries are either:
+#   (module_path: str, class_name: str, message: str)  — internal lazy entries
+#   (cls: type,        message: str)                    — externally registered classes
 _TRAINER_REGISTRY = {
     "era5-gen1": (
         "credit.trainers.trainerERA5gen1",
@@ -78,6 +80,73 @@ _TRAINER_REGISTRY = {
 trainer_types = _TRAINER_REGISTRY
 
 
+def register_trainer(trainer_type, message=None):
+    """Decorator that adds an external trainer class to the trainer registry.
+
+    The class must inherit from :class:`credit.trainers.base_trainer.BaseTrainer`.
+    Mirrors ``credit.models.register_model`` — see that docstring for the full
+    rationale; this is the same pattern applied to trainers.
+
+    Args:
+        trainer_type: Key used in the config ``trainer.type`` field.
+        message: Optional log message shown when the trainer is loaded.
+
+    Example::
+
+        from credit.trainers import register_trainer
+        from credit.trainers.base_trainer import BaseTrainer
+
+        @register_trainer("my_trainer", "Loading my custom trainer ...")
+        class MyTrainer(BaseTrainer):
+            ...
+    """
+
+    def decorator(cls):
+        from credit.trainers.base_trainer import BaseTrainer  # imported here to avoid loading it at module import time
+
+        if not (isinstance(cls, type) and issubclass(cls, BaseTrainer)):
+            raise TypeError(
+                f"register_trainer: '{cls.__name__}' must inherit from credit.trainers.base_trainer.BaseTrainer."
+            )
+        if trainer_type in _TRAINER_REGISTRY:  # warn instead of silently overwriting
+            logger.warning(f"register_trainer: overwriting existing registry entry for '{trainer_type}'")
+        _TRAINER_REGISTRY[trainer_type] = (cls, message or f"Loading {trainer_type} trainer ...")
+        return cls  # must return the class, otherwise it becomes None after decoration
+
+    return decorator
+
+
+def _load_trainer_entry(trainer_type):
+    """Lazily import and return (trainer_class, message) for a registered trainer type.
+
+    Raises:
+        ValueError: If trainer_type is not in _TRAINER_REGISTRY.
+        ImportError: If the trainer's module cannot be imported.
+    """
+    if trainer_type not in _TRAINER_REGISTRY:
+        msg = (
+            f"Trainer type '{trainer_type}' not supported. Available types: {sorted(_TRAINER_REGISTRY)}. "
+            "Register a custom trainer with @register_trainer or via custom_objects in your config."
+        )
+        logger.warning(msg)
+        raise ValueError(msg)
+    entry = _TRAINER_REGISTRY[trainer_type]
+    # Unlike a plain lazy entry, an externally registered trainer stores (cls, message)
+    # rather than (module_path, class_name, message) -- same disambiguation credit.models
+    # uses: check whether the first element is a string (module path) or not (class).
+    if not isinstance(entry[0], str):
+        cls, message = entry
+        return cls, message
+    module_path, class_name, message = entry
+    try:
+        module = importlib.import_module(module_path)
+        return getattr(module, class_name), message
+    except (ImportError, Exception) as e:
+        msg = f"Could not import trainer '{class_name}' from '{module_path}': {e}"
+        logger.warning(msg)
+        raise ImportError(msg) from e
+
+
 def load_trainer(conf):
     conf = copy.deepcopy(conf)
     trainer_conf = conf["trainer"]
@@ -89,17 +158,10 @@ def load_trainer(conf):
 
     trainer_type = trainer_conf.pop("type")
 
-    if trainer_type not in _TRAINER_REGISTRY:
-        msg = f"Trainer type {trainer_type} not supported. Exiting."
-        logger.warning(msg)
-        raise ValueError(msg)
+    from credit.registry import load_custom_objects  # imported here to avoid a circular import at module load time
 
-    module_path, class_name, message = _TRAINER_REGISTRY[trainer_type]
+    load_custom_objects(conf)  # register any custom classes listed under custom_objects in the config
+
+    cls, message = _load_trainer_entry(trainer_type)
     logger.info(message)
-    try:
-        module = importlib.import_module(module_path)
-        return getattr(module, class_name)
-    except (ImportError, Exception) as e:
-        msg = f"Could not import trainer '{class_name}' from '{module_path}': {e}"
-        logger.warning(msg)
-        raise ImportError(msg) from e
+    return cls

--- a/docs/source/Custom.md
+++ b/docs/source/Custom.md
@@ -1,11 +1,11 @@
 # Custom Objects
 
-CREDIT is built around a **registry pattern**: models, datasets, preblocks,
-postblocks, losses, and metrics are all selected purely by a string key in the
-config (`model.type`, `data.source.<name>.dataset_type`, a preblock's `type`, and
-so on). This same mechanism lets you plug in **your own** classes without editing
-or forking CREDIT's source code — you write a class, point the config at it, and
-it behaves exactly like a built-in type.
+CREDIT is built around a **registry pattern**: models, trainers, datasets,
+preblocks, postblocks, losses, and metrics are all selected purely by a string key
+in the config (`model.type`, `trainer.type`, `data.source.<name>.dataset_type`, a
+preblock's `type`, and so on). This same mechanism lets you plug in **your own**
+classes without editing or forking CREDIT's source code — you write a class,
+point the config at it, and it behaves exactly like a built-in type.
 
 This page explains how that works and how to add your own objects.
 
@@ -29,7 +29,7 @@ There are two ways a class enters a registry:
    and never touch CREDIT's source. **This is the common case and the focus of
    this guide.**
 
-## The six object types
+## The seven object types
 
 Every custom class must subclass the CREDIT base class for its type. The base
 class fixes the method contract the rest of the pipeline relies on.
@@ -42,6 +42,7 @@ class fixes the method contract the rest of the pipeline relies on.
 | `postblock` | {py:obj}`credit.postblock.base.BasePostblock` | `forward(batch: dict) -> dict` |
 | `loss`      | `torch.nn.Module` | `forward(pred, target) -> loss` |
 | `metric`    | {py:obj}`credit.metrics.base.BaseVariableMetric` (recommended) | called as `metric(full_data_dict)` |
+| `trainer`   | {py:obj}`credit.trainers.base_trainer.BaseTrainer` | `__init__(model, rank, conf)`, drives the training/validation loop |
 
 Registration **validates the base class** and raises `TypeError` if it does not
 match — so a wrong base class fails loudly at startup, not deep in training.
@@ -98,7 +99,7 @@ custom_objects:
 Fields:
 
 - **`object_type`** *(required)* — one of `dataset`, `preblock`, `model`,
-  `postblock`, `loss`, `metric`.
+  `postblock`, `loss`, `metric`, `trainer`.
 - **`module_path`** *(required)* — the dotted Python module to import the class
   from.
 - **`module_name`** *(optional)* — the Python class name. It **defaults to the
@@ -161,9 +162,13 @@ metrics:
   type: combined
   args:
     metrics: {rmse: {}, MyMetric: {}}
+
+# trainer → trainer.type
+trainer:
+  type: MyTrainer
 ```
 
-## Full example — all six types
+## Full example — all seven types
 
 ```yaml
 custom_objects:
@@ -192,6 +197,10 @@ custom_objects:
   MyMetric:
     object_type: metric
     module_path: mypackage.metrics
+
+  MyTrainer:
+    object_type: trainer
+    module_path: mypackage.trainers
 ```
 
 ## Validate before you train
@@ -237,7 +246,7 @@ class MyPreBlock(BasePreblock):
 ```
 
 The equivalent decorators are `register_dataset`, `register_model`,
-`register_postblock`, `register_loss`, and `register_metric`, each importable
-from its package (`credit.datasets`, `credit.models`, …). When you add a
-built-in type, also update the matching validation in `credit check` and the
-relevant doc page.
+`register_postblock`, `register_loss`, `register_metric`, and `register_trainer`,
+each importable from its package (`credit.datasets`, `credit.models`, …,
+`credit.trainers`). When you add a built-in type, also update the matching
+validation in `credit check` and the relevant doc page.


### PR DESCRIPTION
## Summary

This is here to support Kyle's regional trainer. His WRF/downscaling model needs a training loop that's different enough from the standard gen2 trainer (it takes interior + boundary + time-encoding tensors, not a single `x`) that it doesn't make sense to bolt onto `trainer_gen2.py` directly. The cleaner path is a new trainer class that subclasses `TrainerERA5Gen2` and overrides just what it needs, living in credit-zoo rather than in CREDIT itself. But there was no way to actually plug a trainer like that into a config without hand-editing `credit/trainers/__init__.py`, so this PR adds that missing piece first.

Trainers were the one part of the registry system you couldn't extend without editing CREDIT's source directly. Models, datasets, preblocks, postblocks, losses, and metrics all support a `custom_objects:` block in the config, so you can write your own class, point a config at it, and it behaves exactly like a built-in. Trainers never got that. `_TRAINER_REGISTRY` in `credit/trainers/__init__.py` was just a closed dict, and the only way to add one was to hand-edit that file.

This PR closes that gap. We added `register_trainer`, which works the same way `register_model` already does: decorate a class, it gets checked against `BaseTrainer`, and it lands in the registry. We also added `"trainer"` to `registry.py`'s `_REGISTRY_MAP`, so `custom_objects: {..., object_type: trainer}` works right away, no other wiring needed.

Worth noting: `credit check` already runs `load_custom_objects` before it does any registry lookups, so it picks up custom trainers for free. Nothing to change there.

This doesn't touch `trainer_gen2.py` or any trainer's actual training logic. It's purely the registration/dispatch layer, the same file where every built-in trainer already lives. Docs are updated too (`CLAUDE.md`, `docs/source/Custom.md`), since we're now at seven registrable types instead of six.

## Verification

Tested the decorator path, the `custom_objects` path (the one most people will actually use), and confirmed a wrong base class raises `TypeError` like it should. Built-in trainers still resolve fine. `test_trainer_components.py` passes 89/89, and the full suite passes clean: 1602 passed, 33 skipped, 0 failed.